### PR TITLE
Debloat crossbeam-utils

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,12 @@ default = ["std"]
 nightly = ["crossbeam-epoch/nightly", "crossbeam-utils/nightly"]
 std = ["crossbeam-epoch/std", "crossbeam-utils/std"]
 
+[dependencies]
+cfg-if = "0.1"
+lazy_static = "1.1.0"
+num_cpus = "1.8.0"
+parking_lot = "0.6.4"
+
 [dependencies.crossbeam-channel]
 version = "0.3"
 path = "./crossbeam-channel"

--- a/ci/crossbeam-epoch.sh
+++ b/ci/crossbeam-epoch.sh
@@ -5,10 +5,11 @@ set -ex
 
 export RUSTFLAGS="-D warnings"
 
-cargo build --no-default-features
+cargo check --no-default-features
 cargo test
 
 if [[ "$TRAVIS_RUST_VERSION" == "nightly" ]]; then
+    cargo check --no-default-features --features nightly
     cargo test --features nightly
 
     ASAN_OPTIONS="detect_odr_violation=0 detect_leaks=0" \

--- a/ci/crossbeam-skiplist.sh
+++ b/ci/crossbeam-skiplist.sh
@@ -5,9 +5,10 @@ set -ex
 
 export RUSTFLAGS="-D warnings"
 
-cargo build --no-default-features
+cargo check --no-default-features
 cargo test
 
 if [[ "$TRAVIS_RUST_VERSION" == "nightly" ]]; then
+    cargo check --no-default-features --features nightly
     cargo test --features nightly
 fi

--- a/ci/crossbeam-utils.sh
+++ b/ci/crossbeam-utils.sh
@@ -5,9 +5,10 @@ set -ex
 
 export RUSTFLAGS="-D warnings"
 
-cargo build --no-default-features
+cargo check --no-default-features
 cargo test
 
 if [[ "$TRAVIS_RUST_VERSION" == "nightly" ]]; then
+    cargo check --no-default-features --features nightly
     cargo test --features nightly
 fi

--- a/ci/crossbeam.sh
+++ b/ci/crossbeam.sh
@@ -5,9 +5,10 @@ set -ex
 
 export RUSTFLAGS="-D warnings"
 
-cargo build --no-default-features
+cargo check --no-default-features
 cargo test
 
 if [[ "$TRAVIS_RUST_VERSION" == "nightly" ]]; then
+    cargo check --no-default-features --features nightly
     cargo test --features nightly
 fi

--- a/crossbeam-channel/src/lib.rs
+++ b/crossbeam-channel/src/lib.rs
@@ -1,5 +1,3 @@
-#![warn(missing_docs, missing_debug_implementations)]
-
 //! Multi-producer multi-consumer channels for message passing.
 //!
 //! This library is an alternative to [`std::sync::mpsc`] with more features and better
@@ -346,6 +344,9 @@
 //! [`Select`]: struct.Select.html
 //! [`Sender`]: struct.Sender.html
 //! [`Receiver`]: struct.Receiver.html
+
+#![warn(missing_docs)]
+#![warn(missing_debug_implementations)]
 
 extern crate crossbeam_epoch;
 extern crate crossbeam_utils;

--- a/crossbeam-deque/src/lib.rs
+++ b/crossbeam-deque/src/lib.rs
@@ -60,6 +60,9 @@
 //! [`fifo`]: fn.fifo.html
 //! [`lifo`]: fn.lifo.html
 
+#![warn(missing_docs)]
+#![warn(missing_debug_implementations)]
+
 extern crate crossbeam_epoch as epoch;
 extern crate crossbeam_utils as utils;
 

--- a/crossbeam-epoch/src/lib.rs
+++ b/crossbeam-epoch/src/lib.rs
@@ -54,28 +54,30 @@
 //! [`pin`]: fn.pin.html
 //! [`defer`]: fn.defer.html
 
-#![cfg_attr(feature = "nightly", feature(const_fn))]
+#![warn(missing_docs)]
+#![warn(missing_debug_implementations)]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "nightly", feature(alloc))]
-#![cfg_attr(not(test), no_std)]
-#![warn(missing_docs, missing_debug_implementations)]
+#![cfg_attr(feature = "nightly", feature(const_fn))]
 
