### PR TITLE
Added ability to let destructors get called

### DIFF
--- a/src/mem/epoch/garbage.rs
+++ b/src/mem/epoch/garbage.rs
@@ -33,7 +33,7 @@ impl Bag {
 
     fn insert<T>(&mut self, elem: *mut T, do_drop: bool) {
         let size = mem::size_of::<T>();
-        if size > 0 {
+        if size > 0 || do_drop {
             self.0.push(Item {
                 ptr: elem as *mut u8,
                 free: if do_drop { destroy::<T> } else { free::<T> },

--- a/src/mem/epoch/guard.rs
+++ b/src/mem/epoch/guard.rs
@@ -40,7 +40,11 @@ impl Guard {
     /// Assert that the value is no longer reachable from a lock-free data
     /// structure and should be collected when sufficient epochs have passed.
     pub unsafe fn unlinked<T>(&self, val: Shared<T>) {
-        local::with_participant(|p| p.reclaim(val.as_raw()))
+        local::with_participant(|p| p.reclaim(val.as_raw(), false))
+    }
+
+    pub unsafe fn unlinked_drop<T: Drop + Send + 'static>(&self, val: Shared<T>) {
+        local::with_participant(|p| p.reclaim(val.as_raw(), true))
     }
 
     /// Move the thread-local garbage into the global set of garbage.

--- a/src/mem/epoch/guard.rs
+++ b/src/mem/epoch/guard.rs
@@ -43,7 +43,7 @@ impl Guard {
         local::with_participant(|p| p.reclaim(val.as_raw(), false))
     }
 
-    pub unsafe fn unlinked_drop<T: Drop + Send + 'static>(&self, val: Shared<T>) {
+    pub unsafe fn unlinked_drop<T: Send + 'static>(&self, val: Shared<T>) {
         local::with_participant(|p| p.reclaim(val.as_raw(), true))
     }
 

--- a/src/mem/epoch/mod.rs
+++ b/src/mem/epoch/mod.rs
@@ -222,7 +222,6 @@ impl<'a, T> Shared<'a, T> {
     }
 }
 
-
 #[cfg(test)]
 mod test {
     use std::sync::atomic::Ordering;
@@ -252,6 +251,41 @@ mod test {
 
         unsafe {
             assert_eq!(DROPS, 0);
+        }
+    }
+
+    #[test]
+    fn test_drop() {
+        static mut DROPS: i32 = 0;
+        static RUNS: i32 = 10000;
+        struct Test;
+        impl Drop for Test {
+            fn drop(&mut self) {
+                unsafe {
+                    DROPS += 1;
+                }
+            }
+        }
+        //unlinked and dropping...
+        for _ in 0..RUNS {
+            let g = pin();
+
+            let x = Atomic::null();
+            x.store(Some(Owned::new(Test)), Ordering::Relaxed);
+            unsafe { g.unlinked_drop(x.load(Ordering::Relaxed, &g).unwrap()); }
+        }
+
+        // unlinking but not dropping, enough to flush all the garbage
+        for _ in 0..RUNS {
+            let g = pin();
+
+            let x = Atomic::null();
+            x.store(Some(Owned::new(Test)), Ordering::Relaxed);
+            unsafe { g.unlinked(x.load(Ordering::Relaxed, &g).unwrap()); }
+        }
+
+        unsafe {
+            assert_eq!(DROPS, RUNS);
         }
     }
 

--- a/src/mem/epoch/mod.rs
+++ b/src/mem/epoch/mod.rs
@@ -276,6 +276,7 @@ mod test {
         }
 
         // unlinking but not dropping, enough to flush all the garbage
+        // tests that the normla unlinked won't do drops
         for _ in 0..RUNS {
             let g = pin();
 

--- a/src/mem/epoch/participant.rs
+++ b/src/mem/epoch/participant.rs
@@ -82,8 +82,8 @@ impl Participant {
     }
 
     /// Begin the reclamation process for a piece of data.
-    pub unsafe fn reclaim<T>(&self, data: *mut T) {
-        (*self.garbage.get()).insert(data);
+    pub unsafe fn reclaim<T>(&self, data: *mut T, drop: bool) {
+        (*self.garbage.get()).insert(data, drop);
     }
 
     /// Attempt to collect garbage by moving the global epoch forward.


### PR DESCRIPTION
This allows a program to specify that unlinked memory should be dropped when it's freed. This capability is needed for owning datastructures, like hashmaps.

One thing I'm not 100% sure on is how to handle zero-sized structs. From what I know, types that implement drop can't be zero sized due to the drop flag so this doesn't explicitly handle that case (and the test case uses a 'zero sized' dropping struct but I'm still not 100% sure.

Also, this implementation doesn't provide any ordering properties of destructors. It would be nice to have the property that all unlink_drops performed by the same thread will actually drop in the same order, but this doesn't hold when migrating garbage to the global bags. I think that using 4 global bags may fix this, I'm not sure how useful of a property this really is and whether affecting the rest of crossbeam is worth it.
