### PR TITLE
Implement `Default` for `Atomic<T>` (returning null pointer).

### DIFF
--- a/src/mem/epoch/atomic.rs
+++ b/src/mem/epoch/atomic.rs
@@ -179,3 +179,9 @@ impl<T> Atomic<T> {
         unsafe { Shared::from_raw(self.ptr.swap(opt_shared_into_raw(new), ord)) }
     }
 }
+
+impl<T> Default for Atomic<T> {
+    fn default() -> Atomic<T> {
+        Atomic::null()
+    }
+}


### PR DESCRIPTION
Following the style of `AtomicPtr<T>`, `*const T`, and `Option<T>`.