### PR TITLE
Add num_shards argument to ShardedLock::new

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ std = ["crossbeam-epoch/std", "crossbeam-utils/std"]
 [dependencies]
 cfg-if = "0.1"
 lazy_static = "1.1.0"
-num_cpus = "1.8.0"
 parking_lot = "0.7"
 
 [dependencies.crossbeam-channel]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,6 @@ cfg_if! {
 
         #[macro_use]
         extern crate lazy_static;
-        extern crate num_cpus;
         extern crate parking_lot;
 
         mod ms_queue;

--- a/src/sharded_lock.rs
+++ b/src/sharded_lock.rs
@@ -12,7 +12,6 @@ use std::ops::{Deref, DerefMut};
 use std::thread::{self, ThreadId};
 
 use crossbeam_utils::CachePadded;
-use num_cpus;
 use parking_lot::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 /// A scalable reader-writer lock.
@@ -41,12 +40,15 @@ unsafe impl<T: Send> Send for ShardedLock<T> {}
 unsafe impl<T: Send + Sync> Sync for ShardedLock<T> {}
 
 impl<T> ShardedLock<T> {
-    /// Creates a new `ShardedLock` initialized with `value`.
-    pub fn new(value: T) -> ShardedLock<T> {
+    /// Creates a new `ShardedLock`.
+    ///
+    /// The lock is initialized to `value`. The actual number of shards used might be slightly
+    /// different from `num_shards` because that argument is only considered to be a *hint*. A
+    /// generally good number of shards to use is the number of available CPUs.
+    pub fn new(value: T, num_shards: usize) -> ShardedLock<T> {
         // The number of shards is a power of two so that the modulo operation in `read` becomes a
         // simple bitwise "and".
-        let num_shards = num_cpus::get().next_power_of_two();
-
+        let num_shards = num_shards.max(1).next_power_of_two();
         ShardedLock {
             shards: (0..num_shards)
                 .map(|_| CachePadded::new(RwLock::new(())))


### PR DESCRIPTION
This removes the dependency on `num_cpus`. If we also remove dependency on `parking_lot`, then `ShardedLock` can be moved into `crossbeam-utils`.

The `num_shards` arguments is somewhat reminiscent of `concurrencyLevel` in [this](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentHashMap.html#ConcurrentHashMap-int-float-int-) `ConcurrentHashMap` constructor.