### PR TITLE
Use std::ops::Bound in crossbeam-skiplist

### DIFF
--- a/crossbeam-skiplist/src/base.rs
+++ b/crossbeam-skiplist/src/base.rs
@@ -5,14 +5,13 @@ use core::borrow::Borrow;
 use core::cmp;
 use core::fmt;
 use core::mem;
-use core::ops::{Deref, Index};
+use core::ops::{Bound, Deref, Index};
 use core::ptr;
 use core::sync::atomic::{fence, AtomicUsize, Ordering};
 
 use epoch::{self, Atomic, Collector, Guard, Shared};
 use scopeguard;
 use utils::CachePadded;
-use Bound;
 
 /// Number of bits needed to store height.
 const HEIGHT_BITS: usize = 5;

--- a/crossbeam-skiplist/src/lib.rs
+++ b/crossbeam-skiplist/src/lib.rs
@@ -35,14 +35,3 @@ cfg_if! {
         pub use set::SkipSet;
     }
 }
-
-/// An endpoint of a range of keys.
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
-pub enum Bound<T> {
-    /// An inclusive bound.
-    Included(T),
-    /// An exclusive bound.
-    Excluded(T),
-    /// An infinite endpoint. Indicates that there is no bound in this direction.
-    Unbounded,
-}

--- a/crossbeam-skiplist/src/map.rs
+++ b/crossbeam-skiplist/src/map.rs
@@ -3,10 +3,10 @@
 use std::borrow::Borrow;
 use std::fmt;
 use std::iter::FromIterator;
+use std::ops::Bound;
 
 use base::{self, try_pin_loop};
 use epoch;
-use Bound;
 
 /// A map based on a lock-free skip list.
 pub struct SkipMap<K, V> {

--- a/crossbeam-skiplist/src/set.rs
+++ b/crossbeam-skiplist/src/set.rs
@@ -3,9 +3,9 @@
 use std::borrow::Borrow;
 use std::fmt;
 use std::iter::FromIterator;
+use std::ops::Bound;
 
 use map;
-use Bound;
 
 /// A set based on a lock-free skip list.
 pub struct SkipSet<T> {

--- a/crossbeam-skiplist/tests/base.rs
+++ b/crossbeam-skiplist/tests/base.rs
@@ -1,9 +1,10 @@
 extern crate crossbeam_epoch as epoch;
 extern crate crossbeam_skiplist as skiplist;
 
+use std::ops::Bound;
 use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
 
-use skiplist::{Bound, SkipList};
+use skiplist::SkipList;
 
 #[test]
 fn new() {

--- a/crossbeam-skiplist/tests/map.rs
+++ b/crossbeam-skiplist/tests/map.rs
@@ -1,6 +1,6 @@
 extern crate crossbeam_skiplist as skiplist;
 
-use skiplist::{Bound, SkipMap};
+use skiplist::SkipMap;
 
 #[test]
 fn smoke() {
@@ -36,7 +36,7 @@ fn iter() {
 
 #[test]
 fn iter_range() {
-    use Bound::*;
+    use std::ops::Bound::*;
     let s = SkipMap::new();
     let v = (0..10).map(|x| x * 10).collect::<Vec<_>>();
     for &x in v.iter() {


### PR DESCRIPTION
It’s stable since 1.17