### PR TITLE
Introduce owned epoch guards (`Pinned<T>`).

### DIFF
--- a/src/mem/epoch/mod.rs
+++ b/src/mem/epoch/mod.rs
@@ -135,7 +135,7 @@ mod participant;
 mod participants;
 
 pub use self::atomic::Atomic;
-pub use self::guard::{pin, Guard};
+pub use self::guard::{pin, Guard, Pinned};
 
 use std::ops::{Deref, DerefMut};
 use std::ptr;
@@ -160,6 +160,10 @@ impl<T> Owned<T> {
     /// Move data out of the owned box, deallocating the box.
     pub fn into_inner(self) -> T {
         *self.data
+    }
+
+    pub fn into_pinned(self, guard: Guard) -> Pinned<Box<T>> {
+        Pinned::new(self.data, guard)
     }
 }
 
@@ -219,6 +223,10 @@ impl<'a, T> Shared<'a, T> {
 
     pub fn as_raw(&self) -> *mut T {
         self.data as *const _ as *mut _
+    }
+
+    pub fn into_pinned(self, guard: Guard) -> Pinned<&'a T> {
+        Pinned::new(self.data, guard)
     }
 }
 


### PR DESCRIPTION
Currently every epoch guard is usually used through a reference, making
it somewhat inconvinient for certain usecases, especially when you need
to expose an API, where you don't want the downstream user to have to
interact with the crossbeam API.

This patch solves this issue by introducing the `Pinned<T>` type, which
wraps `T` in a manner that only allow access through immutable
reference. `Pinned<T>` also holds an `epoch::Guard` meaning that `T` is
essentially "bound" to this guard.

Initially, I tried my hands at a `pin_then` method taking a closure, but
it proved inconvinient and possibly unsound, so instead I let
`Pinned<T>` be created through the methods of `Owned<T>` and
`Shared<T>`.

TLDR. This gets rid of the lifetime hell by providing a wrapper type,
which guarantees that a `Guard` exists while the inner value is held.

cc. @aturon @carllerche @alexcrichton 