### PR TITLE
Bump to version 0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Version 0.3
 
 - Introduced `ScopedThreadBuilder` with the ability to name threads and set stack size
-- `Worker` methods don't require mutable access anymore
+- `Worker` methods in the Chase-Lev deque don't require mutable access anymore
 - Fixed a bug when unblocking `pop()` in `MsQueue`
 - Implemented `Drop` for `MsQueue`, `SegQueue`, and `TreiberStack`
 - Implemented `Default` for `TreiberStack`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# Version 0.3
+
+- Introduced `ScopedThreadBuilder` with the ability to name threads and set stack size
+- `Worker` methods don't require mutable access anymore
+- Fixed a bug when unblocking `pop()` in `MsQueue`
+- Implemented `Drop` for `MsQueue`, `SegQueue`, and `TreiberStack`
+- Implemented `Default` for `TreiberStack`
+- Added `is_empty` to `SegQueue`
+- Renamed `mem::epoch` to `epoch`
+- Other bug fixes
+
 # Version 0.2
 
 - Changed existing non-blocking `pop` methods to `try_pop`

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To use Crossbeam, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-crossbeam = "0.2"
+crossbeam = "0.3"
 ```
 
 For examples of what Crossbeam is capable of, see the


### PR DESCRIPTION
The motivation of this release is just to get a few bug fixes and features out so that users don't wait for them forever. 

Crossbeam 0.2.x has several long-standing bugs (e.g. leaks and crashes in `MsQueue`). These have been fixed in the master branch, so I suggest we cut a new release. There were also some compatibility breaking changes, so I'm bumping to version 0.3.

The next steps in development will be rework of EBR and splitting Crossbeam up into multiple crates.