### PR TITLE
Add compare-and-swap and rename all the `cas_` prefixed methods.

### DIFF
--- a/src/mem/epoch/atomic.rs
+++ b/src/mem/epoch/atomic.rs
@@ -117,15 +117,33 @@ impl<T> Atomic<T> {
         self.ptr.store(opt_shared_into_raw(val), ord)
     }
 
+    /// Atomically compare the value against `old` and swap it with `new` if matching.
+    ///
+    /// This is commonly refered to as 'CAS'. `self` is compared to `old`. If equal, `self` is set
+    /// to `new` and `Ok(())` returned. Otherwise, `Err(actual_value)` is returned (with
+    /// `actual_value` being the read value of `self`).
+    ///
+    /// All this is done atomically according to the atomic ordering specified in `ord`.
+    pub fn compare_and_swap<'a>(&self, old: Option<Shared<T>>, new: Option<Shared<T>>, ord: Ordering, _: &'a Guard)
+               -> Result<(), Option<Shared<'a, T>>> {
+        let old = opt_shared_into_raw(old);
+        let found = self.ptr.compare_and_swap(old, opt_shared_into_raw(new), ord);
+
+        if found == old {
+            Ok(())
+        } else {
+            Err(unsafe { Shared::from_raw(found) })
+        }
+    }
+
     /// Do a compare-and-set from a `Shared` to an `Owned` pointer with the
     /// given memory ordering.
     ///
     /// As with `store`, this operation does not require a guard; it produces no new
     /// lifetime information. The `Result` indicates whether the CAS succeeded; if
     /// not, ownership of the `new` pointer is returned to the caller.
-    pub fn cas(&self, old: Option<Shared<T>>, new: Option<Owned<T>>, ord: Ordering)
-               -> Result<(), Option<Owned<T>>>
-    {
+    pub fn compare_and_set(&self, old: Option<Shared<T>>, new: Option<Owned<T>>, ord: Ordering)
+               -> Result<(), Option<Owned<T>>> {
         if self.ptr.compare_and_swap(opt_shared_into_raw(old),
                                      opt_owned_as_raw(&new),
                                      ord) == opt_shared_into_raw(old)
@@ -135,6 +153,13 @@ impl<T> Atomic<T> {
         } else {
             Err(new)
         }
+   }
+
+    /// Renamed to `compare_and_set`.
+    #[deprecated]
+    pub fn cas(&self, old: Option<Shared<T>>, new: Option<Owned<T>>, ord: Ordering)
+               -> Result<(), Option<Owned<T>>> {
+        self.compare_and_set(old, new, ord)
     }
 
     /// Do a compare-and-set from a `Shared` to an `Owned` pointer with the
@@ -142,10 +167,9 @@ impl<T> Atomic<T> {
     /// the previously-owned pointer if successful.
     ///
     /// This operation is analogous to `store_and_ref`.
-    pub fn cas_and_ref<'a>(&self, old: Option<Shared<T>>, new: Owned<T>,
+    pub fn compare_and_set_ref<'a>(&self, old: Option<Shared<T>>, new: Owned<T>,
                            ord: Ordering, _: &'a Guard)
-                           -> Result<Shared<'a, T>, Owned<T>>
-    {
+                           -> Result<Shared<'a, T>, Owned<T>> {
         if self.ptr.compare_and_swap(opt_shared_into_raw(old), new.as_raw(), ord)
             == opt_shared_into_raw(old)
         {
@@ -155,16 +179,30 @@ impl<T> Atomic<T> {
         }
     }
 
+    /// Renamed to `compare_and_set_ref`.
+    #[deprecated]
+    pub fn cas_and_ref<'a>(&self, old: Option<Shared<T>>, new: Owned<T>,
+                           ord: Ordering, guard: &'a Guard)
+                           -> Result<Shared<'a, T>, Owned<T>> {
+        self.compare_and_set_ref(old, new, ord, guard)
+    }
+
     /// Do a compare-and-set from a `Shared` to another `Shared` pointer with
     /// the given memory ordering.
     ///
     /// The boolean return value is `true` when the CAS is successful.
-    pub fn cas_shared(&self, old: Option<Shared<T>>, new: Option<Shared<T>>, ord: Ordering)
-                      -> bool
-    {
+    pub fn compare_and_set_shared(&self, old: Option<Shared<T>>, new: Option<Shared<T>>, ord: Ordering)
+                      -> bool {
         self.ptr.compare_and_swap(opt_shared_into_raw(old),
                                   opt_shared_into_raw(new),
                                   ord) == opt_shared_into_raw(old)
+    }
+
+    /// Renamed to `compare_and_set_shared`.
+    #[deprecated]
+    pub fn cas_shared(&self, old: Option<Shared<T>>, new: Option<Shared<T>>, ord: Ordering)
+                      -> bool {
+        self.compare_and_set_shared(old, new, ord)
     }
 
     /// Do an atomic swap with an `Owned` pointer with the given memory ordering.

--- a/src/mem/epoch/mod.rs
+++ b/src/mem/epoch/mod.rs
@@ -246,8 +246,8 @@ mod test {
         x.store(Some(Owned::new(Test)), Ordering::Relaxed);
         x.store_and_ref(Owned::new(Test), Ordering::Relaxed, &g);
         let y = x.load(Ordering::Relaxed, &g);
-        let z = x.cas_and_ref(y, Owned::new(Test), Ordering::Relaxed, &g).ok();
-        let _ = x.cas(z, Some(Owned::new(Test)), Ordering::Relaxed);
+        let z = x.compare_and_set_ref(y, Owned::new(Test), Ordering::Relaxed, &g).ok();
+        let _ = x.compare_and_set(z, Some(Owned::new(Test)), Ordering::Relaxed);
         x.swap(Some(Owned::new(Test)), Ordering::Relaxed, &g);
 
         unsafe {

--- a/src/mem/epoch/participants.rs
+++ b/src/mem/epoch/participants.rs
@@ -62,7 +62,7 @@ impl Participants {
         loop {
             let head = self.head.load(Relaxed, g);
             participant.next.store_shared(head, Relaxed);
-            match self.head.cas_and_ref(head, participant, Release, g) {
+            match self.head.compare_and_set_ref(head, participant, Release, g) {
                 Ok(shared) => {
                     let shared: &Participant = &shared;
                     return shared;

--- a/src/sync/treiber_stack.rs
+++ b/src/sync/treiber_stack.rs
@@ -33,7 +33,7 @@ impl<T> TreiberStack<T> {
         loop {
             let head = self.head.load(Relaxed, &guard);
             n.next.store_shared(head, Relaxed);
-            match self.head.cas_and_ref(head, n, Release, &guard) {
+            match self.head.compare_and_set_ref(head, n, Release, &guard) {
                 Ok(_) => break,
                 Err(owned) => n = owned,
             }
@@ -58,7 +58,7 @@ impl<T> TreiberStack<T> {
             match self.head.load(Acquire, &guard) {
                 Some(head) => {
                     let next = head.next.load(Relaxed, &guard);
-                    if self.head.cas_shared(Some(head), next, Release) {
+                    if self.head.compare_and_set_shared(Some(head), next, Release) {
                         unsafe {
                             guard.unlinked(head);
                             return Some(ptr::read(&(*head).data));


### PR DESCRIPTION
This effectively implements what is described in https://github.com/aturon/crossbeam/issues/116

**Warning**: This change is non-trivial in that it changes API (although without any breakage).