### PR TITLE
Improve unlinked doc

### DIFF
--- a/src/mem/epoch/guard.rs
+++ b/src/mem/epoch/guard.rs
@@ -39,6 +39,11 @@ pub fn pin() -> Guard {
 impl Guard {
     /// Assert that the value is no longer reachable from a lock-free data
     /// structure and should be collected when sufficient epochs have passed.
+    ///
+    /// Bear in mind that epoch garbage collection does not actually drop the
+    /// structure, it only frees its associated memory. If the value owns some
+    /// other region of memory, for example through a pointer, it will have to
+    /// be freed before in some other way.
     pub unsafe fn unlinked<T>(&self, val: Shared<T>) {
         local::with_participant(|p| p.reclaim(val.as_raw()))
     }


### PR DESCRIPTION
The epoch GC does not drop structures it reclaims the memory from, it only frees their memory. This behaviour seems to me non-obvious and since it's not documented I had to look for the associated code (https://github.com/aturon/crossbeam/blob/master/src/mem/epoch/garbage.rs#L43), so I propose specifying it in the documentation of `guard.unlinked(..)`.