### PR TITLE
Add additional is_* methods to error types

### DIFF
--- a/crossbeam-channel/src/err.rs
+++ b/crossbeam-channel/src/err.rs
@@ -200,6 +200,22 @@ impl<T> TrySendError<T> {
             TrySendError::Disconnected(v) => v,
         }
     }
+
+    /// Returns `true` if the send operation failed because the channel is full.
+    pub fn is_full(&self) -> bool {
+        match self {
+            TrySendError::Full(_) => true,
+            _ => false,
+        }
+    }
+
+    /// Returns `true` if the send operation failed because the channel is disconnected.
+    pub fn is_disconnected(&self) -> bool {
+        match self {
+            TrySendError::Disconnected(_) => true,
+            _ => false,
+        }
+    }
 }
 
 impl<T> fmt::Debug for SendTimeoutError<T> {
@@ -256,6 +272,22 @@ impl<T> SendTimeoutError<T> {
             SendTimeoutError::Disconnected(v) => v,
         }
     }
+
+    /// Returns `true` if the send operation timed out.
+    pub fn is_timeout(&self) -> bool {
+        match self {
+            SendTimeoutError::Timeout(_) => true,
+            _ => false,
+        }
+    }
+
+    /// Returns `true` if the send operation failed because the channel is disconnected.
+    pub fn is_disconnected(&self) -> bool {
+        match self {
+            SendTimeoutError::Disconnected(_) => true,
+            _ => false,
+        }
+    }
 }
 
 impl fmt::Display for RecvError {
@@ -304,6 +336,24 @@ impl From<RecvError> for TryRecvError {
     }
 }
 
+impl TryRecvError {
+    /// Returns `true` if the receive operation failed because the channel is empty.
+    pub fn is_empty(&self) -> bool {
+        match self {
+            TryRecvError::Empty => true,
+            _ => false,
+        }
+    }
+
+    /// Returns `true` if the receive operation failed because the channel is disconnected.
+    pub fn is_disconnected(&self) -> bool {
+        match self {
+            TryRecvError::Disconnected => true,
+            _ => false,
+        }
+    }
+}
+
 impl fmt::Display for RecvTimeoutError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
@@ -330,6 +380,24 @@ impl From<RecvError> for RecvTimeoutError {
     fn from(err: RecvError) -> RecvTimeoutError {
         match err {
             RecvError => RecvTimeoutError::Disconnected,
+        }
+    }
+}
+
+impl RecvTimeoutError {
+    /// Returns `true` if the receive operation timed out.
+    pub fn is_timeout(&self) -> bool {
+        match self {
+            RecvTimeoutError::Timeout => true,
+            _ => false,
+        }
+    }
+
+    /// Returns `true` if the receive operation failed because the channel is disconnected.
+    pub fn is_disconnected(&self) -> bool {
+        match self {
+            RecvTimeoutError::Disconnected => true,
+            _ => false,
         }
     }
 }


### PR DESCRIPTION
Add methods like `is_disconnected()`, `is_full()`, and `is_empty()` to error types returned by channel operations.