### PR TITLE
Rustfmt + Clippy

### DIFF
--- a/crossbeam-channel/benchmarks/atomicring.rs
+++ b/crossbeam-channel/benchmarks/atomicring.rs
@@ -131,7 +131,7 @@ fn main() {
                 "Rust atomicring",
                 elapsed.as_secs() as f64 + elapsed.subsec_nanos() as f64 / 1e9
             );
-        }
+        };
     }
 
     run!("bounded_mpmc", mpmc(MESSAGES));

--- a/crossbeam-channel/benchmarks/atomicringqueue.rs
+++ b/crossbeam-channel/benchmarks/atomicringqueue.rs
@@ -114,7 +114,7 @@ fn main() {
                 "Rust atomicringqueue",
                 elapsed.as_secs() as f64 + elapsed.subsec_nanos() as f64 / 1e9
             );
-        }
+        };
     }
 
     run!("bounded_mpmc", mpmc(MESSAGES));

--- a/crossbeam-channel/benchmarks/bus.rs
+++ b/crossbeam-channel/benchmarks/bus.rs
@@ -50,7 +50,7 @@ fn main() {
                 "Rust bus",
                 elapsed.as_secs() as f64 + elapsed.subsec_nanos() as f64 / 1e9
             );
-        }
+        };
     }
 
     run!("bounded1_spsc", spsc(1));

--- a/crossbeam-channel/benchmarks/chan.rs
+++ b/crossbeam-channel/benchmarks/chan.rs
@@ -12,7 +12,7 @@ const THREADS: usize = 4;
 fn new<T>(cap: Option<usize>) -> (chan::Sender<T>, chan::Receiver<T>) {
     match cap {
         None => chan::async(),
-        Some(cap) => chan::sync(cap)
+        Some(cap) => chan::sync(cap),
     }
 }
 
@@ -170,7 +170,7 @@ fn main() {
                 "Rust chan",
                 elapsed.as_secs() as f64 + elapsed.subsec_nanos() as f64 / 1e9
             );
-        }
+        };
     }
 
     run!("bounded0_mpmc", mpmc(Some(0)));

--- a/crossbeam-channel/benchmarks/crossbeam-channel.rs
+++ b/crossbeam-channel/benchmarks/crossbeam-channel.rs
@@ -155,7 +155,7 @@ fn main() {
                 "Rust crossbeam-channel",
                 elapsed.as_secs() as f64 + elapsed.subsec_nanos() as f64 / 1e9
             );
-        }
+        };
     }
 
     run!("bounded0_mpmc", mpmc(Some(0)));

--- a/crossbeam-channel/benchmarks/crossbeam-deque.rs
+++ b/crossbeam-channel/benchmarks/crossbeam-deque.rs
@@ -60,7 +60,7 @@ fn main() {
                 "Rust crossbeam-deque",
                 elapsed.as_secs() as f64 + elapsed.subsec_nanos() as f64 / 1e9
             );
-        }
+        };
     }
 
     run!("unbounded_seq", seq());

--- a/crossbeam-channel/benchmarks/futures-channel.rs
+++ b/crossbeam-channel/benchmarks/futures-channel.rs
@@ -4,7 +4,7 @@ extern crate futures;
 use futures::channel::mpsc;
 use futures::executor::ThreadPool;
 use futures::prelude::*;
-use futures::{SinkExt, StreamExt, future, stream};
+use futures::{future, stream, SinkExt, StreamExt};
 
 use shared::message;
 
@@ -14,134 +14,146 @@ const MESSAGES: usize = 5_000_000;
 const THREADS: usize = 4;
 
 fn seq_unbounded() {
-    ThreadPool::new().unwrap().run(future::lazy(|_| {
-        let (tx, rx) = mpsc::unbounded();
-        for i in 0..MESSAGES {
-            tx.unbounded_send(message(i)).unwrap();
-        }
-        drop(tx);
+    ThreadPool::new()
+        .unwrap()
+        .run(future::lazy(|_| {
+            let (tx, rx) = mpsc::unbounded();
+            for i in 0..MESSAGES {
+                tx.unbounded_send(message(i)).unwrap();
+            }
+            drop(tx);
 
-        rx.for_each(|_| future::ok(()))
-    })).unwrap();
+            rx.for_each(|_| future::ok(()))
+        })).unwrap();
 }
 
 fn seq_bounded(cap: usize) {
     let (mut tx, rx) = mpsc::channel(cap);
-    ThreadPool::new().unwrap().run(future::lazy(|_| {
-        for i in 0..MESSAGES {
-            tx.try_send(message(i)).unwrap();
-        }
-        drop(tx);
+    ThreadPool::new()
+        .unwrap()
+        .run(future::lazy(|_| {
+            for i in 0..MESSAGES {
+                tx.try_send(message(i)).unwrap();
+            }
+            drop(tx);
 
-        rx.for_each(|_| future::ok(()))
-    })).unwrap();
+            rx.for_each(|_| future::ok(()))
+        })).unwrap();
 }
 
 fn spsc_unbounded() {
-    ThreadPool::new().unwrap().run(future::lazy(|cx| {
-        let (tx, rx) = mpsc::unbounded();
+    ThreadPool::new()
+        .unwrap()
+        .run(future::lazy(|cx| {
+            let (tx, rx) = mpsc::unbounded();
 
-        cx.spawn(future::lazy(move |_| {
-            tx.send_all(stream::iter_ok((0..MESSAGES).map(|i| message(i))))
-                .map_err(|_| panic!())
-                .and_then(|_| future::ok(()))
-        }));
+            cx.spawn(future::lazy(move |_| {
+                tx.send_all(stream::iter_ok((0..MESSAGES).map(|i| message(i))))
+                    .map_err(|_| panic!())
+                    .and_then(|_| future::ok(()))
+            }));
 
-        rx.for_each(|_| future::ok(()))
-    })).unwrap();
+            rx.for_each(|_| future::ok(()))
+        })).unwrap();
 }
 
 fn spsc_bounded(cap: usize) {
-    ThreadPool::new().unwrap().run(future::lazy(|cx| {
-        let (tx, rx) = mpsc::channel(cap);
+    ThreadPool::new()
+        .unwrap()
+        .run(future::lazy(|cx| {
+            let (tx, rx) = mpsc::channel(cap);
 
-        cx.spawn(future::lazy(move |_| {
-            tx.send_all(stream::iter_ok((0..MESSAGES).map(|i| message(i))))
-                .map_err(|_| panic!())
-                .and_then(|_| future::ok(()))
-        }));
+            cx.spawn(future::lazy(move |_| {
+                tx.send_all(stream::iter_ok((0..MESSAGES).map(|i| message(i))))
+                    .map_err(|_| panic!())
+                    .and_then(|_| future::ok(()))
+            }));
 
-        rx.for_each(|_| future::ok(()))
-    })).unwrap();
+            rx.for_each(|_| future::ok(()))
+        })).unwrap();
 }
 
 fn mpsc_unbounded() {
-    ThreadPool::new().unwrap().run(future::lazy(|cx| {
-        let (tx, rx) = mpsc::unbounded();
+    ThreadPool::new()
+        .unwrap()
+        .run(future::lazy(|cx| {
+            let (tx, rx) = mpsc::unbounded();
 
-        for _ in 0..THREADS {
-            let tx = tx.clone();
-            cx.spawn(future::lazy(move |_| {
-                tx.send_all(stream::iter_ok((0..MESSAGES / THREADS).map(|i| message(i))))
-                    .map_err(|_| panic!())
-                    .and_then(|_| future::ok(()))
-            }));
-        }
-        drop(tx);
+            for _ in 0..THREADS {
+                let tx = tx.clone();
+                cx.spawn(future::lazy(move |_| {
+                    tx.send_all(stream::iter_ok((0..MESSAGES / THREADS).map(|i| message(i))))
+                        .map_err(|_| panic!())
+                        .and_then(|_| future::ok(()))
+                }));
+            }
+            drop(tx);
 
-        rx.for_each(|_| future::ok(()))
-    })).unwrap();
+            rx.for_each(|_| future::ok(()))
+        })).unwrap();
 }
 
 fn mpsc_bounded(cap: usize) {
-    ThreadPool::new().unwrap().run(future::lazy(|cx| {
-        let (tx, rx) = mpsc::channel(cap);
+    ThreadPool::new()
+        .unwrap()
+        .run(future::lazy(|cx| {
+            let (tx, rx) = mpsc::channel(cap);
 
-        for _ in 0..THREADS {
-            let tx = tx.clone();
-            cx.spawn(future::lazy(move |_| {
-                tx.send_all(stream::iter_ok((0..MESSAGES / THREADS).map(|i| message(i))))
-                    .map_err(|_| panic!())
-                    .and_then(|_| future::ok(()))
-            }));
-        }
-        drop(tx);
+            for _ in 0..THREADS {
+                let tx = tx.clone();
+                cx.spawn(future::lazy(move |_| {
+                    tx.send_all(stream::iter_ok((0..MESSAGES / THREADS).map(|i| message(i))))
+                        .map_err(|_| panic!())
+                        .and_then(|_| future::ok(()))
+                }));
+            }
+            drop(tx);
 
-        rx.for_each(|_| future::ok(()))
-    })).unwrap();
+            rx.for_each(|_| future::ok(()))
+        })).unwrap();
 }
 
 fn select_rx_unbounded() {
-    ThreadPool::new().unwrap().run(future::lazy(|cx| {
-        let chans = (0..THREADS)
-            .map(|_| mpsc::unbounded())
-            .collect::<Vec<_>>();
+    ThreadPool::new()
+        .unwrap()
+        .run(future::lazy(|cx| {
+            let chans = (0..THREADS).map(|_| mpsc::unbounded()).collect::<Vec<_>>();
 
-        for (tx, _) in &chans {
-            let tx = tx.clone();
-            cx.spawn(future::lazy(move |_| {
-                for i in 0..MESSAGES / THREADS {
-                    tx.unbounded_send(message(i)).unwrap();
-                }
-                future::ok(())
-            }));
-        }
+            for (tx, _) in &chans {
+                let tx = tx.clone();
+                cx.spawn(future::lazy(move |_| {
+                    for i in 0..MESSAGES / THREADS {
+                        tx.unbounded_send(message(i)).unwrap();
+                    }
+                    future::ok(())
+                }));
+            }
 
-        stream::select_all(chans.into_iter().map(|(_, rx)| rx))
-            .for_each(|_| future::ok(()))
-            .and_then(|_| future::ok(()))
-    })).unwrap();
+            stream::select_all(chans.into_iter().map(|(_, rx)| rx))
+                .for_each(|_| future::ok(()))
+                .and_then(|_| future::ok(()))
+        })).unwrap();
 }
 
 fn select_rx_bounded(cap: usize) {
-    ThreadPool::new().unwrap().run(future::lazy(|cx| {
-        let chans = (0..THREADS)
-            .map(|_| mpsc::channel(cap))
-            .collect::<Vec<_>>();
+    ThreadPool::new()
+        .unwrap()
+        .run(future::lazy(|cx| {
+            let chans = (0..THREADS).map(|_| mpsc::channel(cap)).collect::<Vec<_>>();
 
-        for (tx, _) in &chans {
-            let tx = tx.clone();
-            cx.spawn(future::lazy(move |_| {
-                tx.send_all(stream::iter_ok((0..MESSAGES / THREADS).map(|i| message(i))))
-                    .map_err(|_| panic!())
-                    .and_then(|_| future::ok(()))
-            }));
-        }
+            for (tx, _) in &chans {
+                let tx = tx.clone();
+                cx.spawn(future::lazy(move |_| {
+                    tx.send_all(stream::iter_ok((0..MESSAGES / THREADS).map(|i| message(i))))
+                        .map_err(|_| panic!())
+                        .and_then(|_| future::ok(()))
+                }));
+            }
 
-        stream::select_all(chans.into_iter().map(|(_, rx)| rx))
-            .for_each(|_| future::ok(()))
-            .and_then(|_| future::ok(()))
-    })).unwrap();
+            stream::select_all(chans.into_iter().map(|(_, rx)| rx))
+                .for_each(|_| future::ok(()))
+                .and_then(|_| future::ok(()))
+        })).unwrap();
 }
 
 fn main() {
@@ -156,7 +168,7 @@ fn main() {
                 "Rust futures-channel",
                 elapsed.as_secs() as f64 + elapsed.subsec_nanos() as f64 / 1e9
             );
-        }
+        };
     }
 
     run!("bounded0_mpsc", mpsc_bounded(0));

