### PR TITLE
Add Parker for thread parking

### DIFF
--- a/crossbeam-utils/src/lib.rs
+++ b/crossbeam-utils/src/lib.rs
@@ -30,6 +30,7 @@ pub use cache_padded::CachePadded;
 
 cfg_if! {
     if #[cfg(feature = "std")] {
+        pub mod sync;
         pub mod thread;
     }
 }

--- a/crossbeam-utils/src/sync/mod.rs
+++ b/crossbeam-utils/src/sync/mod.rs
@@ -2,4 +2,4 @@
 
 mod parker;
 
-pub use self::parker::Parker;
+pub use self::parker::{Parker, Unparker};

--- a/crossbeam-utils/src/sync/mod.rs
+++ b/crossbeam-utils/src/sync/mod.rs
@@ -1,0 +1,5 @@
+//! Synchronization tools.
+
+mod parker;
+
+pub use self::parker::Parker;

--- a/crossbeam-utils/src/sync/parker.rs
+++ b/crossbeam-utils/src/sync/parker.rs
@@ -1,0 +1,258 @@
+use std::fmt;
+use std::sync::{Condvar, Mutex};
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering::SeqCst;
+use std::time::Duration;
+
+const EMPTY: usize = 0;
+const PARKED: usize = 1;
+const NOTIFIED: usize = 2;
+
+/// A thread parking primitive.
+///
+/// Only one thread at a time may call [`park`], but any thread may call [`unpark`] at any time.
+///
+/// Conceptually, each `Parker` has an associated token which is initially not present:
+///
+/// * The [`park`] method blocks the current thread unless or until the token is available, at
+///   which point it automatically consumes the token. It may also return *spuriously*, without
+///   consuming the token.
+///
+/// * The [`park_timeout`] method works the same as [`park`], but blocks for a specified maximum
+///   time.
+///
+/// * The [`unpark`] method atomically makes the token available if it wasn't already. Because the
+///   token is initially absent, [`unpark`] followed by [`park`] will result in the second call
+///   returning immediately.
+///
+/// In other words, each `Parker` acts a bit like a spinlock that can be locked and unlocked using
+/// [`park`] and [`unpark`].
+///
+/// # Examples
+///
+/// ```
+/// use std::sync::Arc;
+/// use std::thread;
+/// use std::time::Duration;
+/// use crossbeam_utils::sync::Parker;
+///
+/// let parker = Arc::new(Parker::new());
+///
+/// // Make the token available.
+/// parker.unpark();
+/// // Wakes up immediately and consumes the token.
+/// parker.park();
+///
+/// let parker2 = parker.clone();
+/// thread::spawn(move || {
+///     thread::sleep(Duration::from_millis(500));
+///     parker2.unpark();
+/// });
+///
+/// // Wakes up when `parker2.unpark()` provides the token, but may also wake up
+/// // spuriously before that without consuming the token.
+/// parker.park();
+/// ```
+///
+/// [`park`]: struct.Parker.html#method.park
+/// [`park_timeout`]: struct.Parker.html#method.park_timeout
+/// [`unpark`]: struct.Parker.html#method.unpark
+pub struct Parker {
+    state: AtomicUsize,
+    lock: Mutex<()>,
+    cvar: Condvar,
+}
+
+impl Parker {
+    /// Creates a new `Parker`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_utils::sync::Parker;
+    ///
+    /// let parker = Parker::new();
+    /// ```
+    ///
+    pub fn new() -> Parker {
+        Parker {
+            state: AtomicUsize::new(EMPTY),
+            lock: Mutex::new(()),
+            cvar: Condvar::new(),
+        }
+    }
+
+    /// Blocks the current thread until the token is made available.
+    ///
+    /// A call to [`park`] may wake up spuriously without consuming the token, and callers should
+    /// be prepared for this possibility.
+    ///
+    /// Only one thread may call [`park`] or [`park_timeout`] at a time. If multiple threads call
+    /// it at the same time, deadlocks or panics might occur.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_utils::sync::Parker;
+    ///
+    /// let parker = Parker::new();
+    ///
+    /// // Make the token available.
+    /// parker.unpark();
+    ///
+    /// // Wakes up immediately and consumes the token.
+    /// parker.park();
+    /// ```
+    ///
+    /// [`park`]: struct.Parker.html#method.park
+    /// [`park_timeout`]: struct.Parker.html#method.park_timeout
+    /// [`unpark`]: struct.Parker.html#method.unpark
+    pub fn park(&self) {
+        self.park_internal(None);
+    }
+
+    /// Blocks the current thread until the token is made available, but only for a limited time.
+    ///
+    /// A call to [`park_timeout`] may wake up spuriously without consuming the token, and callers
+    /// should be prepared for this possibility.
+    ///
+    /// Only one thread may call [`park`] or [`park_timeout`] at a time. If multiple threads call
+    /// it at the same time, deadlocks or panics might occur.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::time::Duration;
+    /// use crossbeam_utils::sync::Parker;
+    ///
+    /// let parker = Parker::new();
+    ///
+    /// // Waits for the token to become available, but will not wait longer than 500 ms.
+    /// parker.park_timeout(Duration::from_millis(500));
+    /// ```
+    ///
+    /// [`park`]: struct.Parker.html#method.park
+    /// [`park_timeout`]: struct.Parker.html#method.park_timeout
+    /// [`unpark`]: struct.Parker.html#method.unpark
+    pub fn park_timeout(&self, timeout: Duration) {
+        self.park_internal(Some(timeout));
+    }
+
+    fn park_internal(&self, timeout: Option<Duration>) {
+        // If we were previously notified then we consume this notification and return quickly.
+        if self.state.compare_exchange(NOTIFIED, EMPTY, SeqCst, SeqCst).is_ok() {
+            return;
+        }
+
+        // If the timeout is zero, then there is no need to actually block.
+        if let Some(ref dur) = timeout {
+            if *dur == Duration::from_millis(0) {
+                return;
+            }
+        }
+
+        // Otherwise we need to coordinate going to sleep.
+        let mut m = self.lock.lock().unwrap();
+
+        match self.state.compare_exchange(EMPTY, PARKED, SeqCst, SeqCst) {
+            Ok(_) => {}
+            // Consume this notification to avoid spurious wakeups in the next park.
+            Err(NOTIFIED) => {
+                // We must read `state` here, even though we know it will be `NOTIFIED`. This is
+                // because `unpark` may have been called again since we read `NOTIFIED` in the
+                // `compare_exchange` above. We must perform an acquire operation that synchronizes
+                // with that `unpark` to observe any writes it made before the call to `unpark`. To
+                // do that we must read from the write it made to `state`.
+                let old = self.state.swap(EMPTY, SeqCst);
+                assert_eq!(old, NOTIFIED, "park state changed unexpectedly");
+                return;
+            }
+            Err(n) => panic!("inconsistent park_timeout state: {}", n),
+        }
+
+        match timeout {
+            None => {
+                loop {
+                    // Block the current thread on the conditional variable.
+                    m = self.cvar.wait(m).unwrap();
+
+                    match self.state.compare_exchange(NOTIFIED, EMPTY, SeqCst, SeqCst) {
+                        Ok(_) => return, // got a notification
+                        Err(_) => {} // spurious wakeup, go back to sleep
+                    }
+                }
+            }
+            Some(timeout) => {
+                // Wait with a timeout, and if we spuriously wake up or otherwise wake up from a
+                // notification we just want to unconditionally set `state` back to `EMPTY`, either
+                // consuming a notification or un-flagging ourselves as parked.
+                let (_m, _result) = self.cvar.wait_timeout(m, timeout).unwrap();
+
+                match self.state.swap(EMPTY, SeqCst) {
+                    NOTIFIED => {} // got a notification
+                    PARKED => {} // no notification
+                    n => panic!("inconsistent park_timeout state: {}", n),
+                }
+            }
+        }
+    }
+
+    /// Atomically makes the token available if it is not already.
+    ///
+    /// This method will wake up the thread blocked on [`park`] or [`park_timeout`], if there is
+    /// any.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use std::thread;
+    /// use std::time::Duration;
+    /// use crossbeam_utils::sync::Parker;
+    ///
+    /// let parker = Arc::new(Parker::new());
+    ///
+    /// let parker2 = parker.clone();
+    /// thread::spawn(move || {
+    ///     thread::sleep(Duration::from_millis(500));
+    ///     parker2.unpark();
+    /// });
+    ///
+    /// // Wakes up when `parker2.unpark()` provides the token, but may also wake up
+    /// // spuriously before that without consuming the token.
+    /// parker.park();
+    /// ```
+    ///
+    /// [`park`]: struct.Parker.html#method.park
+    /// [`park_timeout`]: struct.Parker.html#method.park_timeout
+    /// [`unpark`]: struct.Parker.html#method.unpark
+    pub fn unpark(&self) {
+        // To ensure the unparked thread will observe any writes we made before this call, we must
+        // perform a release operation that `park` can synchronize with. To do that we must write
+        // `NOTIFIED` even if `state` is already `NOTIFIED`. That is why this must be a swap rather
+        // than a compare-and-swap that returns if it reads `NOTIFIED` on failure.
+        match self.state.swap(NOTIFIED, SeqCst) {
+            EMPTY => return, // no one was waiting
+            NOTIFIED => return, // already unparked
+            PARKED => {} // gotta go wake someone up
+            _ => panic!("inconsistent state in unpark"),
+        }
+
+        // There is a period between when the parked thread sets `state` to `PARKED` (or last
+        // checked `state` in the case of a spurious wakeup) and when it actually waits on `cvar`.
+        // If we were to notify during this period it would be ignored and then when the parked
+        // thread went to sleep it would never wake up. Fortunately, it has `lock` locked at this
+        // stage so we can acquire `lock` to wait until it is ready to receive the notification.
+        //
+        // Releasing `lock` before the call to `notify_one` means that when the parked thread wakes
+        // it doesn't get woken only to have to wait for us to release `lock`.
+        drop(self.lock.lock().unwrap());
+        self.cvar.notify_one();
+    }
+}
+
+impl fmt::Debug for Parker {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Parker")
+    }
+}

