### PR TITLE
Clean up `atomic.rs` in `epoch`

### DIFF
--- a/src/epoch/guard.rs
+++ b/src/epoch/guard.rs
@@ -1,3 +1,5 @@
+//! RAII guards for epochs.
+
 use std::marker;
 
 use super::{local, Shared};
@@ -9,21 +11,33 @@ use super::{local, Shared};
 #[must_use]
 #[derive(Debug)]
 pub struct Guard {
-    _marker: marker::PhantomData<*mut ()>, // !Send and !Sync
+    /// A marker to force `!Sync` and `!Send`.
+    ///
+    /// Sharing a guard between threads is unsafe, as it only tracks an epoch
+    /// of the current thread.
+    _marker: marker::PhantomData<*mut ()>,
 }
 
 /// Pin the current epoch.
 ///
-/// Threads generally pin before interacting with a lock-free data
-/// structure. Pinning requires a full memory barrier, so is somewhat
-/// expensive. It is rentrant -- you can safely acquire nested guards, and only
-/// the first guard requires a barrier. Thus, in cases where you expect to
-/// perform several lock-free operations in quick succession, you may consider
-/// pinning around the entire set of operations.
+/// Threads generally pin before interacting with a lock-free data structure. It
+/// activates an epoch, represented by a `Guard`, which can be used in types like
+/// `Atomic<T>`.
+///
+/// # Performance
+///
+/// Pinning requires a full memory barrier, so is somewhat expensive. It is however
+/// rentrant -- you can safely acquire nested guards, and only the first guard
+/// requires a barrier.  Thus, in cases where you expect to perform several
+/// lock-free operations in quick succession, you may consider pinning around the
+/// entire set of operations.
 pub fn pin() -> Guard {
+    // Set the current thread as participant while handling the epoch.
     local::with_participant(|p| {
         let entered = p.enter();
 
+        // Construct the guard. This is safe as we have already called  `enter`,
+        // ensuring that there is an active epoch for this thread.
         let g = Guard {
             _marker: marker::PhantomData,
         };

--- a/src/epoch/mod.rs
+++ b/src/epoch/mod.rs
@@ -85,7 +85,7 @@
 //!             n.next.store_shared(head, Relaxed);
 //!
 //!             // if snapshot is still good, link in the new node
-//!             match self.head.cas_and_ref(head, n, Release, &guard) {
+//!             match self.head.compare_and_set_ref(head, n, Release, &guard) {
 //!                 Ok(_) => return,
 //!                 Err(owned) => n = owned,
 //!             }
@@ -105,7 +105,7 @@
 //!                     let next = head.next.load(Relaxed, &guard);
 //!
 //!                     // if snapshot is still good, update from `head` to `next`
-//!                     if self.head.cas_shared(Some(head), next, Release) {
+//!                     if self.head.compare_and_set_shared(Some(head), next, Release) {
 //!                         unsafe {
 //!                             // mark the node as unlinked
 //!                             guard.unlinked(head);
@@ -244,10 +244,10 @@ mod test {
 
         let x = Atomic::null();
         x.store(Some(Owned::new(Test)), Ordering::Relaxed);
-        x.store_and_ref(Owned::new(Test), Ordering::Relaxed, &g);
+        x.store_ref(Owned::new(Test), Ordering::Relaxed, &g);
         let y = x.load(Ordering::Relaxed, &g);
-        let z = x.cas_and_ref(y, Owned::new(Test), Ordering::Relaxed, &g).ok();
-        let _ = x.cas(z, Some(Owned::new(Test)), Ordering::Relaxed);
+        let z = x.compare_and_set_ref(y, Owned::new(Test), Ordering::Relaxed, &g).ok();
+        let _ = x.compare_and_set(z, Some(Owned::new(Test)), Ordering::Relaxed);
         x.swap(Some(Owned::new(Test)), Ordering::Relaxed, &g);
 
         unsafe {

--- a/src/epoch/participants.rs
+++ b/src/epoch/participants.rs
@@ -62,7 +62,7 @@ impl Participants {
         loop {
             let head = self.head.load(Relaxed, g);
             participant.next.store_shared(head, Relaxed);
-            match self.head.cas_and_ref(head, participant, Release, g) {
+            match self.head.compare_and_set_ref(head, participant, Release, g) {
                 Ok(shared) => {
                     let shared: &Participant = &shared;
                     return shared;

--- a/src/sync/chase_lev.rs
+++ b/src/sync/chase_lev.rs
@@ -281,7 +281,7 @@ impl<T> Deque<T> {
                               guard: &'a epoch::Guard)
                               -> Shared<'a, Buffer<T>> {
         let newbuf = Owned::new(buf);
-        let newbuf = self.array.store_and_ref(newbuf, Release, &guard);
+        let newbuf = self.array.store_ref(newbuf, Release, &guard);
         guard.unlinked(old);
 
         newbuf

--- a/src/sync/ms_queue.rs
+++ b/src/sync/ms_queue.rs
@@ -67,7 +67,7 @@ impl<T> MsQueue<T> {
             next: Atomic::null(),
         });
         let guard = epoch::pin();
-        let sentinel = q.head.store_and_ref(sentinel, Relaxed, &guard);
+        let sentinel = q.head.store_ref(sentinel, Relaxed, &guard);
         q.tail.store_shared(Some(sentinel), Relaxed);
         q
     }
@@ -86,13 +86,13 @@ impl<T> MsQueue<T> {
         // is `onto` the actual tail?
         if let Some(next) = onto.next.load(Acquire, guard) {
             // if not, try to "help" by moving the tail pointer forward
-            self.tail.cas_shared(Some(onto), Some(next), Release);
+            self.tail.compare_and_set_shared(Some(onto), Some(next), Release);
             Err(n)
         } else {
             // looks like the actual tail; attempt to link in `n`
-            onto.next.cas_and_ref(None, n, Release, guard).map(|shared| {
+            onto.next.compare_and_set_ref(None, n, Release, guard).map(|shared| {
                 // try to move the tail pointer forward
-                self.tail.cas_shared(Some(onto), Some(shared), Release);
+                self.tail.compare_and_set_shared(Some(onto), Some(shared), Release);
             })
         }
     }
@@ -170,7 +170,7 @@ impl<T> MsQueue<T> {
                 });
                 if let Some((blocked_node, signal)) = request {
                     // race to dequeue the node
-                    if self.head.cas_shared(Some(head), Some(blocked_node), Release) {
+                    if self.head.compare_and_set_shared(Some(head), Some(blocked_node), Release) {
                         unsafe {
                             // signal the thread
                             (*signal).data = Some(cache.into_data());
@@ -193,7 +193,7 @@ impl<T> MsQueue<T> {
         if let Some(next) = head.next.load(Acquire, guard) {
             if let Payload::Data(ref t) = next.payload {
                 unsafe {
-                    if self.head.cas_shared(Some(head), Some(next), Release) {
+                    if self.head.compare_and_set_shared(Some(head), Some(next), Release) {
                         guard.unlinked(head);
                         Ok(Some(ptr::read(t)))
                     } else {

--- a/src/sync/seg_queue.rs
+++ b/src/sync/seg_queue.rs
@@ -60,7 +60,7 @@ impl<T> SegQueue<T> {
         };
         let sentinel = Owned::new(Segment::new());
         let guard = epoch::pin();
-        let sentinel = q.head.store_and_ref(sentinel, Relaxed, &guard);
+        let sentinel = q.head.store_ref(sentinel, Relaxed, &guard);
         q.tail.store_shared(Some(sentinel), Relaxed);
         q
     }
@@ -79,7 +79,7 @@ impl<T> SegQueue<T> {
                     (*cell).1.store(true, Release);
 
                     if i + 1 == SEG_SIZE {
-                        let tail = tail.next.store_and_ref(Owned::new(Segment::new()), Release, &guard);
+                        let tail = tail.next.store_ref(Owned::new(Segment::new()), Release, &guard);
                         self.tail.store_shared(Some(tail), Release);
                     }
 

--- a/src/sync/treiber_stack.rs
+++ b/src/sync/treiber_stack.rs
@@ -33,7 +33,7 @@ impl<T> TreiberStack<T> {
         loop {
             let head = self.head.load(Relaxed, &guard);
             n.next.store_shared(head, Relaxed);
-            match self.head.cas_and_ref(head, n, Release, &guard) {
+            match self.head.compare_and_set_ref(head, n, Release, &guard) {
                 Ok(_) => break,
                 Err(owned) => n = owned,
             }
@@ -58,7 +58,7 @@ impl<T> TreiberStack<T> {
             match self.head.load(Acquire, &guard) {
                 Some(head) => {
                     let next = head.next.load(Relaxed, &guard);
-                    if self.head.cas_shared(Some(head), next, Release) {
+                    if self.head.compare_and_set_shared(Some(head), next, Release) {
                         unsafe {
                             guard.unlinked(head);
                             return Some(ptr::read(&(*head).data));


### PR DESCRIPTION
This PR is a subset of #122 , which is on `atomic.rs`.  Most notably:
- Rename `cas` into `compare_and_set`, and introduce `compare_and_swap`.
- Pass `&'a Guard` to `Shared::from_{raw,ref,owned}`, and mark them as safe.

Those are the changes in #122 I **didn't** make:
- Add `into_pinned`.  Currently I don't quite understand the use case of this.  I will make another PR when it's necessary.
- Remove `Owned`.  As @whataloadofwhat pointed out, `Owned<T>` is rather `Box<ManualDrop<T>>` (https://github.com/crossbeam-rs/crossbeam/pull/122#issuecomment-288436809).  Furthermore it would be nice to hide the implementation detail that `Owned` is implemented as `Box`, IMO.

I made the following breaking changes on `epoch`, but I think it's okay: we didn't commit to stability for `epoch` yet:
- Rename `store_and_ref` into `store_ref`.  This is consistent with the naming of `compare_and_set_ref`.
- Rename `cas*`.