-#[cfg(test)]
-extern crate core;
-#[cfg(all(not(test), feature = "std"))]
 #[macro_use]
-extern crate std;
+extern crate cfg_if;
+#[cfg(feature = "std")]
+extern crate core;
 
-// Use liballoc on nightly to avoid a dependency on libstd
-#[cfg(feature = "nightly")]
-extern crate alloc;
-#[cfg(not(feature = "nightly"))]
-extern crate std as alloc;
+cfg_if! {
+    if #[cfg(feature = "nightly")] {
+        extern crate alloc;
+    } else {
+        mod alloc {
+            extern crate std;
+            pub use self::std::*;
+        }
+    }
+}
 
 extern crate arrayvec;
 extern crate crossbeam_utils;
-#[cfg(feature = "std")]
-#[macro_use]
-extern crate lazy_static;
 #[macro_use]
 extern crate memoffset;
 #[macro_use]
@@ -83,8 +85,6 @@ extern crate scopeguard;
 
 mod atomic;
 mod collector;
-#[cfg(feature = "std")]
-mod default;
 mod deferred;
 mod epoch;
 mod guard;
@@ -93,6 +93,14 @@ mod sync;
 
 pub use self::atomic::{Atomic, CompareAndSetError, CompareAndSetOrdering, Owned, Pointer, Shared};
 pub use self::collector::{Collector, LocalHandle};
-#[cfg(feature = "std")]
-pub use self::default::{default_collector, is_pinned, pin};
 pub use self::guard::{unprotected, Guard};
+
+cfg_if! {
+    if #[cfg(feature = "std")] {
+        #[macro_use]
+        extern crate lazy_static;
+
+        mod default;
+        pub use self::default::{default_collector, is_pinned, pin};
+    }
+}

--- a/crossbeam-skiplist/Cargo.toml
+++ b/crossbeam-skiplist/Cargo.toml
@@ -20,6 +20,9 @@ default = ["std"]
 nightly = ["crossbeam-epoch/nightly"]
 std = ["crossbeam-epoch/std"]
 
+[dependencies]
+cfg-if = "0.1"
+
 [dependencies.crossbeam-epoch]
 version = "0.6"
 path = "../crossbeam-epoch"

--- a/crossbeam-skiplist/src/base.rs
+++ b/crossbeam-skiplist/src/base.rs
@@ -1,3 +1,5 @@
+//! TODO: docs
+
 use alloc::vec::Vec;
 use core::borrow::Borrow;
 use core::cmp;
@@ -1754,6 +1756,7 @@ where
         self.head.clone()
     }
 
+    /// TODO: docs
     pub fn next_back(&mut self, guard: &Guard) -> Option<RefEntry<'a, K, V>> {
         self.parent.check_guard(guard);
         self.tail = match self.tail {
@@ -1779,6 +1782,7 @@ where
 }
 
 /// An owning iterator over the entries of a `SkipList`.
+#[derive(Debug)] // TODO: write a custom impl
 pub struct IntoIter<K, V> {
     /// The current node.
     ///

--- a/crossbeam-skiplist/src/lib.rs
+++ b/crossbeam-skiplist/src/lib.rs
@@ -1,20 +1,22 @@
+// #![warn(missing_docs)] // TODO: Uncomment this.
+// #![warn(missing_debug_implementations)] // TODO: Uncomment this.
+#![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "nightly", feature(alloc))]
-#![cfg_attr(not(test), no_std)]
 
-#[cfg(test)]
-extern crate core;
-#[cfg(all(not(test), feature = "std"))]
 #[macro_use]
-extern crate std;
+extern crate cfg_if;
+#[cfg(feature = "std")]
+extern crate core;
 
-// Use liballoc on nightly to avoid a dependency on libstd
-#[cfg(feature = "nightly")]
-extern crate alloc;
-#[cfg(not(feature = "nightly"))]
-mod alloc {
-    // Tweak the module layout to match the one in liballoc
-    extern crate std;
-    pub use self::std::vec;
+cfg_if! {
+    if #[cfg(feature = "nightly")] {
+        extern crate alloc;
+    } else {
+        mod alloc {
+            extern crate std;
+            pub use self::std::*;
+        }
+    }
 }
 
 extern crate crossbeam_epoch as epoch;
@@ -22,16 +24,17 @@ extern crate crossbeam_utils as utils;
 extern crate scopeguard;
 
 pub mod base;
-#[cfg(feature = "std")]
-pub mod map;
-#[cfg(feature = "std")]
-pub mod set;
-
 pub use base::SkipList;
-#[cfg(feature = "std")]
-pub use map::SkipMap;
-#[cfg(feature = "std")]
-pub use set::SkipSet;
+
+cfg_if! {
+    if #[cfg(feature = "std")] {
+        pub mod map;
+        pub use map::SkipMap;
+
+        pub mod set;
+        pub use set::SkipSet;
+    }
+}
 
 /// An endpoint of a range of keys.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]

