### PR TITLE
Bump to 0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# Version 0.4
+
+- Switch to the new implementation of epoch-based reclamation in
+  [`crossbeam-epoch`](https://github.com/crossbeam-rs/crossbeam-epoch), fixing numerous bugs in the
+  old implementation.  Its API is changed in a backward-incompatible way.
+- Switch to the new implementation of `CachePadded` and scoped thread in
+  [`crossbeam-utils`](https://github.com/crossbeam-rs/crossbeam-utils).  The scoped thread API is
+  changed in a backward-incompatible way.  
+- Switch to the new implementation of Chase-Lev deque in
+  [`crossbeam-deque`](https://github.com/crossbeam-rs/crossbeam-deque).  Its API is changed in a
+  backward-incompatible way.
+- Export channel implemented in
+  [`crossbeam-channel`](https://github.com/crossbeam-rs/crossbeam-channel).
+- Remove `AtomicOption`.
+- Implement `Default` and `From` traits.
+
 # Version 0.3
 
 - Introduced `ScopedThreadBuilder` with the ability to name threads and set stack size

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To use Crossbeam, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-crossbeam = "0.4.0"
+crossbeam = "0.4"
 ```
 
 For examples of what Crossbeam is capable of, see the [documentation][docs].

--- a/README.md
+++ b/README.md
@@ -1,33 +1,40 @@
 # Crossbeam: support for concurrent programming
 
 [![Build Status](https://travis-ci.org/crossbeam-rs/crossbeam.svg?branch=master)](https://travis-ci.org/crossbeam-rs/crossbeam)
+[![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](https://github.com/crossbeam-rs/crossbeam)
+[![Cargo](https://img.shields.io/crates/v/crossbeam.svg)](https://crates.io/crates/crossbeam)
+[![Documentation](https://docs.rs/crossbeam/badge.svg)](https://docs.rs/crossbeam)
 
 Crossbeam supports concurrent programming, especially focusing on memory
 management, synchronization, and non-blocking data structures.
 
-Crossbeam consists of [several subcrates](https://github.com/crossbeam-rs).
+Crossbeam consists of several submodules:
 
- - `crossbeam-epoch` for **Memory management**. Because non-blocking data
-   structures avoid global synchronization, it is not easy to tell when
-   internal data can be safely freed. The crate provides generic, easy to
-   use, and high-performance APIs for managing memory in these cases. We plan
-   to support other memory management schemes, e.g. hazard pointers (HP) and
-   quiescent state-based reclamation (QSBR). The crate is reexported as the
-   `epoch` module.
+ - `atomic` for **enhancing `std::sync` API**. `AtomicConsume` provides
+   C/C++11-style "consume" atomic operations (re-exported from
+   [`crossbeam-utils`]). `ArcCell` provides atomic storage and retrieval of
+   `Arc`.
 
- - `crossbeam-utils` for **Utilities**. The "scoped" thread API makes it
-   possible to spawn threads that share stack data with their parents. The
-   `CachePadded` struct inserts padding to align data with the size of a
-   cacheline. This crate also seeks to expand the standard library's few
-   synchronization primitives (locks, barriers, etc) to include
-   advanced/niche primitives, as well as userspace alternatives. This crate
-   is reexported as the `utils` module. `CachePadded` and scoped thread API
-   are also reexported at the top-level.
+ - `utils` and `thread` for **utilities**, re-exported from [`crossbeam-utils`].
+   The "scoped" thread API in `thread` makes it possible to spawn threads that
+   share stack data with their parents. The `utils::CachePadded` struct inserts
+   padding to align data with the size of a cacheline. This crate also seeks to
+   expand the standard library's few synchronization primitives (locks,
+   barriers, etc) to include advanced/niche primitives, as well as userspace
+   alternatives.
 
- - **Non-blocking data structures**. Several crates provide high performance
-   and highly-concurrent data structures, which are much superior to wrapping
-   with a `Mutex`. Ultimately the goal is to include stacks, queues, deques,
-   bags, sets and maps. These subcrates are reexported in the `sync` module.
+ - `epoch` for **memory management**, re-exported from [`crossbeam-epoch`].
+   Because non-blocking data structures avoid global synchronization, it is not
+   easy to tell when internal data can be safely freed. The crate provides
+   generic, easy to use, and high-performance APIs for managing memory in these
+   cases. We plan to support other memory management schemes, e.g. hazard
+   pointers (HP) and quiescent state-based reclamation (QSBR).
+
+ - **Concurrent data structures** which are non-blocking and much superior to
+   wrapping sequential ones with a `Mutex`. Crossbeam currently provides
+   channels (re-exported from [`crossbeam-channel`]), deques
+   (re-exported from [`crossbeam-deque`]), queues, and stacks. Ultimately the
+   goal is to also include bags, sets and maps.
 
 # Usage
 
@@ -41,3 +48,7 @@ crossbeam = "0.4"
 For examples of what Crossbeam is capable of, see the [documentation][docs].
 
 [docs]: https://docs.rs/crossbeam/
+[`crossbeam-epoch`]: https://github.com/crossbeam-rs/crossbeam-epoch
+[`crossbeam-utils`]: https://github.com/crossbeam-rs/crossbeam-utils
+[`crossbeam-channel`]: https://github.com/crossbeam-rs/crossbeam-channel
+[`crossbeam-deque`]: https://github.com/crossbeam-rs/crossbeam-deque

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,29 +1,33 @@
-//! Support for concurrent programming: memory management, synchronization,
-//! non-blocking data structures.
+//! Crossbeam supports concurrent programming, especially focusing on memory
+//! management, synchronization, and non-blocking data structures.
 //!
-//! Crossbeam consists of several subcrates.
+//! Crossbeam consists of several submodules:
 //!
-//! - `crossbeam-epoch` for **Memory management**. Because non-blocking data
-//!   structures avoid global synchronization, it is not easy to tell when
-//!   internal data can be safely freed. The crate provides generic, easy to
-//!   use, and high-performance APIs for managing memory in these cases. We plan
-//!   to support other memory management schemes, e.g. hazard pointers (HP) and
-//!   quiescent state-based reclamation (QSBR). The crate is reexported as the
-//!   `epoch` module.
+//!  - `atomic` for **enhancing `std::sync` API**. `AtomicConsume` provides
+//!    C/C++11-style "consume" atomic operations (re-exported from
+//!    [`crossbeam-utils`]). `ArcCell` provides atomic storage and retrieval of
+//!    `Arc`.
 //!
-//! - `crossbeam-utils` for **Utilities**. The "scoped" thread API makes it
-//!   possible to spawn threads that share stack data with their parents. The
-//!   `CachePadded` struct inserts padding to align data with the size of a
-//!   cacheline. This crate also seeks to expand the standard library's few
-//!   synchronization primitives (locks, barriers, etc) to include
-//!   advanced/niche primitives, as well as userspace alternatives. This crate
-//!   is reexported as the `utils` module. `CachePadded` and scoped thread API
-//!   are also reexported at the top-level.
+//!  - `utils` and `thread` for **utilities**, re-exported from [`crossbeam-utils`].
+//!    The "scoped" thread API in `thread` makes it possible to spawn threads that
+//!    share stack data with their parents. The `utils::CachePadded` struct inserts
+//!    padding to align data with the size of a cacheline. This crate also seeks to
+//!    expand the standard library's few synchronization primitives (locks,
+//!    barriers, etc) to include advanced/niche primitives, as well as userspace
+//!    alternatives.
 //!
-//! - **Non-blocking data structures**. Several crates provide high performance
-//!   and highly-concurrent data structures, which are much superior to wrapping
-//!   with a `Mutex`. Ultimately the goal is to include stacks, queues, deques,
-//!   bags, sets and maps. These subcrates are reexported in the `sync` module.
+//!  - `epoch` for **memory management**, re-exported from [`crossbeam-epoch`].
+//!    Because non-blocking data structures avoid global synchronization, it is not
+//!    easy to tell when internal data can be safely freed. The crate provides
+//!    generic, easy to use, and high-performance APIs for managing memory in these
+//!    cases. We plan to support other memory management schemes, e.g. hazard
+//!    pointers (HP) and quiescent state-based reclamation (QSBR).
+//!
+//!  - **Concurrent data structures** which are non-blocking and much superior to
+//!    wrapping sequential ones with a `Mutex`. Crossbeam currently provides
+//!    channels (re-exported from [`crossbeam-channel`]), deques
+//!    (re-exported from [`crossbeam-deque`]), queues, and stacks. Ultimately the
+//!    goal is to also include bags, sets and maps.
 
 #![warn(missing_docs)]
 


### PR DESCRIPTION
This PR bumps to version 0.4!

Last year @aturon [called for a help for Crossbeam](https://internals.rust-lang.org/t/crossbeam-request-for-help/4933), and we Crossbeam developers gathered together to work on this wonderful project.  @stjepang stepped up to propose and lead a major overhaul, and as a result, we have successfully released a handful of sub-crates so far.  Now finally, we're ready to mark the end of the overhaul by releasing a new version of `crossbeam`: it is now an umbrella project of the Crossbeam sub-crates developed so far.  Let's celebrate it! 🎉  Thanks to all the contributors! 🙏

--

Updated README and CHANGELOG.

Closes #179 
Closes #181 