--- a/crossbeam-channel/benchmarks/mpmc.rs
+++ b/crossbeam-channel/benchmarks/mpmc.rs
@@ -1,5 +1,5 @@
-extern crate mpmc;
 extern crate crossbeam;
+extern crate mpmc;
 
 use shared::message;
 use std::thread;
@@ -131,7 +131,7 @@ fn main() {
                 "Rust mpmc",
                 elapsed.as_secs() as f64 + elapsed.subsec_nanos() as f64 / 1e9
             );
-        }
+        };
     }
 
     run!("bounded_mpmc", mpmc(MESSAGES));

--- a/crossbeam-channel/benchmarks/mpsc.rs
+++ b/crossbeam-channel/benchmarks/mpsc.rs
@@ -2,8 +2,8 @@
 
 extern crate crossbeam;
 
-use std::sync::mpsc;
 use shared::{message, shuffle};
+use std::sync::mpsc;
 
 mod shared;
 
@@ -137,7 +137,9 @@ fn select_rx_async() {
 
 fn select_rx_sync(cap: usize) {
     assert_eq!(THREADS, 4);
-    let mut chans = (0..THREADS).map(|_| mpsc::sync_channel(cap)).collect::<Vec<_>>();
+    let mut chans = (0..THREADS)
+        .map(|_| mpsc::sync_channel(cap))
+        .collect::<Vec<_>>();
 
     crossbeam::scope(|scope| {
         for &(ref tx, _) in &chans {
@@ -178,7 +180,7 @@ fn main() {
                 "Rust mpsc",
                 elapsed.as_secs() as f64 + elapsed.subsec_nanos() as f64 / 1e9
             );
-        }
+        };
     }
 
     run!("bounded0_mpsc", mpsc_sync(0));

--- a/crossbeam-channel/benchmarks/msqueue.rs
+++ b/crossbeam-channel/benchmarks/msqueue.rs
@@ -107,7 +107,7 @@ fn main() {
                 "Rust msqueue",
                 elapsed.as_secs() as f64 + elapsed.subsec_nanos() as f64 / 1e9
             );
-        }
+        };
     }
 
     run!("unbounded_mpmc", mpmc());

--- a/crossbeam-channel/benchmarks/segqueue.rs
+++ b/crossbeam-channel/benchmarks/segqueue.rs
@@ -107,7 +107,7 @@ fn main() {
                 "Rust segqueue",
                 elapsed.as_secs() as f64 + elapsed.subsec_nanos() as f64 / 1e9
             );
-        }
+        };
     }
 
     run!("unbounded_mpmc", mpmc());

--- a/crossbeam-channel/examples/stopwatch.rs
+++ b/crossbeam-channel/examples/stopwatch.rs
@@ -5,12 +5,12 @@ extern crate crossbeam_channel;
 extern crate signal_hook;
 
 use std::io;
-use std::time::{Duration, Instant};
 use std::thread;
+use std::time::{Duration, Instant};
 
 use crossbeam_channel::{tick, unbounded, Receiver};
-use signal_hook::SIGINT;
 use signal_hook::iterator::Signals;
+use signal_hook::SIGINT;
 
 // Creates a channel that gets a message every time `SIGINT` is signalled.
 fn sigint_notifier() -> io::Result<Receiver<()>> {
@@ -30,7 +30,11 @@ fn sigint_notifier() -> io::Result<Receiver<()>> {
 
 // Prints the elapsed time.
 fn show(dur: Duration) {
-    println!("Elapsed: {}.{:03} sec", dur.as_secs(), dur.subsec_nanos() / 1_000_000);
+    println!(
+        "Elapsed: {}.{:03} sec",
+        dur.as_secs(),
+        dur.subsec_nanos() / 1_000_000
+    );
 }
 
 fn main() {

--- a/crossbeam-channel/src/context.rs
+++ b/crossbeam-channel/src/context.rs
@@ -1,8 +1,8 @@
 //! Thread-local context used in select.
 
 use std::cell::Cell;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::thread::{self, Thread, ThreadId};
 use std::time::Instant;
 
@@ -48,8 +48,8 @@ impl Context {
             f(cx)
         };
 
-        CONTEXT.try_with(|cell| {
-            match cell.take() {
+        CONTEXT
+            .try_with(|cell| match cell.take() {
                 None => f(&Context::new()),
                 Some(cx) => {
                     cx.reset();
@@ -57,10 +57,7 @@ impl Context {
                     cell.set(Some(cx));
                     res
                 }
-            }
-        }).unwrap_or_else(|_| {
-            f(&Context::new())
-        })
+            }).unwrap_or_else(|_| f(&Context::new()))
     }
 
     /// Creates a new `Context`.
@@ -79,7 +76,9 @@ impl Context {
     /// Resets `select` and `packet`.
     #[inline]
     fn reset(&self) {
-        self.inner.select.store(Selected::Waiting.into(), Ordering::Release);
+        self.inner
+            .select
+            .store(Selected::Waiting.into(), Ordering::Release);
         self.inner.packet.store(0, Ordering::Release);
     }
 
@@ -95,8 +94,7 @@ impl Context {
                 select.into(),
                 Ordering::AcqRel,
                 Ordering::Acquire,
-            )
-            .map(|_| ())
+            ).map(|_| ())
             .map_err(|e| e.into())
     }
 

--- a/crossbeam-channel/src/flavors/after.rs
+++ b/crossbeam-channel/src/flavors/after.rs
@@ -2,8 +2,8 @@
 //!
 //! Messages cannot be sent into this kind of channel; they are materialized on demand.
 
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -169,9 +169,7 @@ impl SelectHandle for Channel {
                 token.after = None;
                 true
             }
-            Err(TryRecvError::Empty) => {
-                false
-            }
+            Err(TryRecvError::Empty) => false,
         }
     }
 