--- a/crossbeam-skiplist/src/map.rs
+++ b/crossbeam-skiplist/src/map.rs
@@ -1,3 +1,5 @@
+//! TODO: docs
+
 use std::borrow::Borrow;
 use std::fmt;
 use std::iter::FromIterator;

--- a/crossbeam-skiplist/src/set.rs
+++ b/crossbeam-skiplist/src/set.rs
@@ -1,3 +1,5 @@
+//! TODO: docs
+
 use std::borrow::Borrow;
 use std::fmt;
 use std::iter::FromIterator;

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -22,6 +22,3 @@ std = []
 
 [dependencies]
 cfg-if = "0.1"
-lazy_static = "1.1.0"
-num_cpus = "1.8.0"
-parking_lot = "0.6.4"

--- a/crossbeam-utils/src/atomic/mod.rs
+++ b/crossbeam-utils/src/atomic/mod.rs
@@ -1,5 +1,5 @@
-mod atomic_cell;
+//! Additional utilities for atomics.
+
 mod consume;
 
-pub use self::atomic_cell::AtomicCell;
 pub use self::consume::AtomicConsume;

--- a/crossbeam-utils/src/lib.rs
+++ b/crossbeam-utils/src/lib.rs
@@ -1,27 +1,35 @@
-#![cfg_attr(
-    feature = "nightly",
-    feature(cfg_target_has_atomic, integer_atomics)
-)]
+//! Utilities for concurrent programming.
+
+#![warn(missing_docs)]
+#![warn(missing_debug_implementations)]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(feature = "nightly", feature(alloc))]
+#![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]
+#![cfg_attr(feature = "nightly", feature(integer_atomics))]
 
 #[macro_use]
 extern crate cfg_if;
 #[cfg(feature = "std")]
 extern crate core;
-#[cfg(feature = "std")]
-extern crate num_cpus;
-#[cfg(feature = "std")]
-extern crate parking_lot;
-#[cfg(feature = "std")]
-#[macro_use]
-extern crate lazy_static;
 
-mod cache_padded;
+cfg_if! {
+    if #[cfg(feature = "nightly")] {
+        extern crate alloc;
+    } else {
+        mod alloc {
+            extern crate std;
+            pub use self::std::*;
+        }
+    }
+}
 
 pub mod atomic;
-#[cfg(feature = "std")]
-pub mod sync;
-#[cfg(feature = "std")]
-pub mod thread;
 
+mod cache_padded;
 pub use cache_padded::CachePadded;
+
+cfg_if! {
+    if #[cfg(feature = "std")] {
+        pub mod thread;
+    }
+}

--- a/crossbeam-utils/src/sync/mod.rs
+++ b/crossbeam-utils/src/sync/mod.rs
@@ -1,7 +1,0 @@
-//! Synchronization primitives.
-
-mod sharded_lock;
-mod wait_group;
-
-pub use self::sharded_lock::{ShardedLock, ShardedLockReadGuard, ShardedLockWriteGuard};
-pub use self::wait_group::WaitGroup;

--- a/src/arc_cell.rs
+++ b/src/arc_cell.rs
@@ -1,7 +1,7 @@
-use std::marker::PhantomData;
-use std::mem;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
+use alloc::sync::Arc;
+use core::marker::PhantomData;
+use core::mem;
+use core::sync::atomic::{AtomicUsize, Ordering};
 
 /// A type providing atomic storage and retrieval of an `Arc<T>`.
 #[derive(Debug)]

