### PR TITLE
Call destructors when collecting garbage

### DIFF
--- a/src/epoch/garbage.rs
+++ b/src/epoch/garbage.rs
@@ -40,7 +40,7 @@ impl Bag {
             })
         }
         unsafe fn free<T>(t: *mut u8) {
-            drop(Vec::from_raw_parts(t as *mut T, 0, 1));
+            drop(Box::from_raw(t as *mut T));
         }
     }
 

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -12,3 +12,4 @@ mod treiber_stack;
 mod seg_queue;
 pub mod chase_lev;
 mod arc_cell;
+mod spot;

--- a/src/sync/spot.rs
+++ b/src/sync/spot.rs
@@ -1,0 +1,33 @@
+use std::{mem, cell};
+
+#[derive(Debug)]
+pub struct Spot<T>(cell::RefCell<Inner<T>>);
+
+#[derive(Debug)]
+enum Inner<T> {
+    Present(T),
+    Empty,
+}
+
+impl<T> Spot<T> {
+    pub fn new(t: T) -> Self {
+        Spot(cell::RefCell::new(Inner::Present(t)))
+    }
+
+    pub fn take(&self) -> T {
+        self.0.borrow_mut().take()
+    }
+}
+
+impl<T> Inner<T> {
+    pub fn unpack(self) -> T {
+        match self {
+            Inner::Present(t) => t,
+            Inner::Empty => unreachable!(),
+        }
+    }
+
+    pub fn take(&mut self) -> T {
+        mem::replace(self, Inner::Empty).unpack()
+    }
+}


### PR DESCRIPTION
Related to #13, this PR causes the garbage collector to call drop on the collected `T` nodes.

The previous implementation of the MS queue and the Trieber stack rely on being able to return the popped elements by simply `ptr::read` the `T` embedded in the entry in the structure.  This PR changes this to instead store the `T` in a new rather inelegant structure that holds a `T` but can have that `T` taken away from it (so that it won't drop it when it is dropped).

I'm not sure if the Chase-Lev deque relies on the same trick, since I've not grokked that component yet, similar for the segmented MS queue.  Perhaps someone can confirm/apply the same fix?