--- a/crossbeam-channel/src/flavors/array.rs
+++ b/crossbeam-channel/src/flavors/array.rs
@@ -360,9 +360,7 @@ impl<T> Channel<T> {
     pub fn try_send(&self, msg: T) -> Result<(), TrySendError<T>> {
         let token = &mut Token::default();
         if self.start_send(token) {
-            unsafe {
-                self.write(token, msg).map_err(TrySendError::Disconnected)
-            }
+            unsafe { self.write(token, msg).map_err(TrySendError::Disconnected) }
         } else {
             Err(TrySendError::Full(msg))
         }
@@ -419,9 +417,7 @@ impl<T> Channel<T> {
         let token = &mut Token::default();
 
         if self.start_recv(token) {
-            unsafe {
-                self.read(token).map_err(|_| TryRecvError::Disconnected)
-            }
+            unsafe { self.read(token).map_err(|_| TryRecvError::Disconnected) }
         } else {
             Err(TryRecvError::Empty)
         }

--- a/crossbeam-channel/src/flavors/tick.rs
+++ b/crossbeam-channel/src/flavors/tick.rs
@@ -156,9 +156,7 @@ impl SelectHandle for Channel {
                 token.tick = None;
                 true
             }
-            Err(TryRecvError::Empty) => {
-                false
-            }
+            Err(TryRecvError::Empty) => false,
         }
     }
 

--- a/crossbeam-channel/src/flavors/zero.rs
+++ b/crossbeam-channel/src/flavors/zero.rs
@@ -360,9 +360,7 @@ impl<T> Channel<T> {
         if let Some(operation) = inner.senders.wake_one() {
             token.zero = operation.packet;
             drop(inner);
-            unsafe {
-                self.read(token).map_err(|_| TryRecvError::Disconnected)
-            }
+            unsafe { self.read(token).map_err(|_| TryRecvError::Disconnected) }
         } else if inner.is_disconnected {
             Err(TryRecvError::Disconnected)
         } else {

--- a/crossbeam-channel/src/lib.rs
+++ b/crossbeam-channel/src/lib.rs
@@ -362,13 +362,13 @@ mod select_macro;
 mod utils;
 mod waker;
 
-pub use channel::{Receiver, Sender};
-pub use channel::{bounded, unbounded};
 pub use channel::{after, never, tick};
+pub use channel::{bounded, unbounded};
 pub use channel::{IntoIter, Iter, TryIter};
+pub use channel::{Receiver, Sender};
 
 pub use select::{Select, SelectedOperation};
 
 pub use err::{RecvError, RecvTimeoutError, TryRecvError};
-pub use err::{SendError, SendTimeoutError, TrySendError};
 pub use err::{SelectTimeoutError, TrySelectError};
+pub use err::{SendError, SendTimeoutError, TrySendError};

--- a/crossbeam-channel/src/select.rs
+++ b/crossbeam-channel/src/select.rs
@@ -344,7 +344,7 @@ where
         // Check for timeout.
         match timeout {
             Timeout::Now => unreachable!(),
-            Timeout::Never => {},
+            Timeout::Never => {}
             Timeout::At(when) => {
                 if Instant::now() >= when {
                     // Fall back to one final non-blocking select. This is needed to make the whole

--- a/crossbeam-channel/src/waker.rs
+++ b/crossbeam-channel/src/waker.rs
@@ -64,7 +64,8 @@ impl Waker {
     /// Unregisters an operation previously registered by the current thread.
     #[inline]
     pub fn unregister(&mut self, oper: Operation) -> Option<Entry> {
-        if let Some((i, _)) = self.entries
+        if let Some((i, _)) = self
+            .entries
             .iter()
             .enumerate()
             .find(|&(_, entry)| entry.oper == oper)

--- a/crossbeam-channel/tests/array.rs
+++ b/crossbeam-channel/tests/array.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::Ordering;
 use std::thread;
 use std::time::Duration;
 
-use crossbeam_channel::{bounded};
+use crossbeam_channel::bounded;
 use crossbeam_channel::{RecvError, RecvTimeoutError, TryRecvError};
 use crossbeam_channel::{SendError, SendTimeoutError, TrySendError};
 use rand::{thread_rng, Rng};
@@ -225,7 +225,10 @@ fn send_after_disconnect() {
 
     assert_eq!(s.send(4), Err(SendError(4)));
     assert_eq!(s.try_send(5), Err(TrySendError::Disconnected(5)));
-    assert_eq!(s.send_timeout(6, ms(500)), Err(SendTimeoutError::Disconnected(6)));
+    assert_eq!(
+        s.send_timeout(6, ms(500)),
+        Err(SendTimeoutError::Disconnected(6))
+    );
 }
 
 #[test]

--- a/crossbeam-channel/tests/golang.rs
+++ b/crossbeam-channel/tests/golang.rs
@@ -74,7 +74,8 @@ impl<T> Clone for Chan<T> {
 
 impl<T> Chan<T> {
     fn send(&self, msg: T) {
-        let s = self.inner
+        let s = self
+            .inner
             .lock()
             .s
             .as_ref()
@@ -84,34 +85,21 @@ impl<T> Chan<T> {
     }
 
     fn try_recv(&self) -> Option<T> {
-        let r = self.inner
-            .lock()
-            .r
-            .clone();
+        let r = self.inner.lock().r.clone();
         r.try_recv().ok()
     }
 
     fn recv(&self) -> Option<T> {
-        let r = self.inner
-            .lock()
-            .r
-            .clone();
+        let r = self.inner.lock().r.clone();
         r.recv().ok()
     }
 
     fn close(&self) {
-        self.inner
-            .lock()
-            .s
-            .take()
-            .expect("channel already closed");
+        self.inner.lock().s.take().expect("channel already closed");
     }
 
     fn rx(&self) -> Receiver<T> {
-        self.inner
-            .lock()
-            .r
-            .clone()
+        self.inner.lock().r.clone()
     }
 
     fn tx(&self) -> Sender<T> {
@@ -146,10 +134,7 @@ impl<'a, T> IntoIterator for &'a Chan<T> {
 fn make<T>(cap: usize) -> Chan<T> {
     let (s, r) = bounded(cap);
     Chan {
-        inner: Arc::new(Mutex::new(ChanInner {
-            s: Some(s),
-            r,
-        })),
+        inner: Arc::new(Mutex::new(ChanInner { s: Some(s), r })),
     }
 }
 
@@ -749,9 +734,7 @@ mod chan_test {
 
         go!(c, wg, {
             let mut n = [0; 4];
-            let mut c1 = c.iter()
-                .map(|c| Some(c.rx().clone()))
-                .collect::<Vec<_>>();
+            let mut c1 = c.iter().map(|c| Some(c.rx().clone())).collect::<Vec<_>>();
 
             for _ in 0..4 * N {
                 let index = {
@@ -785,9 +768,7 @@ mod chan_test {
 
         go!(c, wg, {
             let mut n = [0; 4];
-            let mut c1 = c.iter()
-                .map(|c| Some(c.tx().clone()))
-                .collect::<Vec<_>>();
+            let mut c1 = c.iter().map(|c| Some(c.tx().clone())).collect::<Vec<_>>();
 
             for _ in 0..4 * N {
                 let index = {
@@ -878,9 +859,7 @@ mod chan_test {
         if e > 4.4172 / (2.0 * (TRIALS as f64).sqrt()) {
             panic!(
                 "unfair select: in {} trials, results were {}, {}",
-                TRIALS,
-                cnt1,
-                cnt2,
+                TRIALS, cnt1, cnt2,
             );
         }
 
@@ -943,9 +922,7 @@ mod chan_test {
             if n0 <= N as i32 / 10 || n1 <= N as i32 / 10 {
                 panic!(
                     "Want pseudorandom, got {} zeros and {} ones (chan cap {})",
-                    n0,
-                    n1,
-                    cap,
+                    n0, n1, cap,
                 );
             }
         }

--- a/crossbeam-channel/tests/list.rs
+++ b/crossbeam-channel/tests/list.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::Ordering;
 use std::thread;
 use std::time::Duration;
 
-use crossbeam_channel::{unbounded};
+use crossbeam_channel::unbounded;
 use crossbeam_channel::{RecvError, RecvTimeoutError, TryRecvError};
 use crossbeam_channel::{SendError, SendTimeoutError, TrySendError};
 use rand::{thread_rng, Rng};
@@ -160,7 +160,10 @@ fn send_timeout() {
     }
 
     drop(r);
-    assert_eq!(s.send_timeout(777, ms(0)), Err(SendTimeoutError::Disconnected(777)));
+    assert_eq!(
+        s.send_timeout(777, ms(0)),
+        Err(SendTimeoutError::Disconnected(777))
+    );
 }
 
 #[test]
@@ -175,7 +178,10 @@ fn send_after_disconnect() {
 
     assert_eq!(s.send(4), Err(SendError(4)));
     assert_eq!(s.try_send(5), Err(TrySendError::Disconnected(5)));
-    assert_eq!(s.send_timeout(6, ms(0)), Err(SendTimeoutError::Disconnected(6)));
+    assert_eq!(
+        s.send_timeout(6, ms(0)),
+        Err(SendTimeoutError::Disconnected(6))
+    );
 }
 
 #[test]

--- a/crossbeam-channel/tests/never.rs
+++ b/crossbeam-channel/tests/never.rs
@@ -41,7 +41,6 @@ fn optional() {
     }
 }
 
-
 #[test]
 fn tick_n() {
     let mut r = tick(ms(100));

--- a/crossbeam-channel/tests/select.rs
+++ b/crossbeam-channel/tests/select.rs
@@ -8,7 +8,7 @@ use std::cell::Cell;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use crossbeam_channel::{after, bounded, unbounded, tick, Receiver, Select, TryRecvError};
+use crossbeam_channel::{after, bounded, tick, unbounded, Receiver, Select, TryRecvError};
 
 fn ms(ms: u64) -> Duration {
     Duration::from_millis(ms)
@@ -93,7 +93,7 @@ fn disconnected() {
                 i if i == oper1 => assert!(oper.recv(&r1).is_err()),
                 i if i == oper2 => panic!(),
                 _ => unreachable!(),
-            }
+            },
         }
 
         r2.recv().unwrap();
@@ -109,7 +109,7 @@ fn disconnected() {
             i if i == oper1 => assert!(oper.recv(&r1).is_err()),
             i if i == oper2 => panic!(),
             _ => unreachable!(),
-        }
+        },
     }
 
     crossbeam::scope(|scope| {
@@ -127,7 +127,7 @@ fn disconnected() {
                 i if i == oper1 => assert!(oper.recv(&r2).is_err()),
                 i if i == oper2 => panic!(),
                 _ => unreachable!(),
-            }
+            },
         }
     });
 }
@@ -157,8 +157,8 @@ fn default() {
         Ok(oper) => match oper.index() {
             i if i == oper1 => assert!(oper.recv(&r1).is_err()),
             i if i == oper2 => panic!(),
-            _ => unreachable!()
-        }
+            _ => unreachable!(),
+        },
     }
 
     s2.send(2).unwrap();
@@ -170,8 +170,8 @@ fn default() {
         Err(_) => panic!(),
         Ok(oper) => match oper.index() {
             i if i == oper1 => assert_eq!(oper.recv(&r2), Ok(2)),
-            _ => unreachable!()
-        }
+            _ => unreachable!(),
+        },
     }
 
     let mut sel = Select::new();
@@ -211,7 +211,7 @@ fn timeout() {
                 i if i == oper1 => panic!(),
                 i if i == oper2 => panic!(),
                 _ => unreachable!(),
-            }
+            },
         }
 
         let mut sel = Select::new();
@@ -224,7 +224,7 @@ fn timeout() {
                 i if i == oper1 => panic!(),
                 i if i == oper2 => assert_eq!(oper.recv(&r2), Ok(2)),
                 _ => unreachable!(),
-            }
+            },
         }
     });
 
@@ -248,7 +248,7 @@ fn timeout() {
                     Ok(oper) => match oper.index() {
                         i if i == oper1 => assert!(oper.recv(&r).is_err()),
                         _ => unreachable!(),
-                    }
+                    },
                 }
             }
             Ok(_) => unreachable!(),
@@ -268,7 +268,7 @@ fn default_when_disconnected() {
         Ok(oper) => match oper.index() {
             i if i == oper1 => assert!(oper.recv(&r).is_err()),
             _ => unreachable!(),
-        }
+        },
     }
 
     let (_, r) = unbounded::<i32>();
@@ -281,7 +281,7 @@ fn default_when_disconnected() {
         Ok(oper) => match oper.index() {
             i if i == oper1 => assert!(oper.recv(&r).is_err()),
             _ => unreachable!(),
-        }
+        },
     }
 
     let (s, _) = bounded::<i32>(0);
@@ -294,7 +294,7 @@ fn default_when_disconnected() {
         Ok(oper) => match oper.index() {
             i if i == oper1 => assert!(oper.send(&s, 0).is_err()),
             _ => unreachable!(),
-        }
+        },
     }
 
     let (s, _) = bounded::<i32>(0);
@@ -307,7 +307,7 @@ fn default_when_disconnected() {
         Ok(oper) => match oper.index() {
             i if i == oper1 => assert!(oper.send(&s, 0).is_err()),
             _ => unreachable!(),
-        }
+        },
     }
 }
 
@@ -330,7 +330,6 @@ fn default_only() {
     assert!(now - start <= ms(550));
 }
 
-
 #[test]
 fn unblocks() {
     let (s1, r1) = bounded::<i32>(0);
@@ -352,7 +351,7 @@ fn unblocks() {
                 i if i == oper1 => panic!(),
                 i if i == oper2 => assert_eq!(oper.recv(&r2), Ok(2)),
                 _ => unreachable!(),
-            }
+            },
         }
     });
 
