### PR TITLE
Introduce `map` for `Shared<T>`.

### DIFF
--- a/src/mem/epoch/mod.rs
+++ b/src/mem/epoch/mod.rs
@@ -217,6 +217,20 @@ impl<'a, T> Shared<'a, T> {
         ret
     }
 
+    /// Map the pointer to some other pointer.
+    ///
+    /// This applies `f` to the reference and returns the result wrapped in `Shared`.
+    ///
+    /// # Safety
+    ///
+    /// This is safe as it preserves the invariant that `'a` spans an epoch pin.
+    pub fn map<U: 'a, F>(self, f: F) -> Shared<'a, U>
+        where F: FnOnce(&'a T) -> &'a U {
+        unsafe {
+            Shared::from_ref(f(&self))
+        }
+    }
+
     pub fn as_raw(&self) -> *mut T {
         self.data as *const _ as *mut _
     }


### PR DESCRIPTION
This is somewhat similar to owning_ref, but integrated into the pointer type, and much simpler as it is just a wrapper type.

It is similar to other methods named `map`, outside the crate.