### PR TITLE
Fix use-after-free when waking up a blocked thread

### DIFF
--- a/src/sync/ms_queue.rs
+++ b/src/sync/ms_queue.rs
@@ -1,5 +1,5 @@
-use std::sync::atomic::Ordering::{Acquire, Release, Relaxed, SeqCst};
-use std::sync::atomic::{AtomicBool, fence};
+use std::sync::atomic::Ordering::{Acquire, Release, Relaxed};
+use std::sync::atomic::AtomicBool;
 use std::{ptr, mem};
 use std::thread::{self, Thread};
 
@@ -176,7 +176,7 @@ impl<T> MsQueue<T> {
                             (*signal).data = Some(cache.into_data());
                             let thread = (*signal).thread.clone();
 
-                            (*signal).ready.store(true, Relaxed);
+                            (*signal).ready.store(true, Release);
                             thread.unpark();
                             guard.unlinked(head);
                             return;

--- a/src/sync/ms_queue.rs
+++ b/src/sync/ms_queue.rs
@@ -1,5 +1,5 @@
-use std::sync::atomic::Ordering::{Acquire, Release, Relaxed};
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering::{Acquire, Release, Relaxed, SeqCst};
+use std::sync::atomic::{AtomicBool, fence};
 use std::{ptr, mem};
 use std::thread::{self, Thread};
 
@@ -174,8 +174,10 @@ impl<T> MsQueue<T> {
                         unsafe {
                             // signal the thread
                             (*signal).data = Some(cache.into_data());
-                            (*signal).ready.store(true, Release);
-                            (*signal).thread.unpark();
+                            let thread = (*signal).thread.clone();
+
+                            (*signal).ready.store(true, Relaxed);
+                            thread.unpark();
                             guard.unlinked(head);
                             return;
                         }


### PR DESCRIPTION

The problem is that we set `ready` to `true` and then again dereference `signal` to wake up the thread:

```rust
(*signal).ready.store(true, Relaxed);
// Just before we unpark the thread, someone else might do it and
// that thread might destroy the stack-allocated signal.
(*signal).thread.unpark();
```

We must acquire a `Thread` *before* setting `ready` to `true`, and only then unpark the thread without dereferencing `signal`.

cc @Vtec234

This *probably* fixes #107.