### PR TITLE
Change mutability in `push` and `try_pop`

### DIFF
--- a/src/sync/chase_lev.rs
+++ b/src/sync/chase_lev.rs
@@ -19,7 +19,7 @@
 //!
 //! ```
 //! use crossbeam::sync::chase_lev;
-//! let (mut worker, stealer) = chase_lev::deque();
+//! let (worker, stealer) = chase_lev::deque();
 //!
 //! // Only the worker may push/try_pop
 //! worker.push(1);
@@ -73,8 +73,8 @@ unsafe impl<T: Send> Sync for Deque<T> {}
 /// Worker half of the work-stealing deque. This worker has exclusive access to
 /// one side of the deque, and uses `push` and `try_pop` method to manipulate it.
 ///
-/// There may only be one worker per deque, and operations on the worker
-/// require mutable access to the worker itself.
+/// There may only be one worker per deque, so `Worker` does not implement
+/// `Clone` or `Copy`.
 #[derive(Debug)]
 pub struct Worker<T> {
     deque: Arc<Deque<T>>,

--- a/src/sync/chase_lev.rs
+++ b/src/sync/chase_lev.rs
@@ -45,6 +45,8 @@ use std::ptr;
 use std::sync::atomic::Ordering::{Acquire, Relaxed, Release, SeqCst};
 use std::sync::atomic::{AtomicIsize, fence};
 use std::sync::Arc;
+use std::marker::PhantomData;
+use std::cell::Cell;
 
 use mem::epoch::{self, Atomic, Shared, Owned};
 
@@ -78,6 +80,11 @@ unsafe impl<T: Send> Sync for Deque<T> {}
 #[derive(Debug)]
 pub struct Worker<T> {
     deque: Arc<Deque<T>>,
+
+    // Marker so that the Worker is Send but not Sync. The worker can only be
+    // accessed from a single thread at once. Ideally we would use a negative
+    // impl here but these are not stable yet.
+    marker: PhantomData<Cell<()>>,
 }
 
 /// The stealing half of the work-stealing deque. Stealers have access to the
@@ -149,7 +156,7 @@ impl<T> Clone for Stealer<T> {
 pub fn deque<T>() -> (Worker<T>, Stealer<T>) {
     let a = Arc::new(Deque::new());
     let b = a.clone();
-    (Worker { deque: a }, Stealer { deque: b })
+    (Worker { deque: a, marker: PhantomData }, Stealer { deque: b })
 }
 
 // Almost all of this code can be found directly in the paper so I'm not

--- a/src/sync/chase_lev.rs
+++ b/src/sync/chase_lev.rs
@@ -121,13 +121,13 @@ impl<T> fmt::Debug for Buffer<T> {
 
 impl<T> Worker<T> {
     /// Pushes data onto the front of this work queue.
-    pub fn push(&mut self, t: T) {
+    pub fn push(&self, t: T) {
         unsafe { self.deque.push(t) }
     }
 
     /// Pops data off the front of the work queue, returning `None` on an empty
     /// queue.
-    pub fn try_pop(&mut self) -> Option<T> {
+    pub fn try_pop(&self) -> Option<T> {
         unsafe { self.deque.try_pop() }
     }
 }
@@ -372,7 +372,7 @@ mod tests {
 
     #[test]
     fn smoke() {
-        let (mut w, s) = deque();
+        let (w, s) = deque();
         assert_eq!(w.try_pop(), None);
         assert_eq!(s.steal(), Steal::Empty);
         w.push(1);
@@ -386,7 +386,7 @@ mod tests {
     #[test]
     fn stealpush() {
         static AMT: isize = 100000;
-        let (mut w, s) = deque();
+        let (w, s) = deque();
         let t = thread::spawn(move || {
             let mut left = AMT;
             while left > 0 {
@@ -410,7 +410,7 @@ mod tests {
     #[test]
     fn stealpush_large() {
         static AMT: isize = 100000;
-        let (mut w, s) = deque();
+        let (w, s) = deque();
         let t = thread::spawn(move || {
             let mut left = AMT;
             while left > 0 {
@@ -429,7 +429,7 @@ mod tests {
         t.join().unwrap();
     }
 
-    fn stampede(mut w: Worker<Box<isize>>,
+    fn stampede(w: Worker<Box<isize>>,
                 s: Stealer<Box<isize>>,
                 nthreads: isize,
                 amt: usize) {
@@ -499,7 +499,7 @@ mod tests {
         static NTHREADS: isize = 8;
         static DONE: AtomicBool = ATOMIC_BOOL_INIT;
         static HITS: AtomicUsize = ATOMIC_USIZE_INIT;
-        let (mut w, s) = deque();
+        let (w, s) = deque();
 
         let threads = (0..NTHREADS).map(|_| {
             let s = s.clone();
@@ -551,7 +551,7 @@ mod tests {
         static AMT: isize = 10000;
         static NTHREADS: isize = 4;
         static DONE: AtomicBool = ATOMIC_BOOL_INIT;
-        let (mut w, s) = deque();
+        let (w, s) = deque();
 
         let (threads, hits): (Vec<_>, Vec<_>) = (0..NTHREADS).map(|_| {
             let s = s.clone();


### PR DESCRIPTION
This makes it possible to use `chase_lev` as a drop-in replacement for
the deque in the `deque` crate, especially in `rayon`
