### PR TITLE
Expose ScopedThreadBuilder

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,4 +29,4 @@ pub extern crate crossbeam_utils as utils;
 
 pub mod sync;
 pub use utils::cache_padded::CachePadded;
-pub use utils::scoped::{scope, Scope, ScopedJoinHandle};
+pub use utils::scoped::{scope, Scope, ScopedJoinHandle, ScopedThreadBuilder};


### PR DESCRIPTION
As reported in #167, `ScopedThreadBuilder` is returned from `Scope::builder()`, but it is not documented.  This solves this issue by exposing `ScopedThreadBuilder`.

 Closes #167 