### PR TITLE
Let ZerosValid be a regular, non-auto trait, in nightly

### DIFF
--- a/src/cache_padded.rs
+++ b/src/cache_padded.rs
@@ -39,29 +39,11 @@ impl<T> fmt::Debug for CachePadded<T> {
 unsafe impl<T: Send> Send for CachePadded<T> {}
 unsafe impl<T: Sync> Sync for CachePadded<T> {}
 
-#[cfg(not(feature = "nightly"))]
-macro_rules! declare_zeros_valid {
-    () => {
-        /// Types for which mem::zeroed() is safe.
-        ///
-        /// If a type `T: ZerosValid`, then a sequence of zeros the size of `T` must be
-        /// a valid member of the type `T`.
-        pub unsafe trait ZerosValid {}
-    }
-}
-
-#[cfg(feature = "nightly")]
-macro_rules! declare_zeros_valid {
-    () => {
-        /// Types for which mem::zeroed() is safe.
-        ///
-        /// If a type `T: ZerosValid`, then a sequence of zeros the size of `T` must be
-        /// a valid member of the type `T`.
-        pub unsafe auto trait ZerosValid {}
-    }
-}
-
-declare_zeros_valid!();
+/// Types for which mem::zeroed() is safe.
+///
+/// If a type `T: ZerosValid`, then a sequence of zeros the size of `T` must be
+/// a valid member of the type `T`.
+pub unsafe trait ZerosValid {}
 
 macro_rules! zeros_valid { ($( $T:ty )*) => ($(
     unsafe impl ZerosValid for $T {}


### PR DESCRIPTION
This bug is related to the crate feature "nightly" only.

It's an unintended bug, but ZerosValid was defined for every type and
did not serve its purpose. For example, `Vec<i32>` would implement
ZerosValid when it was an auto trait, and that was a bug -- all-zeros is
not a correct way to create a Vec; its pointer is always nonnull.

It does not seem to be possible to exclude all types by default and then
one by one whitelist types that are valid.

We could attempt a blacklist:

```rust
  impl<T: ?Sized> !ZerosValid for *const T { }
  impl<T: ?Sized> !ZerosValid for *mut T { }
  impl<'a, T: ?Sized> !ZerosValid for &'a T { }
  impl<'a, T: ?Sized> !ZerosValid for &'a mut T { }
```

And this excludes a lot of problematic types, like Vec, Box, Mutex etc!
But it is not a complete solution.

CachePadded::zeroed allows creating values from nothing as long as they
are ZerosValid. Let's say for example `struct UnforgeableToken(u64);`

With CachePadded::zeroed we could then create
`CachePadded<UnforgeableToken>` and use DerefMut to swap one of our valid
tokens with a forged, all-zeros one.

Fixes #166 