@@ -372,7 +371,7 @@ fn unblocks() {
                 i if i == oper1 => oper.send(&s1, 1).unwrap(),
                 i if i == oper2 => panic!(),
                 _ => unreachable!(),
-            }
+            },
         }
     });
 }
@@ -413,70 +412,66 @@ fn loop_try() {
         let (s_end, r_end) = bounded::<()>(0);
 
         crossbeam::scope(|scope| {
-            scope.spawn(|| {
-                loop {
-                    let mut done = false;
+            scope.spawn(|| loop {
+                let mut done = false;
 
-                    let mut sel = Select::new();
-                    let oper1 = sel.send(&s1);
-                    let oper = sel.try_select();
-                    match oper {
-                        Err(_) => {}
-                        Ok(oper) => match oper.index() {
-                            i if i == oper1 => {
-                                let _ = oper.send(&s1, 1);
-                                done = true;
-                            }
-                            _ => unreachable!(),
+                let mut sel = Select::new();
+                let oper1 = sel.send(&s1);
+                let oper = sel.try_select();
+                match oper {
+                    Err(_) => {}
+                    Ok(oper) => match oper.index() {
+                        i if i == oper1 => {
+                            let _ = oper.send(&s1, 1);
+                            done = true;
                         }
-                    }
-                    if done {
-                        break;
-                    }
+                        _ => unreachable!(),
+                    },
+                }
+                if done {
+                    break;
+                }
 
-                    let mut sel = Select::new();
-                    let oper1 = sel.recv(&r_end);
-                    let oper = sel.try_select();
-                    match oper {
-                        Err(_) => {}
-                        Ok(oper) => match oper.index() {
-                            i if i == oper1 => {
-                                let _ = oper.recv(&r_end);
-                                done = true;
-                            }
-                            _ => unreachable!(),
+                let mut sel = Select::new();
+                let oper1 = sel.recv(&r_end);
+                let oper = sel.try_select();
+                match oper {
+                    Err(_) => {}
+                    Ok(oper) => match oper.index() {
+                        i if i == oper1 => {
+                            let _ = oper.recv(&r_end);
+                            done = true;
                         }
-                    }
-                    if done {
-                        break;
-                    }
+                        _ => unreachable!(),
+                    },
+                }
+                if done {
+                    break;
                 }
             });
 
-            scope.spawn(|| {
-                loop {
-                    if let Ok(x) = r2.try_recv() {
-                        assert_eq!(x, 2);
-                        break;
-                    }
+            scope.spawn(|| loop {
+                if let Ok(x) = r2.try_recv() {
+                    assert_eq!(x, 2);
+                    break;
+                }
 
-                    let mut done = false;
-                    let mut sel = Select::new();
-                    let oper1 = sel.recv(&r_end);
-                    let oper = sel.try_select();
-                    match oper {
-                        Err(_) => {}
-                        Ok(oper) => match oper.index() {
-                            i if i == oper1 => {
-                                let _ = oper.recv(&r_end);
-                                done = true;
-                            }
-                            _ => unreachable!(),
+                let mut done = false;
+                let mut sel = Select::new();
+                let oper1 = sel.recv(&r_end);
+                let oper = sel.try_select();
+                match oper {
+                    Err(_) => {}
+                    Ok(oper) => match oper.index() {
+                        i if i == oper1 => {
+                            let _ = oper.recv(&r_end);
+                            done = true;
                         }
-                    }
-                    if done {
-                        break;
-                    }
+                        _ => unreachable!(),
+                    },
+                }
+                if done {
+                    break;
                 }
             });
 
@@ -493,7 +488,7 @@ fn loop_try() {
                         i if i == oper1 => assert_eq!(oper.recv(&r1), Ok(1)),
                         i if i == oper2 => assert!(oper.send(&s2, 2).is_ok()),
                         _ => unreachable!(),
-                    }
+                    },
                 }
 
                 drop(s_end);
@@ -817,7 +812,7 @@ fn stress_timeout_two_threads() {
                                 break;
                             }
                             _ => unreachable!(),
-                        }
+                        },
                     }
                 }
             }
@@ -842,7 +837,7 @@ fn stress_timeout_two_threads() {
                                 done = true;
                             }
                             _ => unreachable!(),
-                        }
+                        },
                     }
                 }
             }
@@ -863,7 +858,7 @@ fn send_recv_same_channel() {
             ix if ix == oper1 => panic!(),
             ix if ix == oper2 => panic!(),
             _ => unreachable!(),
-        }
+        },
     }
 
     let (s, r) = unbounded::<i32>();
@@ -877,7 +872,7 @@ fn send_recv_same_channel() {
             ix if ix == oper1 => assert!(oper.send(&s, 0).is_ok()),
             ix if ix == oper2 => panic!(),
             _ => unreachable!(),
-        }
+        },
     }
 }
 
@@ -972,14 +967,13 @@ fn channel_through_channel() {
                         let oper1 = sel.recv(&r);
                         let oper = sel.select();
                         match oper.index() {
-                            ix if ix == oper1 => {
-                                 oper.recv(&r)
-                                    .unwrap()
-                                    .downcast_mut::<Option<Receiver<T>>>()
-                                    .unwrap()
-                                    .take()
-                                    .unwrap()
-                            }
+                            ix if ix == oper1 => oper
+                                .recv(&r)
+                                .unwrap()
+                                .downcast_mut::<Option<Receiver<T>>>()
+                                .unwrap()
+                                .take()
+                                .unwrap(),
                             _ => unreachable!(),
                         }
                     };
