### PR TITLE
Simplify the control flow of chase-lev deque

### DIFF
--- a/src/sync/chase_lev.rs
+++ b/src/sync/chase_lev.rs
@@ -210,16 +210,14 @@ impl<T> Deque<T> {
             Some(data)
         } else {
             // racy case. race against steals.
-            let data = a.get(t);
             let success = self.top.compare_and_swap(t, t + 1, SeqCst) == t;
 
             // set the queue to a canonically empty state.
             self.bottom.store(b, Relaxed);
 
             if success {
-                Some(data)
+                Some(a.get(t))
             } else {
-                mem::forget(data); // someone else stole this value
                 None
             }
         }

--- a/src/sync/chase_lev.rs
+++ b/src/sync/chase_lev.rs
@@ -184,46 +184,43 @@ impl<T> Deque<T> {
             b = self.bottom.load(Relaxed);
         }
         a.put(b, data);
-        fence(Release);
-        self.bottom.store(b + 1, Relaxed);
+        self.bottom.store(b + 1, Release);
     }
 
     unsafe fn try_pop(&self) -> Option<T> {
         let guard = epoch::pin();
 
-        let b = self.bottom.load(Relaxed) - 1;
+        let b = self.bottom.load(Relaxed);
         let a = self.array.load(Relaxed, &guard).unwrap();
-        self.bottom.store(b, Relaxed);
+        self.bottom.store(b - 1, Relaxed);
         fence(SeqCst); // the store to bottom must occur before loading top.
         let t = self.top.load(Relaxed);
 
         let size = b - t;
-        if size >= 0 {
-            // non-empty case
-            let mut data = Some(a.get(b));
-            if size == 0 {
-                // last element in queue, check for races.
-                if self.top.compare_and_swap(t, t + 1, SeqCst) != t {
-                    // lost the race.
-                    mem::forget(data.take());
-                }
 
-                // set the queue to a canonically empty state.
-                self.bottom.store(b + 1, Relaxed);
-            } else {
-                self.maybe_shrink(b, t, &guard);
-            }
-            data
-        } else {
-            // empty queue. revert the decrement of "b" and try to shrink.
-            //
-            // the original chase_lev paper uses "t" here, but the new one uses "b + 1".
-            // don't worry, they're the same thing: pop and steal operations will never leave
-            // the top counter greater than the bottom counter. After we decrement "b" at
-            // the beginning of this function, the lowest possible value it could hold here is "t - 1".
-            // That's also the only value that could cause this branch to be taken.
-            self.bottom.store(b + 1, Relaxed);
+        if size <= 0 {
+            // empty queue. revert the decrement of bottom.
+            self.bottom.store(b, Relaxed);
             None
+        } else if size >= 2 {
+            // non-racy case. return the data
+            let data = a.get(b - 1);
+            self.maybe_shrink(b - 1, t, &guard);
+            Some(data)
+        } else {
+            // racy case. race against steals.
+            let data = a.get(t);
+            let success = self.top.compare_and_swap(t, t + 1, SeqCst) == t;
+
+            // set the queue to a canonically empty state.
+            self.bottom.store(b, Relaxed);
+
+            if success {
+                Some(data)
+            } else {
+                mem::forget(data); // someone else stole this value
+                None
+            }
         }
     }
 

--- a/src/sync/chase_lev.rs
+++ b/src/sync/chase_lev.rs
@@ -184,7 +184,8 @@ impl<T> Deque<T> {
             b = self.bottom.load(Relaxed);
         }
         a.put(b, data);
-        self.bottom.store(b + 1, Release);
+        fence(Release);
+        self.bottom.store(b + 1, Relaxed);
     }
 
     unsafe fn try_pop(&self) -> Option<T> {
@@ -227,7 +228,7 @@ impl<T> Deque<T> {
     fn steal(&self) -> Steal<T> {
         let guard = epoch::pin();
 
-        let t = self.top.load(Acquire);
+        let t = self.top.load(Relaxed);
         fence(SeqCst); // top must be loaded before bottom.
         let b = self.bottom.load(Acquire);
 


### PR DESCRIPTION
The `try_pop` function's control flow is simplified.  I think this version is more readable than before.

A downside is that it diverges from the implementation in this [paper](http://www.di.ens.fr/~zappa/readings/ppopp13.pdf).  But I feel the benefit outweighs the cost in this case.