--- a/crossbeam-utils/tests/parker.rs
+++ b/crossbeam-utils/tests/parker.rs
@@ -1,0 +1,42 @@
+extern crate crossbeam_utils;
+
+use std::thread::sleep;
+use std::time::Duration;
+use std::u32;
+
+use crossbeam_utils::sync::Parker;
+use crossbeam_utils::thread;
+
+#[test]
+fn park_timeout_unpark_before() {
+    let mut p = Parker::new();
+    for _ in 0..10 {
+        p.unparker().unpark();
+        p.park_timeout(Duration::from_millis(u32::MAX as u64));
+    }
+}
+
+#[test]
+fn park_timeout_unpark_not_called() {
+    let mut p = Parker::new();
+    for _ in 0..10 {
+        p.park_timeout(Duration::from_millis(10));
+    }
+}
+
+#[test]
+fn park_timeout_unpark_called_other_thread() {
+    for _ in 0..10 {
+        let mut p = Parker::new();
+        let u = p.unparker().clone();
+
+        thread::scope(|scope| {
+            scope.spawn(move |_| {
+                sleep(Duration::from_millis(50));
+                u.unpark();
+            });
+
+            p.park_timeout(Duration::from_millis(u32::MAX as u64));
+        }).unwrap();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,7 @@ cfg_if! {
 
         /// Utilities for thread synchronization.
         pub mod sync {
+            pub use crossbeam_utils::sync::Parker;
             pub use sharded_lock::{ShardedLock, ShardedLockReadGuard, ShardedLockWriteGuard};
             pub use wait_group::WaitGroup;
         }


### PR DESCRIPTION
This is just an extracted copy of the current implementation of `thread::park()` and `thread::unpark()`.

`Parker` is a low-level thread synchronization primitive useful for building others (like locks etc.). It would be useful in https://github.com/tokio-rs/tokio/pull/528 and might remove some cruft and unnecessary TLS access from `context.rs` in `crossbeam-channel`.

I've also added a fast-path check for `timeout == Duration::from_secs(0)`, which Tokio relies on.

An interesting peculiarity of `Parker` is that it's not split into `Parker` and `Unparker`, which means any thread can call `park()` at any time. However, if multiple threads call `park()` at the same time, expect deadlocks or panics - that is the user's problem. Splitting the primitive into an owned `Parker` and shared `Unparker` would require us to wrap the inner structure into an `Arc`, which comes at a cost of allocation and indirection. Since this is a very low-level primitive, I chose not to do that.

The reason why this is in `crossbeam-utils` is because it's a really simple primitive with no dependencies. Also, `tokio-executor` and `tokio-threadpool` really don't want to pull in the whole `crossbeam` in order to use this.

cc @carllerche