@@ -1021,7 +1015,7 @@ fn linearizable_try() {
                             ix if ix == oper1 => assert!(oper.recv(&r1).is_ok()),
                             ix if ix == oper2 => assert!(oper.recv(&r2).is_ok()),
                             _ => unreachable!(),
-                        }
+                        },
                     }
 
                     end_s.send(()).unwrap();
@@ -1072,7 +1066,7 @@ fn linearizable_timeout() {
                             ix if ix == oper1 => assert!(oper.recv(&r1).is_ok()),
                             ix if ix == oper2 => assert!(oper.recv(&r2).is_ok()),
                             _ => unreachable!(),
-                        }
+                        },
                     }
 
                     end_s.send(()).unwrap();

--- a/crossbeam-channel/tests/select_macro.rs
+++ b/crossbeam-channel/tests/select_macro.rs
@@ -12,8 +12,8 @@ use std::ops::Deref;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use crossbeam_channel::{after, bounded, never, unbounded, tick};
-use crossbeam_channel::{Sender, Receiver, RecvError, SendError, TryRecvError};
+use crossbeam_channel::{after, bounded, never, tick, unbounded};
+use crossbeam_channel::{Receiver, RecvError, SendError, Sender, TryRecvError};
 
 fn ms(ms: u64) -> Duration {
     Duration::from_millis(ms)
@@ -289,31 +289,27 @@ fn loop_try() {
         let (s_end, r_end) = bounded::<()>(0);
 
         crossbeam::scope(|scope| {
-            scope.spawn(|| {
-                loop {
-                    select! {
-                        send(s1, 1) -> _ => break,
-                        default => {}
-                    }
+            scope.spawn(|| loop {
+                select! {
+                    send(s1, 1) -> _ => break,
+                    default => {}
+                }
 
-                    select! {
-                        recv(r_end) -> _ => break,
-                        default => {}
-                    }
+                select! {
+                    recv(r_end) -> _ => break,
+                    default => {}
                 }
             });
 
-            scope.spawn(|| {
-                loop {
-                    if let Ok(x) = r2.try_recv() {
-                        assert_eq!(x, 2);
-                        break;
-                    }
+            scope.spawn(|| loop {
+                if let Ok(x) = r2.try_recv() {
+                    assert_eq!(x, 2);
+                    break;
+                }
 
-                    select! {
-                        recv(r_end) -> _ => break,
-                        default => {}
-                    }
+                select! {
+                    recv(r_end) -> _ => break,
+                    default => {}
                 }
             });
 

--- a/crossbeam-channel/tests/zero.rs
+++ b/crossbeam-channel/tests/zero.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::Ordering;
 use std::thread;
 use std::time::Duration;
 
-use crossbeam_channel::{bounded};
+use crossbeam_channel::bounded;
 use crossbeam_channel::{RecvError, RecvTimeoutError, TryRecvError};
 use crossbeam_channel::{SendError, SendTimeoutError, TrySendError};
 use rand::{thread_rng, Rng};

--- a/crossbeam-deque/tests/fifo.rs
+++ b/crossbeam-deque/tests/fifo.rs
@@ -1,10 +1,10 @@
-extern crate rand;
 extern crate crossbeam_deque as deque;
 extern crate crossbeam_epoch as epoch;
+extern crate rand;
 
-use std::sync::{Arc, Mutex};
-use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::sync::atomic::Ordering::SeqCst;
+use std::sync::atomic::{AtomicBool, AtomicUsize};
+use std::sync::{Arc, Mutex};
 use std::thread;
 
 use deque::{Pop, Steal};
@@ -94,8 +94,7 @@ fn stampede() {
                     }
                 }
             })
-        })
-        .collect::<Vec<_>>();
+        }).collect::<Vec<_>>();
 
     let mut last = 0;
     while remaining.load(SeqCst) > 0 {
@@ -155,8 +154,7 @@ fn run_stress() {
                     }
                 }
             })
-        })
-        .collect::<Vec<_>>();
+        }).collect::<Vec<_>>();
 
     let mut rng = rand::thread_rng();
     let mut expected = 0;
@@ -248,8 +246,7 @@ fn no_starvation() {
             };
 
             (t, hits)
-        })
-        .unzip();
+        }).unzip();
 
     let mut rng = rand::thread_rng();
     let mut my_hits = 0;
@@ -333,8 +330,7 @@ fn destructors() {
                     }
                 }
             })
-        })
-        .collect::<Vec<_>>();
+        }).collect::<Vec<_>>();
 
     for _ in 0..STEPS {
         loop {

--- a/crossbeam-deque/tests/lifo.rs
+++ b/crossbeam-deque/tests/lifo.rs
@@ -1,10 +1,10 @@
-extern crate rand;
 extern crate crossbeam_deque as deque;
 extern crate crossbeam_epoch as epoch;
+extern crate rand;
 
-use std::sync::{Arc, Mutex};
-use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::sync::atomic::Ordering::SeqCst;
+use std::sync::atomic::{AtomicBool, AtomicUsize};
+use std::sync::{Arc, Mutex};
 use std::thread;
 
 use deque::{Pop, Steal};
@@ -94,8 +94,7 @@ fn stampede() {
                     }
                 }
             })
-        })
-        .collect::<Vec<_>>();
+        }).collect::<Vec<_>>();
 
     let mut last = COUNT + 1;
     while remaining.load(SeqCst) > 0 {
@@ -155,8 +154,7 @@ fn run_stress() {
                     }
                 }
             })
-        })
-        .collect::<Vec<_>>();
+        }).collect::<Vec<_>>();
 
     let mut rng = rand::thread_rng();
     let mut expected = 0;
@@ -248,8 +246,7 @@ fn no_starvation() {
             };
 
             (t, hits)
-        })
-        .unzip();
+        }).unzip();
 
     let mut rng = rand::thread_rng();
     let mut my_hits = 0;
@@ -333,8 +330,7 @@ fn destructors() {
                     }
                 }
             })
-        })
-        .collect::<Vec<_>>();
+        }).collect::<Vec<_>>();
 
     for _ in 0..STEPS {
         loop {

--- a/crossbeam-epoch/examples/sanitize.rs
+++ b/crossbeam-epoch/examples/sanitize.rs
@@ -1,11 +1,11 @@
 extern crate crossbeam_epoch as epoch;
 extern crate rand;
 
-use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::{AcqRel, Acquire, Relaxed};
-use std::time::{Duration, Instant};
+use std::sync::Arc;
 use std::thread;
+use std::time::{Duration, Instant};
 
 use epoch::{Atomic, Collector, LocalHandle, Owned, Shared};
 use rand::Rng;
@@ -34,9 +34,7 @@ fn worker(a: Arc<Atomic<AtomicUsize>>, handle: LocalHandle) -> usize {
                 }
             } else {
                 let p = a.load(Acquire, guard);
-                unsafe {
-                    p.deref().fetch_add(sum, Relaxed)
-                }
+                unsafe { p.deref().fetch_add(sum, Relaxed) }
             };
 
             sum = sum.wrapping_add(val);
@@ -56,15 +54,15 @@ fn main() {
                 let a = a.clone();
                 let c = collector.clone();
                 thread::spawn(move || worker(a, c.register()))
-            })
-            .collect::<Vec<_>>();
+            }).collect::<Vec<_>>();
 
         for t in threads {
             t.join().unwrap();
         }
 
         unsafe {
-            a.swap(Shared::null(), AcqRel, epoch::unprotected()).into_owned();
+            a.swap(Shared::null(), AcqRel, epoch::unprotected())
+                .into_owned();
         }
     }
 }

--- a/crossbeam-epoch/src/atomic.rs
+++ b/crossbeam-epoch/src/atomic.rs
@@ -1,16 +1,16 @@
+use alloc::boxed::Box;
 use core::borrow::{Borrow, BorrowMut};
 use core::cmp;
 use core::fmt;
 use core::marker::PhantomData;
 use core::mem;
-use core::ptr;
 use core::ops::{Deref, DerefMut};
-use core::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT};
+use core::ptr;
 use core::sync::atomic::Ordering;
-use alloc::boxed::Box;
+use core::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT};
 
-use guard::Guard;
 use crossbeam_utils::atomic::AtomicConsume;
+use guard::Guard;
 
 /// Given ordering for the success case in a compare-exchange operation, returns the strongest
 /// appropriate ordering for the failure case.

--- a/crossbeam-epoch/src/collector.rs
+++ b/crossbeam-epoch/src/collector.rs
@@ -12,12 +12,11 @@
 ///
 /// handle.pin().flush();
 /// ```
-
 use alloc::sync::Arc;
 use core::fmt;
 
-use internal::{Global, Local};
 use guard::Guard;
