### PR TITLE
Wait on a set of operations without committing to any

### DIFF
--- a/crossbeam-channel/src/err.rs
+++ b/crossbeam-channel/src/err.rs
@@ -99,6 +99,22 @@ pub struct TrySelectError;
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub struct SelectTimeoutError;
 
+/// An error returned from the [`try_ready`] method.
+///
+/// Failed because none of the channel operations were ready.
+///
+/// [`try_ready`]: struct.Select.html#method.try_ready
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+pub struct TryReadyError;
+
+/// An error returned from the [`ready_timeout`] method.
+///
+/// Failed because none of the channel operations became ready before the timeout.
+///
+/// [`ready_timeout`]: struct.Select.html#method.ready_timeout
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+pub struct ReadyTimeoutError;
+
 impl<T> fmt::Debug for SendError<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         "SendError(..)".fmt(f)

--- a/crossbeam-channel/src/flavors/never.rs
+++ b/crossbeam-channel/src/flavors/never.rs
@@ -80,12 +80,7 @@ impl<T> Clone for Channel<T> {
 
 impl<T> SelectHandle for Channel<T> {
     #[inline]
-    fn try(&self, _token: &mut Token) -> bool {
-        false
-    }
-
-    #[inline]
-    fn retry(&self, _token: &mut Token) -> bool {
+    fn try_select(&self, _token: &mut Token) -> bool {
         false
     }
 
@@ -95,17 +90,30 @@ impl<T> SelectHandle for Channel<T> {
     }
 
     #[inline]
-    fn register(&self, _token: &mut Token, _oper: Operation, _cx: &Context) -> bool {
-        true
+    fn register(&self, _oper: Operation, _cx: &Context) -> bool {
+        self.is_ready()
     }
 
     #[inline]
     fn unregister(&self, _oper: Operation) {}
 
     #[inline]
-    fn accept(&self, _token: &mut Token, _cx: &Context) -> bool {
+    fn accept(&self, token: &mut Token, _cx: &Context) -> bool {
+        self.try_select(token)
+    }
+
+    #[inline]
+    fn is_ready(&self) -> bool {
         false
     }
+
+    #[inline]
+    fn watch(&self, _oper: Operation, _cx: &Context) -> bool {
+        self.is_ready()
+    }
+
+    #[inline]
+    fn unwatch(&self, _oper: Operation) {}
 
     #[inline]
     fn state(&self) -> usize {

--- a/crossbeam-channel/src/flavors/tick.rs
+++ b/crossbeam-channel/src/flavors/tick.rs
@@ -146,7 +146,7 @@ impl Clone for Channel {
 
 impl SelectHandle for Channel {
     #[inline]
-    fn try(&self, token: &mut Token) -> bool {
+    fn try_select(&self, token: &mut Token) -> bool {
         match self.try_recv() {
             Ok(msg) => {
                 token.tick = Some(msg);
@@ -161,18 +161,13 @@ impl SelectHandle for Channel {
     }
 
     #[inline]
-    fn retry(&self, token: &mut Token) -> bool {
-        self.try(token)
-    }
-
-    #[inline]
     fn deadline(&self) -> Option<Instant> {
         Some(self.inner.lock().next_tick)
     }
 
     #[inline]
-    fn register(&self, _token: &mut Token, _oper: Operation, _cx: &Context) -> bool {
-        true
+    fn register(&self, _oper: Operation, _cx: &Context) -> bool {
+        self.is_ready()
     }
 
     #[inline]
@@ -180,8 +175,21 @@ impl SelectHandle for Channel {
 
     #[inline]
     fn accept(&self, token: &mut Token, _cx: &Context) -> bool {
-        self.try(token)
+        self.try_select(token)
     }
+
+    #[inline]
+    fn is_ready(&self) -> bool {
+        !self.is_empty()
+    }
+
+    #[inline]
+    fn watch(&self, _oper: Operation, _cx: &Context) -> bool {
+        self.is_ready()
+    }
+
+    #[inline]
+    fn unwatch(&self, _oper: Operation) {}
 
     #[inline]
     fn state(&self) -> usize {

--- a/crossbeam-channel/src/lib.rs
+++ b/crossbeam-channel/src/lib.rs
@@ -371,5 +371,5 @@ pub use channel::{Receiver, Sender};
 pub use select::{Select, SelectedOperation};
 
 pub use err::{RecvError, RecvTimeoutError, TryRecvError};
-pub use err::{SelectTimeoutError, TrySelectError};
+pub use err::{ReadyTimeoutError, SelectTimeoutError, TryReadyError, TrySelectError};
 pub use err::{SendError, SendTimeoutError, TrySendError};

--- a/crossbeam-channel/src/waker.rs
+++ b/crossbeam-channel/src/waker.rs
@@ -263,7 +263,7 @@ impl SyncWaker {
         if self.len.load(Ordering::SeqCst) > 0 {
             let mut inner = self.inner.lock();
             inner.disconnect();
-            self.len.store(inner.len(), Ordering::SeqCst);
+            self.len.store(inner.selectors.len() + inner.observers.len(), Ordering::SeqCst);
         }
     }
 }

--- a/crossbeam-channel/src/waker.rs
+++ b/crossbeam-channel/src/waker.rs
@@ -42,8 +42,8 @@ impl Waker {
     pub fn new() -> Self {
         Waker {
             selectors: Vec::new(),
-            register_count: Wrapping(0),
             observers: Vec::new(),
+            register_count: Wrapping(0),
         }
     }
 
@@ -53,7 +53,7 @@ impl Waker {
         self.register_with_packet(oper, 0, cx);
     }
 
-    /// Registers a select operation with a packet.
+    /// Registers a select operation and a packet.
     #[inline]
     pub fn register_with_packet(&mut self, oper: Operation, packet: usize, cx: &Context) {
         self.selectors.push(Entry {
@@ -80,7 +80,7 @@ impl Waker {
         }
     }
 
-    /// Attempts to find an another thread's entry, select the operation, and wake it up.
+    /// Attempts to find another thread's entry, select the operation, and wake it up.
     #[inline]
     pub fn try_select(&mut self) -> Option<Entry> {
         let mut entry = None;

--- a/crossbeam-channel/src/waker.rs
+++ b/crossbeam-channel/src/waker.rs
@@ -1,6 +1,5 @@
 //! Waking mechanism for threads blocked on channel operations.
 
-use std::collections::VecDeque;
 use std::num::Wrapping;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread::{self, ThreadId};
@@ -12,14 +11,14 @@ use select::{Operation, Selected};
 
 /// Represents a thread blocked on a specific channel operation.
 pub struct Entry {
-    /// Context associated with the thread owning this operation.
-    pub context: Context,
-
     /// The operation.
     pub oper: Operation,
 
     /// Optional packet.
     pub packet: usize,
+
+    /// Context associated with the thread owning this operation.
+    pub cx: Context,
 }
 
 /// A queue of threads blocked on channel operations.
@@ -27,8 +26,11 @@ pub struct Entry {
 /// This data structure is used by threads to register blocking operations and get woken up once
 /// an operation becomes ready.
 pub struct Waker {
-    /// The list of registered blocking operations.
-    entries: VecDeque<Entry>,
+    /// A list of select operations.
+    selectors: Vec<Entry>,
+
+    /// A list of operations waiting to be ready.
+    observers: Vec<Entry>,
 
     /// The number of calls to `register` and `register_with_packet`.
     register_count: Wrapping<usize>,
@@ -39,133 +41,148 @@ impl Waker {
     #[inline]
     pub fn new() -> Self {
         Waker {
-            entries: VecDeque::new(),
+            selectors: Vec::new(),
             register_count: Wrapping(0),
+            observers: Vec::new(),
         }
     }
 
-    /// Registers the current thread with an operation.
+    /// Registers a select operation.
     #[inline]
     pub fn register(&mut self, oper: Operation, cx: &Context) {
         self.register_with_packet(oper, 0, cx);
     }
 
-    /// Registers the current thread with an operation and a packet.
+    /// Registers a select operation with a packet.
     #[inline]
     pub fn register_with_packet(&mut self, oper: Operation, packet: usize, cx: &Context) {
-        self.entries.push_back(Entry {
-            context: cx.clone(),
+        self.selectors.push(Entry {
             oper,
             packet,
+            cx: cx.clone(),
         });
         self.register_count += Wrapping(1);
     }
 
-    /// Unregisters an operation previously registered by the current thread.
+    /// Unregisters a select operation.
     #[inline]
     pub fn unregister(&mut self, oper: Operation) -> Option<Entry> {
         if let Some((i, _)) = self
-            .entries
+            .selectors
             .iter()
             .enumerate()
             .find(|&(_, entry)| entry.oper == oper)
         {
-            let entry = self.entries.remove(i);
-            Self::maybe_shrink(&mut self.entries);
-            entry
+            let entry = self.selectors.remove(i);
+            Some(entry)
         } else {
             None
         }
     }
 
-    /// Attempts to find one thread (not the current one), select its operation, and wake it up.
+    /// Attempts to find an another thread's entry, select the operation, and wake it up.
     #[inline]
-    pub fn wake_one(&mut self) -> Option<Entry> {
-        if !self.entries.is_empty() {
+    pub fn try_select(&mut self) -> Option<Entry> {
+        let mut entry = None;
+
+        if !self.selectors.is_empty() {
             let thread_id = current_thread_id();
 
-            for i in 0..self.entries.len() {
+            for i in 0..self.selectors.len() {
                 // Does the entry belong to a different thread?
-                if self.entries[i].context.thread_id() != thread_id {
+                if self.selectors[i].cx.thread_id() != thread_id {
                     // Try selecting this operation.
-                    let sel = Selected::Operation(self.entries[i].oper);
-                    let res = self.entries[i].context.try_select(sel);
+                    let sel = Selected::Operation(self.selectors[i].oper);
+                    let res = self.selectors[i].cx.try_select(sel);
 
                     if res.is_ok() {
                         // Provide the packet.
-                        self.entries[i].context.store_packet(self.entries[i].packet);
+                        self.selectors[i].cx.store_packet(self.selectors[i].packet);
                         // Wake the thread up.
-                        self.entries[i].context.unpark();
+                        self.selectors[i].cx.unpark();
 
                         // Remove the entry from the queue to keep it clean and improve
                         // performance.
-                        let entry = self.entries.remove(i).unwrap();
-                        Self::maybe_shrink(&mut self.entries);
-                        return Some(entry);
+                        entry = Some(self.selectors.remove(i));
+                        break;
                     }
                 }
             }
         }
 
-        None
+        entry
     }
 
-    /// Notifies all threads that the channel is disconnected.
+    /// Returns `true` if there is an entry which can be selected by the current thread.
+    #[inline]
+    pub fn can_select(&self) -> bool {
+        if self.selectors.is_empty() {
+            false
+        } else {
+            let thread_id = current_thread_id();
+
+            self.selectors.iter().any(|entry| {
+                entry.cx.thread_id() != thread_id && entry.cx.selected() == Selected::Waiting
+            })
+        }
+    }
+
+    /// Registers an operation waiting to be ready.
+    #[inline]
+    pub fn watch(&mut self, oper: Operation, cx: &Context) {
+        self.observers.push(Entry {
+            oper,
+            packet: 0,
+            cx: cx.clone(),
+        });
+    }
+
+    /// Unregisters an operation waiting to be ready.
+    #[inline]
+    pub fn unwatch(&mut self, oper: Operation) {
+        self.observers.retain(|e| e.oper != oper);
+    }
+
+    /// Notifies all operations waiting to be ready.
+    #[inline]
+    pub fn notify(&mut self) {
+        for entry in self.observers.drain(..) {
+            if entry.cx.try_select(Selected::Operation(entry.oper)).is_ok() {
+                entry.cx.unpark();
+            }
+        }
+    }
+
+    /// Notifies all registered operations that the channel is disconnected.
     #[inline]
     pub fn disconnect(&mut self) {
-        for entry in self.entries.iter() {
-            if entry.context.try_select(Selected::Disconnected).is_ok() {
+        for entry in self.selectors.iter() {
+            if entry.cx.try_select(Selected::Disconnected).is_ok() {
                 // Wake the thread up.
                 //
                 // Here we don't remove the entry from the queue. Registered threads must
                 // unregister from the waker by themselves. They might also want to recover the
                 // packet value and destroy it, if necessary.
-                entry.context.unpark();
+                entry.cx.unpark();
             }
         }
+
+        self.notify();
     }
 
-    /// Returns `true` if there is an entry which can be woken up by the current thread.
-    #[inline]
-    pub fn can_wake_one(&self) -> bool {
-        if self.entries.is_empty() {
-            false
-        } else {
-            let thread_id = current_thread_id();
-
-            self.entries.iter().any(|entry| {
-                entry.context.thread_id() != thread_id
-                    && entry.context.selected() == Selected::Waiting
-            })
-        }
-    }
-
-    /// Returns the number of entries in the queue.
-    #[inline]
-    pub fn len(&self) -> usize {
-        self.entries.len()
-    }
-
+    /// Returns the number of calls to `register` and `register_with_packet` that have occurred so
+    /// far.
     #[inline]
     pub fn register_count(&self) -> usize {
         self.register_count.0
-    }
-
-    /// Shrinks the internal queue if its capacity is much larger than length.
-    #[inline]
-    fn maybe_shrink(entries: &mut VecDeque<Entry>) {
-        if entries.capacity() > 32 && entries.len() < entries.capacity() / 4 {
-            let mut v = VecDeque::with_capacity(entries.capacity() / 2);
-            v.extend(entries.drain(..));
-            *entries = v;
-        }
     }
 }
 
 impl Drop for Waker {
     #[inline]
     fn drop(&mut self) {
-        debug_assert!(self.entries.is_empty());
+        debug_assert_eq!(self.selectors.len(), 0);
+        debug_assert_eq!(self.observers.len(), 0);
     }
 }
 
@@ -195,7 +212,7 @@ impl SyncWaker {
     pub fn register(&self, oper: Operation, cx: &Context) {
         let mut inner = self.inner.lock();
         inner.register(oper, cx);
-        self.len.store(inner.len(), Ordering::SeqCst);
+        self.len.store(inner.selectors.len() + inner.observers.len(), Ordering::SeqCst);
     }
 
     /// Unregisters an operation previously registered by the current thread.
@@ -204,7 +221,7 @@ impl SyncWaker {
         if self.len.load(Ordering::SeqCst) > 0 {
             let mut inner = self.inner.lock();
             let entry = inner.unregister(oper);
-            self.len.store(inner.len(), Ordering::SeqCst);
+            self.len.store(inner.selectors.len() + inner.observers.len(), Ordering::SeqCst);
             entry
         } else {
             None
@@ -213,18 +230,35 @@ impl SyncWaker {
 
     /// Attempts to find one thread (not the current one), select its operation, and wake it up.
     #[inline]
-    pub fn wake_one(&self) -> Option<Entry> {
+    pub fn notify(&self) {
         if self.len.load(Ordering::SeqCst) > 0 {
             let mut inner = self.inner.lock();
-            let entry = inner.wake_one();
-            self.len.store(inner.len(), Ordering::SeqCst);
-            entry
-        } else {
-            None
+            inner.try_select();
+            inner.notify();
+            self.len.store(inner.selectors.len() + inner.observers.len(), Ordering::SeqCst);
+        }
+    }
+
+    /// Registers an operation waiting to be ready.
+    #[inline]
+    pub fn watch(&self, oper: Operation, cx: &Context) {
+        let mut inner = self.inner.lock();
+        inner.watch(oper, cx);
+        self.len.store(inner.selectors.len() + inner.observers.len(), Ordering::SeqCst);
+    }
+
+    /// Unregisters an operation waiting to be ready.
+    #[inline]
+    pub fn unwatch(&self, oper: Operation) {
+        if self.len.load(Ordering::SeqCst) > 0 {
+            let mut inner = self.inner.lock();
+            inner.unwatch(oper);
+            self.len.store(inner.selectors.len() + inner.observers.len(), Ordering::SeqCst);
         }
     }
 
     /// Notifies all threads that the channel is disconnected.
+    #[inline]
     pub fn disconnect(&self) {
         self.inner.lock().disconnect();
     }
@@ -233,7 +267,6 @@ impl SyncWaker {
 impl Drop for SyncWaker {
     #[inline]
     fn drop(&mut self) {
-        debug_assert_eq!(self.inner.lock().len(), 0);
         debug_assert_eq!(self.len.load(Ordering::SeqCst), 0);
     }
 }

--- a/crossbeam-channel/tests/ready.rs
+++ b/crossbeam-channel/tests/ready.rs
@@ -1,0 +1,813 @@
+//! Tests for channel readiness using the `Select` struct.
+
+extern crate crossbeam;
+extern crate crossbeam_channel;
+
+use std::any::Any;
+use std::cell::Cell;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use crossbeam_channel::{after, bounded, tick, unbounded};
+use crossbeam_channel::{Receiver, Select, TryRecvError, TrySendError};
+
+fn ms(ms: u64) -> Duration {
+    Duration::from_millis(ms)
+}
+
+#[test]
+fn smoke1() {
+    let (s1, r1) = unbounded::<usize>();
+    let (s2, r2) = unbounded::<usize>();
+
+    s1.send(1).unwrap();
+
+    let mut sel = Select::new();
+    sel.recv(&r1);
+    sel.recv(&r2);
+    assert_eq!(sel.ready(), 0);
+    assert_eq!(r1.try_recv(), Ok(1));
+
+    s2.send(2).unwrap();
+
+    let mut sel = Select::new();
+    sel.recv(&r1);
+    sel.recv(&r2);
+    assert_eq!(sel.ready(), 1);
+    assert_eq!(r2.try_recv(), Ok(2));
+}
+
+#[test]
+fn smoke2() {
+    let (_s1, r1) = unbounded::<i32>();
+    let (_s2, r2) = unbounded::<i32>();
+    let (_s3, r3) = unbounded::<i32>();
+    let (_s4, r4) = unbounded::<i32>();
+    let (s5, r5) = unbounded::<i32>();
+
+    s5.send(5).unwrap();
+
+    let mut sel = Select::new();
+    sel.recv(&r1);
+    sel.recv(&r2);
+    sel.recv(&r3);
+    sel.recv(&r4);
+    sel.recv(&r5);
+    assert_eq!(sel.ready(), 4);
+    assert_eq!(r5.try_recv(), Ok(5));
+}
+
+#[test]
+fn disconnected() {
+    let (s1, r1) = unbounded::<i32>();
+    let (s2, r2) = unbounded::<i32>();
+
+    crossbeam::scope(|scope| {
+        scope.spawn(|| {
+            drop(s1);
+            thread::sleep(ms(500));
+            s2.send(5).unwrap();
+        });
+
+        let mut sel = Select::new();
+        sel.recv(&r1);
+        sel.recv(&r2);
+        match sel.ready_timeout(ms(1000)) {
+            Ok(0) => assert_eq!(r1.try_recv(), Err(TryRecvError::Disconnected)),
+            _ => panic!(),
+        }
+
+        r2.recv().unwrap();
+    });
+
+    let mut sel = Select::new();
+    sel.recv(&r1);
+    sel.recv(&r2);
+    match sel.ready_timeout(ms(1000)) {
+        Ok(0) => assert_eq!(r1.try_recv(), Err(TryRecvError::Disconnected)),
+        _ => panic!(),
+    }
+
+    crossbeam::scope(|scope| {
+        scope.spawn(|| {
+            thread::sleep(ms(500));
+            drop(s2);
+        });
+
+        let mut sel = Select::new();
+        sel.recv(&r2);
+        match sel.ready_timeout(ms(1000)) {
+            Ok(0) => assert_eq!(r2.try_recv(), Err(TryRecvError::Disconnected)),
+            _ => panic!(),
+        }
+    });
+}
+
+#[test]
+fn default() {
+    let (s1, r1) = unbounded::<i32>();
+    let (s2, r2) = unbounded::<i32>();
+
+    let mut sel = Select::new();
+    sel.recv(&r1);
+    sel.recv(&r2);
+    assert!(sel.try_ready().is_err());
+
+    drop(s1);
+
+    let mut sel = Select::new();
+    sel.recv(&r1);
+    sel.recv(&r2);
+    match sel.try_ready() {
+        Ok(0) => assert!(r1.try_recv().is_err()),
+        _ => panic!(),
+    }
+
+    s2.send(2).unwrap();
+
+    let mut sel = Select::new();
+    sel.recv(&r2);
+    match sel.try_ready() {
+        Ok(0) => assert_eq!(r2.try_recv(), Ok(2)),
+        _ => panic!(),
+    }
+
+    let mut sel = Select::new();
+    sel.recv(&r2);
+    assert!(sel.try_ready().is_err());
+
+    let mut sel = Select::new();
+    assert!(sel.try_ready().is_err());
+}
+
+#[test]
+fn timeout() {
+    let (_s1, r1) = unbounded::<i32>();
+    let (s2, r2) = unbounded::<i32>();
+
+    crossbeam::scope(|scope| {
+        scope.spawn(|| {
+            thread::sleep(ms(1500));
+            s2.send(2).unwrap();
+        });
+
+        let mut sel = Select::new();
+        sel.recv(&r1);
+        sel.recv(&r2);
+        assert!(sel.ready_timeout(ms(1000)).is_err());
+
+        let mut sel = Select::new();
+        sel.recv(&r1);
+        sel.recv(&r2);
+        match sel.ready_timeout(ms(1000)) {
+            Ok(1) => assert_eq!(r2.try_recv(), Ok(2)),
+            _ => panic!(),
+        }
+    });
+
+    crossbeam::scope(|scope| {
+        let (s, r) = unbounded::<i32>();
+
+        scope.spawn(move || {
+            thread::sleep(ms(500));
+            drop(s);
+        });
+
+        let mut sel = Select::new();
+        assert!(sel.ready_timeout(ms(1000)).is_err());
+
+        let mut sel = Select::new();
+        sel.recv(&r);
+        match sel.try_ready() {
+            Ok(0) => assert_eq!(r.try_recv(), Err(TryRecvError::Disconnected)),
+            _ => panic!(),
+        }
+    });
+}
+
+#[test]
+fn default_when_disconnected() {
+    let (_, r) = unbounded::<i32>();
+
+    let mut sel = Select::new();
+    sel.recv(&r);
+    match sel.try_ready() {
+        Ok(0) => assert_eq!(r.try_recv(), Err(TryRecvError::Disconnected)),
+        _ => panic!(),
+    }
+
+    let (_, r) = unbounded::<i32>();
+
+    let mut sel = Select::new();
+    sel.recv(&r);
+    match sel.ready_timeout(ms(1000)) {
+        Ok(0) => assert_eq!(r.try_recv(), Err(TryRecvError::Disconnected)),
+        _ => panic!(),
+    }
+
+    let (s, _) = bounded::<i32>(0);
+
+    let mut sel = Select::new();
+    sel.send(&s);
+    match sel.try_ready() {
+        Ok(0) => assert_eq!(s.try_send(0), Err(TrySendError::Disconnected(0))),
+        _ => panic!(),
+    }
+
+    let (s, _) = bounded::<i32>(0);
+
+    let mut sel = Select::new();
+    sel.send(&s);
+    match sel.ready_timeout(ms(1000)) {
+        Ok(0) => assert_eq!(s.try_send(0), Err(TrySendError::Disconnected(0))),
+        _ => panic!(),
+    }
+}
+
+#[test]
+fn default_only() {
+    let start = Instant::now();
+
+    let mut sel = Select::new();
+    assert!(sel.try_ready().is_err());
+    let now = Instant::now();
+    assert!(now - start <= ms(50));
+
+    let start = Instant::now();
+    let mut sel = Select::new();
+    assert!(sel.ready_timeout(ms(500)).is_err());
+    let now = Instant::now();
+    assert!(now - start >= ms(450));
+    assert!(now - start <= ms(550));
+}
+
+#[test]
+fn unblocks() {
+    let (s1, r1) = bounded::<i32>(0);
+    let (s2, r2) = bounded::<i32>(0);
+
+    crossbeam::scope(|scope| {
+        scope.spawn(|| {
+            thread::sleep(ms(500));
+            s2.send(2).unwrap();
+        });
+
+        let mut sel = Select::new();
+        sel.recv(&r1);
+        sel.recv(&r2);
+        match sel.ready_timeout(ms(1000)) {
+            Ok(1) => assert_eq!(r2.try_recv(), Ok(2)),
+            _ => panic!(),
+        }
+    });
+
+    crossbeam::scope(|scope| {
+        scope.spawn(|| {
+            thread::sleep(ms(500));
+            assert_eq!(r1.recv().unwrap(), 1);
+        });
+
+        let mut sel = Select::new();
+        let oper1 = sel.send(&s1);
+        let oper2 = sel.send(&s2);
+        let oper = sel.select_timeout(ms(1000));
+        match oper {
+            Err(_) => panic!(),
+            Ok(oper) => match oper.index() {
+                i if i == oper1 => oper.send(&s1, 1).unwrap(),
+                i if i == oper2 => panic!(),
+                _ => unreachable!(),
+            },
+        }
+    });
+}
+
+#[test]
+fn both_ready() {
+    let (s1, r1) = bounded(0);
+    let (s2, r2) = bounded(0);
+
+    crossbeam::scope(|scope| {
+        scope.spawn(|| {
+            thread::sleep(ms(500));
+            s1.send(1).unwrap();
+            assert_eq!(r2.recv().unwrap(), 2);
+        });
+
+        for _ in 0..2 {
+            let mut sel = Select::new();
+            sel.recv(&r1);
+            sel.send(&s2);
+            match sel.ready() {
+                0 => assert_eq!(r1.try_recv(), Ok(1)),
+                1 => s2.try_send(2).unwrap(),
+                _ => panic!(),
+            }
+        }
+    });
+}
+
+#[test]
+fn cloning1() {
+    crossbeam::scope(|scope| {
+        let (s1, r1) = unbounded::<i32>();
+        let (_s2, r2) = unbounded::<i32>();
+        let (s3, r3) = unbounded::<()>();
+
+        scope.spawn(move || {
+            r3.recv().unwrap();
+            drop(s1.clone());
+            assert!(r3.try_recv().is_err());
+            s1.send(1).unwrap();
+            r3.recv().unwrap();
+        });
+
+        s3.send(()).unwrap();
+
+        let mut sel = Select::new();
+        sel.recv(&r1);
+        sel.recv(&r2);
+        match sel.ready() {
+            0 => drop(r1.try_recv()),
+            1 => drop(r2.try_recv()),
+            _ => panic!(),
+        }
+
+        s3.send(()).unwrap();
+    });
+}
+
+#[test]
+fn cloning2() {
+    let (s1, r1) = unbounded::<()>();
+    let (s2, r2) = unbounded::<()>();
+    let (_s3, _r3) = unbounded::<()>();
+
+    crossbeam::scope(|scope| {
+        scope.spawn(move || {
+            let mut sel = Select::new();
+            sel.recv(&r1);
+            sel.recv(&r2);
+            match sel.ready() {
+                0 => panic!(),
+                1 => drop(r2.try_recv()),
+                _ => panic!(),
+            }
+        });
+
+        thread::sleep(ms(500));
+        drop(s1.clone());
+        s2.send(()).unwrap();
+    })
+}
+
+#[test]
+fn preflight1() {
+    let (s, r) = unbounded();
+    s.send(()).unwrap();
+
+    let mut sel = Select::new();
+    sel.recv(&r);
+    match sel.ready() {
+        0 => drop(r.try_recv()),
+        _ => panic!(),
+    }
+}
+
+#[test]
+fn preflight2() {
+    let (s, r) = unbounded();
+    drop(s.clone());
+    s.send(()).unwrap();
+    drop(s);
+
+    let mut sel = Select::new();
+    sel.recv(&r);
+    match sel.ready() {
+        0 => assert_eq!(r.try_recv(), Ok(())),
+        _ => panic!(),
+    }
+
+    assert_eq!(r.try_recv(), Err(TryRecvError::Disconnected));
+}
+
+#[test]
+fn preflight3() {
+    let (s, r) = unbounded();
+    drop(s.clone());
+    s.send(()).unwrap();
+    drop(s);
+    r.recv().unwrap();
+
+    let mut sel = Select::new();
+    sel.recv(&r);
+    match sel.ready() {
+        0 => assert_eq!(r.try_recv(), Err(TryRecvError::Disconnected)),
+        _ => panic!(),
+    }
+}
+
+#[test]
+fn duplicate_operations() {
+    let (s, r) = unbounded::<i32>();
+    let hit = vec![Cell::new(false); 4];
+
+    while hit.iter().map(|h| h.get()).any(|hit| !hit) {
+        let mut sel = Select::new();
+        sel.recv(&r);
+        sel.recv(&r);
+        sel.send(&s);
+        sel.send(&s);
+        match sel.ready() {
+            0 => {
+                assert!(r.try_recv().is_ok());
+                hit[0].set(true);
+            }
+            1 => {
+                assert!(r.try_recv().is_ok());
+                hit[1].set(true);
+            }
+            2 => {
+                assert!(s.try_send(0).is_ok());
+                hit[2].set(true);
+            }
+            3 => {
+                assert!(s.try_send(0).is_ok());
+                hit[3].set(true);
+            }
+            _ => panic!(),
+        }
+    }
+}
+
+#[test]
+fn nesting() {
+    let (s, r) = unbounded::<i32>();
+
+    let mut sel = Select::new();
+    sel.send(&s);
+    match sel.ready() {
+        0 => {
+            assert!(s.try_send(0).is_ok());
+
+            let mut sel = Select::new();
+            sel.recv(&r);
+            match sel.ready() {
+                0 => {
+                    assert_eq!(r.try_recv(), Ok(0));
+
+                    let mut sel = Select::new();
+                    sel.send(&s);
+                    match sel.ready() {
+                        0 => {
+                            assert!(s.try_send(1).is_ok());
+
+                            let mut sel = Select::new();
+                            sel.recv(&r);
+                            match sel.ready() {
+                                0 => {
+                                    assert_eq!(r.try_recv(), Ok(1));
+                                }
+                                _ => panic!(),
+                            }
+                        }
+                        _ => panic!(),
+                    }
+                }
+                _ => panic!(),
+            }
+        }
+        _ => panic!(),
+    }
+}
+
+#[test]
+fn stress_recv() {
+    const COUNT: usize = 10_000;
+
+    let (s1, r1) = unbounded();
+    let (s2, r2) = bounded(5);
+    let (s3, r3) = bounded(100);
+
+    crossbeam::scope(|scope| {
+        scope.spawn(|| {
+            for i in 0..COUNT {
+                s1.send(i).unwrap();
+                r3.recv().unwrap();
+
+                s2.send(i).unwrap();
+                r3.recv().unwrap();
+            }
+        });
+
+        for i in 0..COUNT {
+            for _ in 0..2 {
+                let mut sel = Select::new();
+                sel.recv(&r1);
+                sel.recv(&r2);
+                match sel.ready() {
+                    0 => assert_eq!(r1.try_recv(), Ok(i)),
+                    1 => assert_eq!(r2.try_recv(), Ok(i)),
+                    _ => panic!(),
+                }
+
+                s3.send(()).unwrap();
+            }
+        }
+    });
+}
+
+#[test]
+fn stress_send() {
+    const COUNT: usize = 10_000;
+
+    let (s1, r1) = bounded(0);
+    let (s2, r2) = bounded(0);
+    let (s3, r3) = bounded(100);
+
+    crossbeam::scope(|scope| {
+        scope.spawn(|| {
+            for i in 0..COUNT {
+                assert_eq!(r1.recv().unwrap(), i);
+                assert_eq!(r2.recv().unwrap(), i);
+                r3.recv().unwrap();
+            }
+        });
+
+        for i in 0..COUNT {
+            for _ in 0..2 {
+                let mut sel = Select::new();
+                sel.send(&s1);
+                sel.send(&s2);
+                match sel.ready() {
+                    0 => assert!(s1.try_send(i).is_ok()),
+                    1 => assert!(s2.try_send(i).is_ok()),
+                    _ => panic!(),
+                }
+            }
+            s3.send(()).unwrap();
+        }
+    });
+}
+
+#[test]
+fn stress_mixed() {
+    const COUNT: usize = 10_000;
+
+    let (s1, r1) = bounded(0);
+    let (s2, r2) = bounded(0);
+    let (s3, r3) = bounded(100);
+
+    crossbeam::scope(|scope| {
+        scope.spawn(|| {
+            for i in 0..COUNT {
+                s1.send(i).unwrap();
+                assert_eq!(r2.recv().unwrap(), i);
+                r3.recv().unwrap();
+            }
+        });
+
+        for i in 0..COUNT {
+            for _ in 0..2 {
+                let mut sel = Select::new();
+                sel.recv(&r1);
+                sel.send(&s2);
+                match sel.ready() {
+                    0 => assert_eq!(r1.try_recv(), Ok(i)),
+                    1 => assert!(s2.try_send(i).is_ok()),
+                    _ => panic!(),
+                }
+            }
+            s3.send(()).unwrap();
+        }
+    });
+}
+
+#[test]
+fn stress_timeout_two_threads() {
+    const COUNT: usize = 20;
+
+    let (s, r) = bounded(2);
+
+    crossbeam::scope(|scope| {
+        scope.spawn(|| {
+            for i in 0..COUNT {
+                if i % 2 == 0 {
+                    thread::sleep(ms(500));
+                }
+
+                let mut done = false;
+                while !done {
+                    let mut sel = Select::new();
+                    sel.send(&s);
+                    match sel.ready_timeout(ms(100)) {
+                        Err(_) => {}
+                        Ok(0) => {
+                            assert!(s.try_send(i).is_ok());
+                            break;
+                        },
+                        Ok(_) => panic!(),
+                    }
+                }
+            }
+        });
+
+        scope.spawn(|| {
+            for i in 0..COUNT {
+                if i % 2 == 0 {
+                    thread::sleep(ms(500));
+                }
+
+                let mut done = false;
+                while !done {
+                    let mut sel = Select::new();
+                    sel.recv(&r);
+                    match sel.ready_timeout(ms(100)) {
+                        Err(_) => {}
+                        Ok(0) => {
+                            assert_eq!(r.try_recv(), Ok(i));
+                            done = true;
+                        },
+                        Ok(_) => panic!(),
+                    }
+                }
+            }
+        });
+    });
+}
+
+#[test]
+fn send_recv_same_channel() {
+    let (s, r) = bounded::<i32>(0);
+    let mut sel = Select::new();
+    sel.send(&s);
+    sel.recv(&r);
+    assert!(sel.ready_timeout(ms(100)).is_err());
+
+    let (s, r) = unbounded::<i32>();
+    let mut sel = Select::new();
+    sel.send(&s);
+    sel.recv(&r);
+    match sel.ready_timeout(ms(100)) {
+        Err(_) => panic!(),
+        Ok(0) => assert!(s.try_send(0).is_ok()),
+        Ok(_) => panic!(),
+    }
+}
+
+#[test]
+fn channel_through_channel() {
+    const COUNT: usize = 1000;
+
+    type T = Box<Any + Send>;
+
+    for cap in 1..4 {
+        let (s, r) = bounded::<T>(cap);
+
+        crossbeam::scope(|scope| {
+            scope.spawn(move || {
+                let mut s = s;
+
+                for _ in 0..COUNT {
+                    let (new_s, new_r) = bounded(cap);
+                    let mut new_r: T = Box::new(Some(new_r));
+
+                    {
+                        let mut sel = Select::new();
+                        sel.send(&s);
+                        match sel.ready() {
+                            0 => assert!(s.try_send(new_r).is_ok()),
+                            _ => panic!(),
+                        }
+                    }
+
+                    s = new_s;
+                }
+            });
+
+            scope.spawn(move || {
+                let mut r = r;
+
+                for _ in 0..COUNT {
+                    let new = {
+                        let mut sel = Select::new();
+                        sel.recv(&r);
+                        match sel.ready() {
+                            0 => r
+                                .try_recv()
+                                .unwrap()
+                                .downcast_mut::<Option<Receiver<T>>>()
+                                .unwrap()
+                                .take()
+                                .unwrap(),
+                            _ => panic!(),
+                        }
+                    };
+                    r = new;
+                }
+            });
+        });
+    }
+}
+
+#[test]
+fn fairness1() {
+    const COUNT: usize = 10_000;
+
+    let (s1, r1) = bounded::<()>(COUNT);
+    let (s2, r2) = unbounded::<()>();
+
+    for _ in 0..COUNT {
+        s1.send(()).unwrap();
+        s2.send(()).unwrap();
+    }
+
+    let hits = vec![Cell::new(0usize); 4];
+    for _ in 0..COUNT {
+        let after = after(ms(0));
+        let tick = tick(ms(0));
+
+        let mut sel = Select::new();
+        sel.recv(&r1);
+        sel.recv(&r2);
+        sel.recv(&after);
+        sel.recv(&tick);
+        match sel.ready() {
+            0 => {
+                r1.try_recv().unwrap();
+                hits[0].set(hits[0].get() + 1);
+            }
+            1 => {
+                r2.try_recv().unwrap();
+                hits[1].set(hits[1].get() + 1);
+            }
+            2 => {
+                after.try_recv().unwrap();
+                hits[2].set(hits[2].get() + 1);
+            }
+            3 => {
+                tick.try_recv().unwrap();
+                hits[3].set(hits[3].get() + 1);
+            }
+            _ => panic!(),
+        }
+    }
+    assert!(hits.iter().all(|x| x.get() >= COUNT / hits.len() / 2));
+}
+
+#[test]
+fn fairness2() {
+    const COUNT: usize = 10_000;
+
+    let (s1, r1) = unbounded::<()>();
+    let (s2, r2) = bounded::<()>(1);
+    let (s3, r3) = bounded::<()>(0);
+
+    crossbeam::scope(|scope| {
+        scope.spawn(|| {
+            for _ in 0..COUNT {
+                let mut sel = Select::new();
+                let mut oper1 = None;
+                let mut oper2 = None;
+                if s1.is_empty() {
+                    oper1 = Some(sel.send(&s1));
+                }
+                if s2.is_empty() {
+                    oper2 = Some(sel.send(&s2));
+                }
+                let oper3 = sel.send(&s3);
+                let oper = sel.select();
+                match oper.index() {
+                    i if Some(i) == oper1 => assert!(oper.send(&s1, ()).is_ok()),
+                    i if Some(i) == oper2 => assert!(oper.send(&s2, ()).is_ok()),
+                    i if i == oper3 => assert!(oper.send(&s3, ()).is_ok()),
+                    _ => unreachable!(),
+                }
+            }
+        });
+
+        let hits = vec![Cell::new(0usize); 3];
+        for _ in 0..COUNT {
+            let mut sel = Select::new();
+            sel.recv(&r1);
+            sel.recv(&r2);
+            sel.recv(&r3);
+            match sel.ready() {
+                0 => {
+                    r1.try_recv().unwrap();
+                    hits[0].set(hits[0].get() + 1);
+                }
+                1 => {
+                    r2.try_recv().unwrap();
+                    hits[1].set(hits[1].get() + 1);
+                }
+                2 => {
+                    r3.try_recv().unwrap();
+                    hits[2].set(hits[2].get() + 1);
+                }
+                _ => unreachable!(),
+            }
+        }
+        assert!(hits.iter().all(|x| x.get() >= COUNT / hits.len() / 10));
+    });
+}

--- a/crossbeam-channel/tests/select_macro.rs
+++ b/crossbeam-channel/tests/select_macro.rs
@@ -289,27 +289,31 @@ fn loop_try() {
         let (s_end, r_end) = bounded::<()>(0);
 
         crossbeam::scope(|scope| {
-            scope.spawn(|| loop {
-                select! {
-                    send(s1, 1) -> _ => break,
-                    default => {}
-                }
+            scope.spawn(|| {
+                loop {
+                    select! {
+                        send(s1, 1) -> _ => break,
+                        default => {}
+                    }
 
-                select! {
-                    recv(r_end) -> _ => break,
-                    default => {}
+                    select! {
+                        recv(r_end) -> _ => break,
+                        default => {}
+                    }
                 }
             });
 
-            scope.spawn(|| loop {
-                if let Ok(x) = r2.try_recv() {
-                    assert_eq!(x, 2);
-                    break;
-                }
+            scope.spawn(|| {
+                loop {
+                    if let Ok(x) = r2.try_recv() {
+                        assert_eq!(x, 2);
+                        break;
+                    }
 
-                select! {
-                    recv(r_end) -> _ => break,
-                    default => {}
+                    select! {
+                        recv(r_end) -> _ => break,
+                        default => {}
+                    }
                 }
             });
 


### PR DESCRIPTION
This PR adds methods `Select::{try_ready,ready,ready_timeout}`, which wait on a set of operations until any one of them becomes ready. However, after that we're not obliged to "complete" the operation.

cc @Munksgaard @laumann This would help in resolving https://github.com/Munksgaard/session-types/issues/45

Closes #222.

If anyone thinks we should name these methods differently, speak up! :)