### PR TITLE
Replace outdated doc link with docs.rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ crossbeam = "0.2"
 For examples of what Crossbeam is capable of, see the
 [documentation][docs].
 
-[docs]: http://aturon.github.io/crossbeam-doc/crossbeam/
+[docs]: https://docs.rs/crate/crossbeam/


### PR DESCRIPTION
The documentation at http://aturon.github.io/crossbeam-doc/crossbeam/ looks stale so I propose that docs.rs is used instead.