--- a/src/atomic_cell.rs
+++ b/src/atomic_cell.rs
@@ -33,7 +33,7 @@ impl<T> AtomicCell<T> {
     /// # Examples
     ///
     /// ```
-    /// use crossbeam_utils::atomic::AtomicCell;
+    /// use crossbeam::atomic::AtomicCell;
     ///
     /// let a = AtomicCell::new(7);
     /// ```
@@ -48,7 +48,7 @@ impl<T> AtomicCell<T> {
     /// # Examples
     ///
     /// ```
-    /// use crossbeam_utils::atomic::AtomicCell;
+    /// use crossbeam::atomic::AtomicCell;
     ///
     /// let mut a = AtomicCell::new(7);
     /// *a.get_mut() += 1;
@@ -64,7 +64,7 @@ impl<T> AtomicCell<T> {
     /// # Examples
     ///
     /// ```
-    /// use crossbeam_utils::atomic::AtomicCell;
+    /// use crossbeam::atomic::AtomicCell;
     ///
     /// let mut a = AtomicCell::new(7);
     /// let v = a.into_inner();
@@ -83,7 +83,7 @@ impl<T> AtomicCell<T> {
     /// # Examples
     ///
     /// ```
-    /// use crossbeam_utils::atomic::AtomicCell;
+    /// use crossbeam::atomic::AtomicCell;
     ///
     /// // This type is internally represented as `AtomicUsize` so we can just use atomic
     /// // operations provided by it.
@@ -112,7 +112,7 @@ impl<T> AtomicCell<T> {
     /// # Examples
     ///
     /// ```
-    /// use crossbeam_utils::atomic::AtomicCell;
+    /// use crossbeam::atomic::AtomicCell;
     ///
     /// let a = AtomicCell::new(7);
     ///
@@ -135,7 +135,7 @@ impl<T> AtomicCell<T> {
     /// # Examples
     ///
     /// ```
-    /// use crossbeam_utils::atomic::AtomicCell;
+    /// use crossbeam::atomic::AtomicCell;
     ///
     /// let a = AtomicCell::new(7);
     ///
@@ -154,7 +154,7 @@ impl<T: Copy> AtomicCell<T> {
     /// # Examples
     ///
     /// ```
-    /// use crossbeam_utils::atomic::AtomicCell;
+    /// use crossbeam::atomic::AtomicCell;
     ///
     /// let a = AtomicCell::new(7);
     ///
@@ -174,7 +174,7 @@ impl<T: Copy + Eq> AtomicCell<T> {
     /// # Examples
     ///
     /// ```
-    /// use crossbeam_utils::atomic::AtomicCell;
+    /// use crossbeam::atomic::AtomicCell;
     ///
     /// let a = AtomicCell::new(1);
     ///
@@ -199,7 +199,7 @@ impl<T: Copy + Eq> AtomicCell<T> {
     /// # Examples
     ///
     /// ```
-    /// use crossbeam_utils::atomic::AtomicCell;
+    /// use crossbeam::atomic::AtomicCell;
     ///
     /// let a = AtomicCell::new(1);
     ///
@@ -239,7 +239,7 @@ macro_rules! impl_arithmetic {
             /// # Examples
             ///
             /// ```
-            /// use crossbeam_utils::atomic::AtomicCell;
+            /// use crossbeam::atomic::AtomicCell;
             ///
             #[doc = $example]
             ///
@@ -267,7 +267,7 @@ macro_rules! impl_arithmetic {
             /// # Examples
             ///
             /// ```
-            /// use crossbeam_utils::atomic::AtomicCell;
+            /// use crossbeam::atomic::AtomicCell;
             ///
             #[doc = $example]
             ///
@@ -293,7 +293,7 @@ macro_rules! impl_arithmetic {
             /// # Examples
             ///
             /// ```
-            /// use crossbeam_utils::atomic::AtomicCell;
+            /// use crossbeam::atomic::AtomicCell;
             ///
             #[doc = $example]
             ///
@@ -319,7 +319,7 @@ macro_rules! impl_arithmetic {
             /// # Examples
             ///
             /// ```
-            /// use crossbeam_utils::atomic::AtomicCell;
+            /// use crossbeam::atomic::AtomicCell;
             ///
             #[doc = $example]
             ///
@@ -345,7 +345,7 @@ macro_rules! impl_arithmetic {
             /// # Examples
             ///
             /// ```
-            /// use crossbeam_utils::atomic::AtomicCell;
+            /// use crossbeam::atomic::AtomicCell;
             ///
             #[doc = $example]
             ///
@@ -376,7 +376,7 @@ macro_rules! impl_arithmetic {
             /// # Examples
             ///
             /// ```
-            /// use crossbeam_utils::atomic::AtomicCell;
+            /// use crossbeam::atomic::AtomicCell;
             ///
             #[doc = $example]
             ///
@@ -396,7 +396,7 @@ macro_rules! impl_arithmetic {
             /// # Examples
             ///
             /// ```
-            /// use crossbeam_utils::atomic::AtomicCell;
+            /// use crossbeam::atomic::AtomicCell;
             ///
             #[doc = $example]
             ///
@@ -414,7 +414,7 @@ macro_rules! impl_arithmetic {
             /// # Examples
             ///
             /// ```
-            /// use crossbeam_utils::atomic::AtomicCell;
+            /// use crossbeam::atomic::AtomicCell;
             ///
             #[doc = $example]
             ///
@@ -432,7 +432,7 @@ macro_rules! impl_arithmetic {
             /// # Examples
             ///
             /// ```
-            /// use crossbeam_utils::atomic::AtomicCell;
+            /// use crossbeam::atomic::AtomicCell;
             ///
             #[doc = $example]
             ///
@@ -450,7 +450,7 @@ macro_rules! impl_arithmetic {
             /// # Examples
             ///
             /// ```
-            /// use crossbeam_utils::atomic::AtomicCell;
+            /// use crossbeam::atomic::AtomicCell;
             ///
             #[doc = $example]
             ///
@@ -505,7 +505,7 @@ impl AtomicCell<bool> {
     /// # Examples
     ///
     /// ```
-    /// use crossbeam_utils::atomic::AtomicCell;
+    /// use crossbeam::atomic::AtomicCell;
     ///
     /// let a = AtomicCell::new(true);
     ///
@@ -526,7 +526,7 @@ impl AtomicCell<bool> {
     /// # Examples
     ///
     /// ```
-    /// use crossbeam_utils::atomic::AtomicCell;
+    /// use crossbeam::atomic::AtomicCell;
     ///
     /// let a = AtomicCell::new(false);
     ///
@@ -547,7 +547,7 @@ impl AtomicCell<bool> {
     /// # Examples
     ///
     /// ```
-    /// use crossbeam_utils::atomic::AtomicCell;
+    /// use crossbeam::atomic::AtomicCell;
     ///
     /// let a = AtomicCell::new(true);
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,20 +30,36 @@
 //!    goal is to also include bags, sets and maps.
 
 #![warn(missing_docs)]
+// #![warn(missing_debug_implementations)] // TODO: Uncomment this.
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(feature = "nightly", feature(alloc))]
 
-extern crate crossbeam_channel;
-extern crate crossbeam_deque;
+#[macro_use]
+extern crate cfg_if;
+#[cfg(feature = "std")]
+extern crate core;
+
+cfg_if! {
+    if #[cfg(feature = "nightly")] {
+        extern crate alloc;
+    } else {
+        mod alloc {
+            extern crate std;
+            pub use self::std::*;
+        }
+    }
+}
+
 extern crate crossbeam_epoch;
 extern crate crossbeam_utils;
 
 mod arc_cell;
-mod ms_queue;
-mod seg_queue;
-mod treiber_stack;
+mod atomic_cell;
 
 /// Additional utilities for atomics.
 pub mod atomic {
     pub use arc_cell::ArcCell;
+    pub use atomic_cell::AtomicCell;
     pub use crossbeam_utils::atomic::AtomicConsume;
 }
 
@@ -55,11 +71,6 @@ pub mod utils {
     pub use crossbeam_utils::CachePadded;
 }
 
-// Export `crossbeam_utils::thread` and `crossbeam_utils::thread::scope` in the crate root, in order
-// not to break established patterns.
-pub use crossbeam_utils::thread;
-pub use crossbeam_utils::thread::scope;
-
 /// Epoch-based memory reclamation.
 ///
 /// See [the `crossbeam-epoch` crate](https://github.com/crossbeam-rs/crossbeam-epoch) for more
@@ -68,58 +79,86 @@ pub mod epoch {
     pub use crossbeam_epoch::*;
 }
 
-/// Multi-producer multi-consumer channels for message passing.
-///
-/// See [the `crossbeam-channel` crate](https://github.com/crossbeam-rs/crossbeam-channel) for more
-/// information.
-///
-/// # Example
-///
-/// ```
-/// # #[macro_use]
-/// # extern crate crossbeam;
-/// # fn main() {
-/// use std::thread;
-/// use crossbeam::channel as channel;
-///
-/// let (s1, r1) = channel::unbounded();
-/// let (s2, r2) = channel::unbounded();
-///
-/// thread::spawn(move || s1.send("foo"));
-/// thread::spawn(move || s2.send("bar"));
-///
-/// // Only one of these two receive operations will be executed.
-/// select! {
-///     recv(r1) -> msg => assert_eq!(msg, Ok("foo")),
-///     recv(r2) -> msg => assert_eq!(msg, Ok("bar")),
-/// }
-/// # }
-/// ```
-pub mod channel {
-    pub use crossbeam_channel::*;
-}
+cfg_if! {
+    if #[cfg(feature = "std")] {
+        extern crate crossbeam_channel;
+        extern crate crossbeam_deque;
+        #[macro_use]
+        extern crate lazy_static;
+        extern crate num_cpus;
+        extern crate parking_lot;
 
-// FIXME(jeehoonkang): The entirety of `crossbeam_channel::*` is re-exported as public in the crate
-// root because it seems it's the only way to re-export its `select!` macro.  We need to find a more
-// precise way to re-export only the `select!` macro.
-#[doc(hidden)]
-pub use crossbeam_channel::*;
+        mod ms_queue;
+        mod seg_queue;
+        mod sharded_lock;
+        mod treiber_stack;
+        mod wait_group;
 
-/// A concurrent work-stealing deque.
-///
-/// See [the `crossbeam-deque` crate](https://github.com/crossbeam-rs/crossbeam-deque) for more
-/// information.
-pub mod deque {
-    pub use crossbeam_deque::*;
-}
+        // Export `crossbeam_utils::thread` and `crossbeam_utils::thread::scope` in the crate root,
+        // in order not to break established patterns.
+        pub use crossbeam_utils::thread;
+        pub use crossbeam_utils::thread::scope;
 
-/// Concurrent queues.
-pub mod queue {
-    pub use ms_queue::MsQueue;
-    pub use seg_queue::SegQueue;
-}
+        /// Multi-producer multi-consumer channels for message passing.
+        ///
+        /// See [the `crossbeam-channel` crate](https://github.com/crossbeam-rs/crossbeam-channel)
+        /// for more information.
+        ///
+        /// # Example
+        ///
+        /// ```
+        /// # #[macro_use]
+        /// # extern crate crossbeam;
+        /// # fn main() {
+        /// use std::thread;
+        /// use crossbeam::channel as channel;
+        ///
+        /// let (s1, r1) = channel::unbounded();
+        /// let (s2, r2) = channel::unbounded();
+        ///
+        /// thread::spawn(move || s1.send("foo"));
+        /// thread::spawn(move || s2.send("bar"));
+        ///
+        /// // Only one of these two receive operations will be executed.
+        /// select! {
+        ///     recv(r1) -> msg => assert_eq!(msg, Ok("foo")),
+        ///     recv(r2) -> msg => assert_eq!(msg, Ok("bar")),
+        /// }
+        /// # }
+        /// ```
+        pub mod channel {
+            pub use crossbeam_channel::*;
+        }
 
-/// Concurrent stacks.
-pub mod stack {
-    pub use treiber_stack::TreiberStack;
+        // FIXME(jeehoonkang): The entirety of `crossbeam_channel::*` is re-exported as public in
+        // the crate root because it seems it's the only way to re-export its `select!` macro.  We
+        // need to find a more precise way to re-export only the `select!` macro.
+        #[doc(hidden)]
+        pub use crossbeam_channel::*;
+
+        /// A concurrent work-stealing deque.
+        ///
+        /// See [the `crossbeam-deque` crate](https://github.com/crossbeam-rs/crossbeam-deque) for
+        /// more information.
+        pub mod deque {
+            pub use crossbeam_deque::*;
+        }
+
+        /// Concurrent queues.
+        pub mod queue {
+            pub use ms_queue::MsQueue;
+            pub use seg_queue::SegQueue;
+        }
+
+        /// Concurrent stacks.
+        pub mod stack {
+            pub use treiber_stack::TreiberStack;
+        }
+
+        /// Utilities for thread synchronization.
+        pub mod sync {
+            pub use sharded_lock::{ShardedLock, ShardedLockReadGuard, ShardedLockWriteGuard};
+            pub use wait_group::WaitGroup;
+        }
+    }
 }

--- a/src/sharded_lock.rs
+++ b/src/sharded_lock.rs
@@ -11,10 +11,9 @@ use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::thread::{self, ThreadId};
 
+use crossbeam_utils::CachePadded;
 use num_cpus;
 use parking_lot::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
-
-use CachePadded;
 
 /// A scalable reader-writer lock.
 ///

--- a/src/wait_group.rs
+++ b/src/wait_group.rs
@@ -22,7 +22,7 @@ use parking_lot::{Condvar, Mutex};
 /// # Examples
 ///
 /// ```
-/// use crossbeam_utils::sync::WaitGroup;
+/// use crossbeam::sync::WaitGroup;
 /// use std::thread;
 ///
 /// // Create a new wait group.
@@ -61,7 +61,7 @@ impl WaitGroup {
     /// # Examples
     ///
     /// ```
-    /// use crossbeam_utils::sync::WaitGroup;
+    /// use crossbeam::sync::WaitGroup;
     ///
     /// let wg = WaitGroup::new();
     /// ```
@@ -79,7 +79,7 @@ impl WaitGroup {
     /// # Examples
     ///
     /// ```
-    /// use crossbeam_utils::sync::WaitGroup;
+    /// use crossbeam::sync::WaitGroup;
     /// use std::thread;
     ///
     /// let wg = WaitGroup::new();

--- a/tests/atomic_cell.rs
+++ b/tests/atomic_cell.rs
@@ -1,9 +1,9 @@
-extern crate crossbeam_utils;
+extern crate crossbeam;
 
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::SeqCst;
 
-use crossbeam_utils::atomic::AtomicCell;
+use crossbeam::atomic::AtomicCell;
 
 #[test]
 fn is_lock_free() {

--- a/tests/subcrates.rs
+++ b/tests/subcrates.rs
@@ -1,0 +1,40 @@
+//! Makes sure subcrates are properly reexported.
+
+#[macro_use]
+extern crate crossbeam;
+
+#[test]
+fn channel() {
+    let (s, r) = crossbeam::channel::bounded(1);
+
+    select! {
+        send(s, 0) -> res => res.unwrap(),
+        recv(r) -> res => assert!(res.is_ok()),
+    }
+}
+
+#[test]
+fn deque() {
+    let (w, s) = crossbeam::deque::fifo();
+    w.push(1);
+    let _ = w.pop();
+    let _ = s.steal();
+}
+
+#[test]
+fn epoch() {
+    crossbeam::epoch::pin();
+}
+
+#[test]
+fn utils() {
+    crossbeam::utils::CachePadded::new(7);
+
+    crossbeam::scope(|scope| {
+        scope.spawn(|_| ());
+    }).unwrap();
+
+    crossbeam::thread::scope(|scope| {
+        scope.spawn(|_| ());
+    }).unwrap();
+}

--- a/tests/wait_group.rs
+++ b/tests/wait_group.rs
@@ -1,10 +1,10 @@
-extern crate crossbeam_utils;
+extern crate crossbeam;
 
 use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 
-use crossbeam_utils::sync::WaitGroup;
+use crossbeam::sync::WaitGroup;
 
 const THREADS: usize = 10;
 


### PR DESCRIPTION
This PR accomplishes several things:

* Moves `crossbeam_utils::AtomicCell` and `crossbeam_utils::sync` into `crossbeam`. This is a conservative decision because I'd prefer not to commit to putting those tools into any particular subcrate at this moment, but we should think about eventually moving them into a dedicated crate in the future. We also want to keep `crossbeam-utils` lean so that it doesn't pull in many dependencies.

* Refactors the `#[cfg(...)]` shenanigans related to features `std` and `nightly`. Every crate that has those features now has a standardized template at the top of `lib.rs`. All parts of crates that use `std` are now placed into a dedicated `cfg_if!` block.

* Tweaks `lib.rs` in the main `crossbeam` crate so that docs get nicely rendered. Now modules `channel`, `deque`, and `thread` use the original docs from subcrates, which means we don't have to write those poor substitutes for the real docs anymore.