### PR TITLE
Update Travis config and readme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,20 @@
 language: rust
-# necessary for `travis-cargo coveralls --no-sudo`
-addons:
-  apt:
-    packages:
-      - libcurl4-openssl-dev
-      - libelf-dev
-      - libdw-dev
 
-# run builds for all the trains (and more)
 rust:
-  - nightly
-  - beta
   - stable
+  - beta
+  - nightly
+  - 1.26.0
 
-# load travis-cargo
-before_script:
-  - |
-      pip install 'travis-cargo<0.2' --user &&
-      export PATH=$HOME/.local/bin:$PATH
-
-# the main build
 script:
+  - cargo build
+  - cargo build --release
+  - cargo build --no-default-features
+  - cargo build --release --no-default-features
+  - cargo test
+  - cargo test --release
   - |
-      travis-cargo build &&
-      travis-cargo test &&
-      travis-cargo test -- --release &&
-      travis-cargo run -- --bin bench --release &&
-      travis-cargo --only stable doc
-env:
-  global:
-    # override the default `--features unstable` used for the nightly branch (optional)
-    - TRAVIS_CARGO_NIGHTLY_FEATURE=nightly
-notifications:
-  email:
-    on_success: never
+    if [ $TRAVIS_RUST_VERSION == nightly ]; then
+      cargo test --features nightly
+      cargo test --features nightly --release
+    fi

--- a/README.md
+++ b/README.md
@@ -38,17 +38,28 @@ Crossbeam consists of several submodules:
 
 # Usage
 
-To use Crossbeam, add this to your `Cargo.toml`:
+Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
 crossbeam = "0.4"
 ```
 
-For examples of what Crossbeam is capable of, see the [documentation][docs].
+Next, add this to your crate:
 
-[docs]: https://docs.rs/crossbeam/
+```rust
+extern crate crossbeam;
+```
+
+The minimum required Rust version is 1.26.
+
 [`crossbeam-epoch`]: https://github.com/crossbeam-rs/crossbeam-epoch
 [`crossbeam-utils`]: https://github.com/crossbeam-rs/crossbeam-utils
 [`crossbeam-channel`]: https://github.com/crossbeam-rs/crossbeam-channel
 [`crossbeam-deque`]: https://github.com/crossbeam-rs/crossbeam-deque
+
+## License
+
+Licensed under the terms of MIT license and the Apache License (Version 2.0).
+
+See [LICENSE-MIT](LICENSE-MIT) and [LICENSE-APACHE](LICENSE-APACHE) for details.


### PR DESCRIPTION
The old Travis config is dated and doesn't even check for minimum Rust version. The old readme doesn't specify the minimum version nor the license.

This PR updates the Travis config and the readme.