+use internal::{Global, Local};
 
 /// An epoch-based garbage collector.
 pub struct Collector {
@@ -30,7 +29,9 @@ unsafe impl Sync for Collector {}
 impl Collector {
     /// Creates a new collector.
     pub fn new() -> Self {
-        Collector { global: Arc::new(Global::new()) }
+        Collector {
+            global: Arc::new(Global::new()),
+        }
     }
 
     /// Registers a new handle for the collector.
@@ -42,7 +43,9 @@ impl Collector {
 impl Clone for Collector {
     /// Creates another reference to the same garbage collector.
     fn clone(&self) -> Self {
-        Collector { global: self.global.clone() }
+        Collector {
+            global: self.global.clone(),
+        }
     }
 }
 
@@ -103,8 +106,8 @@ impl fmt::Debug for LocalHandle {
 #[cfg(test)]
 mod tests {
     use std::mem;
-    use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT};
     use std::sync::atomic::Ordering;
+    use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT};
 
     use crossbeam_utils::thread;
 
@@ -342,7 +345,9 @@ mod tests {
 
         {
             let a = Owned::new(v).into_shared(&guard);
-            unsafe { guard.defer_destroy(a); }
+            unsafe {
+                guard.defer_destroy(a);
+            }
             guard.flush();
         }
 

--- a/crossbeam-epoch/src/default.rs
+++ b/crossbeam-epoch/src/default.rs
@@ -39,7 +39,9 @@ fn with_handle<F, R>(mut f: F) -> R
 where
     F: FnMut(&LocalHandle) -> R,
 {
-    HANDLE.try_with(|h| f(h)).unwrap_or_else(|_| f(&COLLECTOR.register()))
+    HANDLE
+        .try_with(|h| f(h))
+        .unwrap_or_else(|_| f(&COLLECTOR.register()))
 }
 
 #[cfg(test)]

--- a/crossbeam-epoch/src/deferred.rs
+++ b/crossbeam-epoch/src/deferred.rs
@@ -1,8 +1,8 @@
+use alloc::boxed::Box;
 use core::fmt;
 use core::marker::PhantomData;
 use core::mem;
 use core::ptr;
-use alloc::boxed::Box;
 
 /// Number of words a piece of `Data` can hold.
 ///
@@ -78,8 +78,8 @@ impl Deferred {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::Cell;
     use super::Deferred;
+    use std::cell::Cell;
 
     #[test]
     fn on_stack() {

--- a/crossbeam-epoch/src/epoch.rs
+++ b/crossbeam-epoch/src/epoch.rs
@@ -46,13 +46,17 @@ impl Epoch {
     /// Returns the same epoch, but marked as pinned.
     #[inline]
     pub fn pinned(self) -> Epoch {
-        Epoch { data: self.data | 1 }
+        Epoch {
+            data: self.data | 1,
+        }
     }
 
     /// Returns the same epoch, but marked as unpinned.
     #[inline]
     pub fn unpinned(self) -> Epoch {
-        Epoch { data: self.data & !1 }
+        Epoch {
+            data: self.data & !1,
+        }
     }
 
     /// Returns the successor epoch.
@@ -60,7 +64,9 @@ impl Epoch {
     /// The returned epoch will be marked as pinned only if the previous one was as well.
     #[inline]
     pub fn successor(self) -> Epoch {
-        Epoch { data: self.data.wrapping_add(2) }
+        Epoch {
+            data: self.data.wrapping_add(2),
+        }
     }
 }
 
@@ -83,7 +89,9 @@ impl AtomicEpoch {
     /// Loads a value from the atomic epoch.
     #[inline]
     pub fn load(&self, ord: Ordering) -> Epoch {
-        Epoch { data: self.data.load(ord) }
+        Epoch {
+            data: self.data.load(ord),
+        }
     }
 
     /// Stores a value into the atomic epoch.

--- a/crossbeam-epoch/src/guard.rs
+++ b/crossbeam-epoch/src/guard.rs
@@ -1,6 +1,6 @@
 use core::fmt;
-use core::ptr;
 use core::mem;
+use core::ptr;
 
 use atomic::Shared;
 use collector::Collector;

--- a/crossbeam-epoch/src/lib.rs
+++ b/crossbeam-epoch/src/lib.rs
@@ -57,7 +57,6 @@
 #![cfg_attr(feature = "nightly", feature(const_fn))]
 #![cfg_attr(feature = "nightly", feature(alloc))]
 #![cfg_attr(not(test), no_std)]
-
 #![warn(missing_docs, missing_debug_implementations)]
 
 #[cfg(test)]
@@ -92,8 +91,8 @@ mod guard;
 mod internal;
 mod sync;
 
-pub use self::atomic::{Atomic, CompareAndSetError, CompareAndSetOrdering, Owned, Shared, Pointer};
-pub use self::guard::{unprotected, Guard};
+pub use self::atomic::{Atomic, CompareAndSetError, CompareAndSetOrdering, Owned, Pointer, Shared};
+pub use self::collector::{Collector, LocalHandle};
 #[cfg(feature = "std")]
 pub use self::default::{default_collector, is_pinned, pin};
-pub use self::collector::{Collector, LocalHandle};
+pub use self::guard::{unprotected, Guard};

--- a/crossbeam-skiplist/src/base.rs
+++ b/crossbeam-skiplist/src/base.rs
@@ -217,8 +217,11 @@ impl<K, V> Node<K, V> {
     /// Decrements the reference count of a node, destroying it if the count becomes zero.
     #[inline]
     unsafe fn decrement(&self, guard: &Guard) {
-        if self.refs_and_height
-            .fetch_sub(1 << HEIGHT_BITS, Ordering::Release) >> HEIGHT_BITS == 1
+        if self
+            .refs_and_height
+            .fetch_sub(1 << HEIGHT_BITS, Ordering::Release)
+            >> HEIGHT_BITS
+            == 1
         {
             fence(Ordering::Acquire);
             guard.defer_unchecked(move || Self::finalize(self));
@@ -522,10 +525,9 @@ where
             //
             // Note that we're loading the pointer only to check whether it is null, so it's okay
             // to use `epoch::unprotected()` in this situation.
-            while height >= 4
-                && self.head[height - 2]
-                    .load(Ordering::Relaxed, epoch::unprotected())
-                    .is_null()
+            while height >= 4 && self.head[height - 2]
+                .load(Ordering::Relaxed, epoch::unprotected())
+                .is_null()
             {
                 height -= 1;
             }
@@ -642,10 +644,9 @@ where
                 let mut level = self.hot_data.max_height.load(Ordering::Relaxed);
 
                 // Fast loop to skip empty tower levels.
-                while level >= 1
-                    && self.head[level - 1]
-                        .load(Ordering::Relaxed, guard)
-                        .is_null()
+                while level >= 1 && self.head[level - 1]
+                    .load(Ordering::Relaxed, guard)
+                    .is_null()
                 {
                     level -= 1;
                 }
@@ -733,10 +734,9 @@ where
                 let mut level = self.hot_data.max_height.load(Ordering::Relaxed);
 
                 // Fast loop to skip empty tower levels.
-                while level >= 1
-                    && self.head[level - 1]
-                        .load(Ordering::Relaxed, guard)
-                        .is_null()
+                while level >= 1 && self.head[level - 1]
+                    .load(Ordering::Relaxed, guard)
+                    .is_null()
                 {
                     level -= 1;
                 }
@@ -1070,8 +1070,7 @@ where
                                 succ,
                                 Ordering::SeqCst,
                                 guard,
-                            )
-                            .is_ok()
+                            ).is_ok()
                         {
                             // Success! Decrement the reference count.
                             n.decrement(guard);
@@ -1340,7 +1339,8 @@ where
 
     /// Returns the previous entry in the skip list.
     pub fn prev(&self) -> Option<Entry<'a, 'g, K, V>> {
-        let n = self.parent
+        let n = self
+            .parent
             .search_bound(Bound::Excluded(&self.node.key), true, self.guard)?;
         Some(Entry {
             parent: self.parent,
@@ -1474,7 +1474,8 @@ where
         unsafe {
             let mut n = self.node;
             loop {
-                n = self.parent
+                n = self
+                    .parent
                     .next_node(&n.tower, Bound::Excluded(&n.key), guard)?;
                 if let Some(e) = RefEntry::try_acquire(self.parent, n) {
                     return Some(e);
@@ -1499,7 +1500,8 @@ where
         unsafe {
             let mut n = self.node;
             loop {
-                n = self.parent
+                n = self
+                    .parent
                     .search_bound(Bound::Excluded(&n.key), true, guard)?;
                 if let Some(e) = RefEntry::try_acquire(self.parent, n) {
                     return Some(e);
@@ -1531,9 +1533,11 @@ where
 
     fn next(&mut self) -> Option<Entry<'a, 'g, K, V>> {
         self.head = match self.head {
-            Some(n) => self.parent
+            Some(n) => self
+                .parent
                 .next_node(&n.tower, Bound::Excluded(&n.key), self.guard),
-            None => self.parent
+            None => self
+                .parent
                 .next_node(&self.parent.head, Bound::Unbounded, self.guard),
         };
         if let (Some(h), Some(t)) = (self.head, self.tail) {
@@ -1556,7 +1560,8 @@ where
 {
     fn next_back(&mut self) -> Option<Entry<'a, 'g, K, V>> {
         self.tail = match self.tail {
-            Some(n) => self.parent
+            Some(n) => self
+                .parent
                 .search_bound(Bound::Excluded(&n.key), true, self.guard),
             None => self.parent.search_bound(Bound::Unbounded, true, self.guard),
         };
@@ -1649,9 +1654,11 @@ where
 
     fn next(&mut self) -> Option<Entry<'a, 'g, K, V>> {
         self.head = match self.head {
-            Some(n) => self.parent
+            Some(n) => self
+                .parent
                 .next_node(&n.tower, Bound::Excluded(&n.key), self.guard),
-            None => self.parent
+            None => self
+                .parent
                 .search_bound(self.lower_bound, false, self.guard),
         };
         if let Some(h) = self.head {
@@ -1681,7 +1688,8 @@ where
 {
     fn next_back(&mut self) -> Option<Entry<'a, 'g, K, V>> {
         self.tail = match self.tail {
-            Some(n) => self.parent
+            Some(n) => self
+                .parent
                 .search_bound(Bound::Excluded(&n.key), true, self.guard),
             None => self.parent.search_bound(self.upper_bound, true, self.guard),
         };

--- a/crossbeam-skiplist/src/map.rs
+++ b/crossbeam-skiplist/src/map.rs
@@ -328,8 +328,7 @@ impl<K, V> Iterator for IntoIter<K, V> {
     }
 }
 
-impl<K, V> fmt::Debug for IntoIter<K, V>
-{
+impl<K, V> fmt::Debug for IntoIter<K, V> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "IntoIter {{ ... }}")
     }
@@ -362,8 +361,7 @@ where
     }
 }
 
-impl<'a, K, V> fmt::Debug for Iter<'a, K, V>
-{
+impl<'a, K, V> fmt::Debug for Iter<'a, K, V> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Iter {{ ... }}")
     }

--- a/crossbeam-skiplist/src/set.rs
+++ b/crossbeam-skiplist/src/set.rs
@@ -278,9 +278,7 @@ where
     T: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_tuple("Entry")
-            .field(&self.value())
-            .finish()
+        f.debug_tuple("Entry").field(&self.value()).finish()
     }
 }
 
@@ -297,8 +295,7 @@ impl<T> Iterator for IntoIter<T> {
     }
 }
 
-impl<T> fmt::Debug for IntoIter<T>
-{
+impl<T> fmt::Debug for IntoIter<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "IntoIter {{ ... }}")
     }
@@ -329,8 +326,7 @@ where
     }
 }
 
-impl<'a, T> fmt::Debug for Iter<'a, T>
-{
+impl<'a, T> fmt::Debug for Iter<'a, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Iter {{ ... }}")
     }

--- a/crossbeam-utils/benches/atomic_cell.rs
+++ b/crossbeam-utils/benches/atomic_cell.rs
@@ -51,20 +51,18 @@ fn concurrent_load_u8(b: &mut test::Bencher) {
 
     thread::scope(|scope| {
         for _ in 0..THREADS {
-            scope.spawn(|| {
-                loop {
-                    start.wait();
+            scope.spawn(|| loop {
+                start.wait();
 
-                    let mut sum = 0;
-                    for _ in 0..STEPS {
-                        sum += a.load();
-                    }
-                    test::black_box(sum);
+                let mut sum = 0;
+                for _ in 0..STEPS {
+                    sum += a.load();
+                }
+                test::black_box(sum);
 
-                    end.wait();
-                    if exit.load() {
-                        break;
-                    }
+                end.wait();
+                if exit.load() {
+                    break;
                 }
             });
         }
@@ -126,20 +124,18 @@ fn concurrent_load_usize(b: &mut test::Bencher) {
 
     thread::scope(|scope| {
         for _ in 0..THREADS {
-            scope.spawn(|| {
-                loop {
-                    start.wait();
+            scope.spawn(|| loop {
+                start.wait();
 
-                    let mut sum = 0;
-                    for _ in 0..STEPS {
-                        sum += a.load();
-                    }
-                    test::black_box(sum);
+                let mut sum = 0;
+                for _ in 0..STEPS {
+                    sum += a.load();
+                }
+                test::black_box(sum);
 
-                    end.wait();
-                    if exit.load() {
-                        break;
-                    }
+                end.wait();
+                if exit.load() {
+                    break;
                 }
             });
         }

--- a/crossbeam-utils/src/atomic/atomic_cell.rs
+++ b/crossbeam-utils/src/atomic/atomic_cell.rs
@@ -488,8 +488,16 @@ cfg_if! {
     }
 }
 
-impl_arithmetic!(usize, atomic::AtomicUsize, "let a = AtomicCell::new(7usize);");
-impl_arithmetic!(isize, atomic::AtomicIsize, "let a = AtomicCell::new(7isize);");
+impl_arithmetic!(
+    usize,
+    atomic::AtomicUsize,
+    "let a = AtomicCell::new(7usize);"
+);
+impl_arithmetic!(
+    isize,
+    atomic::AtomicIsize,
+    "let a = AtomicCell::new(7isize);"
+);
 
 impl AtomicCell<bool> {
     /// Applies logical "and" to the current value and returns the previous value.
@@ -671,7 +679,9 @@ impl Drop for WriteGuard {
     #[inline]
     fn drop(&mut self) {
         // Release the lock and increment the stamp.
-        self.lock.state.store(self.state.wrapping_add(2), Ordering::Release);
+        self.lock
+            .state
+            .store(self.state.wrapping_add(2), Ordering::Release);
     }
 }
 
@@ -689,7 +699,9 @@ fn lock(addr: usize) -> &'static Lock {
     // The number of locks is prime.
     const LEN: usize = 97;
 
-    const L: Lock = Lock { state: AtomicUsize::new(0) };
+    const L: Lock = Lock {
+        state: AtomicUsize::new(0),
+    };
     static LOCKS: [Lock; LEN] = [
         L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L,
         L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L, L,
@@ -723,7 +735,7 @@ impl AtomicUnit {
         _current: (),
         _new: (),
         _success: Ordering,
-        _failure: Ordering
+        _failure: Ordering,
     ) -> Result<(), ()> {
         Ok(())
     }
@@ -735,7 +747,7 @@ macro_rules! atomic {
     (@check, $t:ty, $atomic:ty, $a:ident, $atomic_op:expr) => {
         if can_transmute::<$t, $atomic>() {
             let $a: &$atomic;
-            break $atomic_op
+            break $atomic_op;
         }
     };
 
@@ -759,7 +771,7 @@ macro_rules! atomic {
                 atomic!(@check, $t, atomic::AtomicU64, $a, $atomic_op);
             }
 
-            break $fallback_op
+            break $fallback_op;
         }
     };
 }

--- a/crossbeam-utils/src/atomic/atomic_cell.rs
+++ b/crossbeam-utils/src/atomic/atomic_cell.rs
@@ -309,7 +309,7 @@ macro_rules! impl_arithmetic {
                     let _guard = lock(self.value.get() as usize).write();
                     let value = unsafe { &mut *(self.value.get()) };
                     let old = *value;
-                    *value = *value & val;
+                    *value &= val;
                     old
                 }
             }
@@ -335,7 +335,7 @@ macro_rules! impl_arithmetic {
                     let _guard = lock(self.value.get() as usize).write();
                     let value = unsafe { &mut *(self.value.get()) };
                     let old = *value;
-                    *value = *value | val;
+                    *value |= val;
                     old
                 }
             }
@@ -361,7 +361,7 @@ macro_rules! impl_arithmetic {
                     let _guard = lock(self.value.get() as usize).write();
                     let value = unsafe { &mut *(self.value.get()) };
                     let old = *value;
-                    *value = *value ^ val;
+                    *value ^= val;
                     old
                 }
             }
@@ -810,7 +810,6 @@ where
                 if lock.validate_read(stamp) {
                     return val;
                 }
-                mem::forget(val);
             }
 
             // Grab a regular write lock so that writers don't starve this load.

--- a/crossbeam-utils/src/atomic/consume.rs
+++ b/crossbeam-utils/src/atomic/consume.rs
@@ -1,6 +1,6 @@
-use core::sync::atomic::Ordering;
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 use core::sync::atomic::compiler_fence;
+use core::sync::atomic::Ordering;
 
 /// Trait which allows reading from an atomic type with "consume" ordering.
 pub trait AtomicConsume {

--- a/crossbeam-utils/src/lib.rs
+++ b/crossbeam-utils/src/lib.rs
@@ -1,4 +1,7 @@
-#![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic, integer_atomics))]
+#![cfg_attr(
+    feature = "nightly",
+    feature(cfg_target_has_atomic, integer_atomics)
+)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[macro_use]
@@ -6,9 +9,9 @@ extern crate cfg_if;
 #[cfg(feature = "std")]
 extern crate core;
 #[cfg(feature = "std")]
-extern crate parking_lot;
-#[cfg(feature = "std")]
 extern crate num_cpus;
+#[cfg(feature = "std")]
+extern crate parking_lot;
 #[cfg(feature = "std")]
 #[macro_use]
 extern crate lazy_static;
@@ -17,8 +20,8 @@ mod cache_padded;
 
 pub mod atomic;
 #[cfg(feature = "std")]
-pub mod thread;
-#[cfg(feature = "std")]
 pub mod sync;
+#[cfg(feature = "std")]
+pub mod thread;
 
 pub use cache_padded::CachePadded;

--- a/crossbeam-utils/src/thread.rs
+++ b/crossbeam-utils/src/thread.rs
@@ -130,10 +130,7 @@ where
 
     // Join all remaining spawned threads.
     let panics: Vec<_> = {
-        let mut handles = scope
-            .handles
-            .lock()
-            .unwrap();
+        let mut handles = scope.handles.lock().unwrap();
 
         // Filter handles that haven't been joined, join them, and collect errors.
         let panics = handles
@@ -268,9 +265,7 @@ impl<'scope, 'env> ScopedThreadBuilder<'scope, 'env> {
 
                 // Allocate `clsoure` on the heap and erase the `'env` bound.
                 let closure: Box<FnMut() + Send + 'env> = Box::new(closure);
-                let closure: Box<FnMut() + Send + 'static> = unsafe {
-                    mem::transmute(closure)
-                };
+                let closure: Box<FnMut() + Send + 'static> = unsafe { mem::transmute(closure) };
 
                 // Finally, spawn the closure.
                 let mut closure = closure;
@@ -283,11 +278,7 @@ impl<'scope, 'env> ScopedThreadBuilder<'scope, 'env> {
         };
 
         // Add the handle to the shared list of join handles.
-        self.scope
-            .handles
-            .lock()
-            .unwrap()
-            .push(Arc::clone(&handle));
+        self.scope.handles.lock().unwrap().push(Arc::clone(&handle));
 
         Ok(ScopedJoinHandle {
             handle,
@@ -331,21 +322,12 @@ impl<'scope, T> ScopedJoinHandle<'scope, T> {
     pub fn join(self) -> thread::Result<T> {
         // Take out the handle. The handle will surely be available because the root scope waits
         // for nested scopes before joining remaining threads.
-        let handle = self
-            .handle
-            .lock()
-            .unwrap()
-            .take()
-            .unwrap();
+        let handle = self.handle.lock().unwrap().take().unwrap();
 
         // Join the thread and then take the result out of its inner closure.
-        handle.join().map(|()| {
-            self.result
-                .lock()
-                .unwrap()
-                .take()
-                .unwrap()
-        })
+        handle
+            .join()
+            .map(|()| self.result.lock().unwrap().take().unwrap())
     }
 
     /// Gets the underlying [`std::thread::Thread`] handle.

--- a/crossbeam-utils/tests/atomic_cell.rs
+++ b/crossbeam-utils/tests/atomic_cell.rs
@@ -15,8 +15,14 @@ fn is_lock_free() {
     assert_eq!(AtomicCell::<UsizeWrap>::is_lock_free(), true);
 
     assert_eq!(AtomicCell::<u8>::is_lock_free(), cfg!(feature = "nightly"));
-    assert_eq!(AtomicCell::<bool>::is_lock_free(), cfg!(feature = "nightly"));
-    assert_eq!(AtomicCell::<U8Wrap>::is_lock_free(), cfg!(feature = "nightly"));
+    assert_eq!(
+        AtomicCell::<bool>::is_lock_free(),
+        cfg!(feature = "nightly")
+    );
+    assert_eq!(
+        AtomicCell::<U8Wrap>::is_lock_free(),
+        cfg!(feature = "nightly")
+    );
 }
 
 #[test]

--- a/crossbeam-utils/tests/cache_padded.rs
+++ b/crossbeam-utils/tests/cache_padded.rs
@@ -1,7 +1,7 @@
 extern crate crossbeam_utils;
 
-use std::mem;
 use std::cell::Cell;
+use std::mem;
 
 use crossbeam_utils::CachePadded;
 

--- a/crossbeam-utils/tests/thread.rs
+++ b/crossbeam-utils/tests/thread.rs
@@ -54,8 +54,7 @@ fn counter_builder() {
                 .stack_size(SMALL_STACK_SIZE)
                 .spawn(|_| {
                     counter.fetch_add(1, Ordering::Relaxed);
-                })
-                .unwrap();
+                }).unwrap();
         }
     }).unwrap();
 
@@ -95,7 +94,9 @@ fn panic_twice() {
     });
 
     let err = result.unwrap_err();
-    let vec = err.downcast_ref::<Vec<Box<Any + Send + 'static>>>().unwrap();
+    let vec = err
+        .downcast_ref::<Vec<Box<Any + Send + 'static>>>()
+        .unwrap();
     assert_eq!(2, vec.len());
 
     let first = vec[0].downcast_ref::<&str>().unwrap();
@@ -148,9 +149,7 @@ fn nesting() {
         }
     }
 
-    let wrapper = Wrapper {
-        var: &var,
-    };
+    let wrapper = Wrapper { var: &var };
 
     thread::scope(|scope| {
         scope.spawn(|scope| {
@@ -165,9 +164,7 @@ fn nesting() {
 fn join_nested() {
     thread::scope(|scope| {
         scope.spawn(|scope| {
-            let handle = scope.spawn(|_| {
-                7
-            });
+            let handle = scope.spawn(|_| 7);
 
             sleep(Duration::from_millis(200));
             handle.join().unwrap();

--- a/src/arc_cell.rs
+++ b/src/arc_cell.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 use std::mem;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 
 /// A type providing atomic storage and retrieval of an `Arc<T>`.
 #[derive(Debug)]
@@ -72,8 +72,8 @@ impl<T> From<T> for ArcCell<T> {
 
 #[cfg(test)]
 mod test {
-    use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+    use std::sync::Arc;
 
     use super::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,11 +41,10 @@ mod ms_queue;
 mod seg_queue;
 mod treiber_stack;
 
-
 /// Additional utilities for atomics.
 pub mod atomic {
-    pub use crossbeam_utils::atomic::AtomicConsume;
     pub use arc_cell::ArcCell;
+    pub use crossbeam_utils::atomic::AtomicConsume;
 }
 
 /// Utilities for concurrent programming.
@@ -61,7 +60,6 @@ pub mod utils {
 pub use crossbeam_utils::thread;
 pub use crossbeam_utils::thread::scope;
 
-
 /// Epoch-based memory reclamation.
 ///
 /// See [the `crossbeam-epoch` crate](https://github.com/crossbeam-rs/crossbeam-epoch) for more
@@ -69,7 +67,6 @@ pub use crossbeam_utils::thread::scope;
 pub mod epoch {
     pub use crossbeam_epoch::*;
 }
-
 
 /// Multi-producer multi-consumer channels for message passing.
 ///
@@ -107,7 +104,6 @@ pub mod channel {
 // precise way to re-export only the `select!` macro.
 #[doc(hidden)]
 pub use crossbeam_channel::*;
-
 
 /// A concurrent work-stealing deque.
 ///

--- a/src/ms_queue.rs
+++ b/src/ms_queue.rs
@@ -103,8 +103,7 @@ impl<T> MsQueue<T> {
                 .map(|shared| {
                     // try to move the tail pointer forward
                     let _ = self.tail.compare_and_set(onto, shared, Release, guard);
-                })
-                .map_err(|e| e.new)
+                }).map_err(|e| e.new)
         }
     }
 
@@ -176,7 +175,8 @@ impl<T> MsQueue<T> {
                 });
                 if let Some((blocked_node, signal)) = request {
                     // race to dequeue the node
-                    if self.head
+                    if self
+                        .head
                         .compare_and_set(head_shared, blocked_node, Release, &guard)
                         .is_ok()
                     {
@@ -206,7 +206,8 @@ impl<T> MsQueue<T> {
         if let Some(next) = unsafe { next_shared.as_ref() } {
             if let Payload::Data(ref t) = next.payload {
                 unsafe {
-                    if self.head
+                    if self
+                        .head
                         .compare_and_set(head_shared, next_shared, Release, guard)
                         .is_ok()
                     {
@@ -352,8 +353,8 @@ impl<T> Default for MsQueue<T> {
 mod test {
     const CONC_COUNT: i64 = 1000000;
 
-    use scope;
     use super::*;
+    use scope;
 
     #[test]
     fn push_try_pop_1() {

--- a/src/seg_queue.rs
+++ b/src/seg_queue.rs
@@ -175,8 +175,8 @@ impl<T> Default for SegQueue<T> {
 mod test {
     const CONC_COUNT: i64 = 1000000;
 
-    use scope;
     use super::*;
+    use scope;
 
     #[test]
     fn push_pop_1() {

--- a/src/treiber_stack.rs
+++ b/src/treiber_stack.rs
@@ -1,6 +1,6 @@
-use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 use std::mem::ManuallyDrop;
 use std::ptr;
+use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 
 use epoch::{self, Atomic, Owned};
 
@@ -53,7 +53,8 @@ impl<T> TreiberStack<T> {
             match unsafe { head_shared.as_ref() } {
                 Some(head) => {
                     let next = head.next.load(Relaxed, &guard);
-                    if self.head
+                    if self
+                        .head
                         .compare_and_set(head_shared, next, Release, &guard)
                         .is_ok()
                     {
@@ -90,8 +91,8 @@ impl<T> Default for TreiberStack<T> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use ::{thread, epoch};
-    use std::sync::atomic::{Ordering, AtomicUsize};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use {epoch, thread};
 
     #[test]
     fn is_empty() {


### PR DESCRIPTION
This PR is the result of running Rustfmt and Clippy for all the repos.  I hope, at some point of time, to keep the repo passing Rustfmt and Clippy.  Maybe it's now...?

--

In the meantime, Clippy says something suspicious:

```
warning: passing a unit value to a function
   --> crossbeam-utils/src/atomic/atomic_cell.rs:834:31
    |
834 |             let res = a.store(mem::transmute_copy(&val), Ordering::SeqCst);
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: #[warn(clippy::unit_arg)] on by default
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#unit_arg
help: if you intended to pass a unit value, use a unit literal instead
    |
834 |             let res = a.store((), Ordering::SeqCst);
    |                               ^^
```

If Clippy is right, it seems a bug in atomic cell.  What do you guys think?