### PR TITLE
add is_empty() interface for SeqQueue

### DIFF
--- a/src/sync/seg_queue.rs
+++ b/src/sync/seg_queue.rs
@@ -89,6 +89,21 @@ impl<T> SegQueue<T> {
         }
     }
 
+    /// Judge if the queue is empty.
+    ///
+    /// Returns `true` if the queue is empty.
+    pub fn is_empty(&self) -> bool {
+        let guard = epoch::pin();
+        let head = self.head.load(Acquire, &guard).unwrap();
+        let tail = self.tail.load(Acquire, &guard).unwrap();
+        if head.as_raw() != tail.as_raw() {
+            return false;
+        }
+
+        let low = head.low.load(Relaxed);
+        low >= cmp::min(head.high.load(Relaxed), SEG_SIZE)
+    }
+
     /// Attempt to dequeue from the front.
     ///
     /// Returns `None` if the queue is observed to be empty.

--- a/src/sync/seg_queue.rs
+++ b/src/sync/seg_queue.rs
@@ -162,6 +162,16 @@ mod test {
     }
 
     #[test]
+    fn push_pop_empty_check() {
+        let q: SegQueue<i64> = SegQueue::new();
+        assert_eq!(q.is_empty(), true);
+        q.push(42);
+        assert_eq!(q.is_empty(), false);
+        assert_eq!(q.try_pop(), Some(42));
+        assert_eq!(q.is_empty(), true);
+    }
+
+    #[test]
     fn push_pop_many_seq() {
         let q: SegQueue<i64> = SegQueue::new();
         for i in 0..200 {


### PR DESCRIPTION
we need a way to quickly test if the queue is empty without taking the action to pull the queue