### PR TITLE
WIP Add a steal_half method to sync::chase_lev

### DIFF
--- a/src/sync/chase_lev.rs
+++ b/src/sync/chase_lev.rs
@@ -102,6 +102,19 @@ pub enum Steal<T> {
     Data(T),
 }
 
+/// When stealing half of the data, this is an enumeration of the possible
+/// outcomes.
+#[derive(PartialEq, Eq, Debug)]
+pub enum StealHalf<T> {
+    /// The deque was empty at the time of stealing.
+    Empty,
+    /// The stealer lost the race for stealing data, and a retry may return more
+    /// data.
+    Abort,
+    /// The stealer has successfully stolen some data.
+    Data(Vec<T>),
+}
+
 // An internal buffer used by the chase-lev deque. This structure is actually
 // implemented as a circular buffer, and is used as the intermediate storage of
 // the data in the deque.
@@ -136,6 +149,12 @@ impl<T> Stealer<T> {
     /// Steals work off the end of the queue (opposite of the worker's end)
     pub fn steal(&self) -> Steal<T> {
         self.deque.steal()
+    }
+
+    /// Steals half of the work off the end of the queue (opposite of the
+    /// worker's end)
+    pub fn steal_half(&self) -> StealHalf<T> {
+        self.deque.steal_half()
     }
 }
 
@@ -252,6 +271,40 @@ impl<T> Deque<T> {
                 Steal::Abort
             }
         }
+    }
+
+    fn steal_half(&self) -> StealHalf<T> {
+        let guard = epoch::pin();
+
+        let t = self.top.load(Acquire);
+        fence(SeqCst);
+        let b = self.bottom.load(Acquire);
+
+        let size = b - t;
+        if size <= 0 {
+            return StealHalf::Empty;
+        }
+
+        let half = size + 1 / 2;
+
+        unsafe {
+            let a = self.array.load(Acquire, &guard).unwrap();
+
+            let mut data = Vec::with_capacity(half as usize);
+            for i in t..t + half {
+                data.push(a.get(i));
+            }
+
+            if self.top.compare_and_swap(t, t + half, SeqCst) == t {
+                StealHalf::Data(data)
+            } else {
+                while data.len() > 0 {
+                    mem::forget(data.pop());
+                }
+                StealHalf::Abort
+            }
+        }
+
     }
 
     // potentially shrink the array. This can be called only from the worker.


### PR DESCRIPTION
Questions:
- We could change the signature to make callers supply a vec, rather than
  allocate our own in `steal_half`. This could potentially be more efficient if
  the caller is repeatedly retrying.
- Is this safe? I think so, but I'm not 100% sure. The paper mentions that it
  would be interesting to apply a steal-half operation to this deque, but they
  didn't do it. I couldn't find any other papers or libraries that implemented
  this operation either, although my google-fu may be weak in this regard. The
  most important part, as far as I can tell, is populating the results array
  before performing the CAS to ensure that we get the correct set of resulting
  items (after the CAS, the circular buffer could circle back over the slots
  we're stealing and overwrite them with new values). Everything seems to be
  pretty much the same as stealing one item, which leads to my next question.
- Should we factor out the common parts between `steal` and `steal_half`?
  There's a ton of duplication here, as I've authored it.

If you think this is a valuable operation to have, then I can write some tests
and fix this up.
