### PR TITLE
Add a slurp method to Treiber stack

### DIFF
--- a/src/sync/treiber_stack.rs
+++ b/src/sync/treiber_stack.rs
@@ -58,7 +58,7 @@ impl<T> TreiberStack<T> {
         // new is exclusively owned and so can be written and read
         // with relaxed atomics
         let newhead = new.head.swap(None, Relaxed, &guard);
-        let head = self.head.swap_shared(newhead, AcqRel, &guard);
+2        let head = self.head.swap_shared(newhead, Relaxed, &guard);
         new.head.store_shared(head, Relaxed);
         return new;
     }

--- a/src/sync/treiber_stack.rs
+++ b/src/sync/treiber_stack.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::Ordering::{AcqRel, Acquire, Release, Relaxed};
+use std::sync::atomic::Ordering::{Acquire, Release, Relaxed};
 use std::ptr;
 
 use mem::epoch::{self, Atomic, Owned};
@@ -57,8 +57,8 @@ impl<T> TreiberStack<T> {
         let guard = epoch::pin();
         // new is exclusively owned and so can be written and read
         // with relaxed atomics
-        let newhead = new.head.swap(None, Relaxed, &guard);
-2        let head = self.head.swap_shared(newhead, Relaxed, &guard);
+        let newhead = new.head.load(Relaxed, &guard);
+        let head = self.head.swap_shared(newhead, Relaxed, &guard);
         new.head.store_shared(head, Relaxed);
         return new;
     }

--- a/src/sync/treiber_stack.rs
+++ b/src/sync/treiber_stack.rs
@@ -55,10 +55,11 @@ impl<T> TreiberStack<T> {
     /// Wait-free
     pub fn swap(&self, new: TreiberStack<T>) -> TreiberStack<T> {
         let guard = epoch::pin();
-
-        let newhead = new.head.swap(None, Acquire, &guard);
+        // new is exclusively owned and so can be written and read
+        // with relaxed atomics
+        let newhead = new.head.swap(None, Relaxed, &guard);
         let head = self.head.swap_shared(newhead, AcqRel, &guard);
-        new.head.store_shared(head, Release);
+        new.head.store_shared(head, Relaxed);
         return new;
     }
 


### PR DESCRIPTION
This is useful because it is wait-free instead of lock-free.