### PR TITLE
Enable bors-ng

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: rust
 
+branches:
+  only:
+    - master
+    - staging
+    - trying
+
 matrix:
   fast_finish: true
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 
-
 matrix:
+  fast_finish: true
   include:
 
   # Test crates on their minimum Rust versions.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ documentation = "https://docs.rs/crossbeam"
 description = "Support for concurrent programming: memory management, utilities, non-blocking data structures"
 keywords = ["atomic", "garbage", "non-blocking", "lock-free", "rcu"]
 categories = ["concurrency", "memory-management", "data-structures"]
+exclude = ["/ci/*", "/.travis.yml", "/bors.toml"]
 
 [badges]
 travis-ci = { repository = "crossbeam-rs/crossbeam" }

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,1 @@
+status = ["continuous-integration/travis-ci/push"]


### PR DESCRIPTION
Using bors has multiple benefits:

* It streamlines PR approval process: just say "bors r+" and it will be tested & merged. We can also delegate permission to approve PRs, which means there will be less ping-ponging between reviewers.

* Once approved, the PR is automatically tested and merged into master. Note that it will be tested only once, while currently we test it twice (before the merge and after merge).

* It'll make it easier to reduce CI build times: https://github.com/rayon-rs/rayon/blob/8c05d2b8788dc64067d6e79ff3b3cfe90a5e249e/.travis.yml#L11-L13

See how Rayon uses bors-ng: https://github.com/rayon-rs/rayon/pull/451
Quick intro: https://bors.tech/documentation/getting-started/