### PR TITLE
Use inline docs and specify subcrate minor versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,19 +31,19 @@ num_cpus = "1.8.0"
 parking_lot = "0.7"
 
 [dependencies.crossbeam-channel]
-version = "0.3"
+version = "0.3.2"
 path = "./crossbeam-channel"
 
 [dependencies.crossbeam-deque]
-version = "0.6"
+version = "0.6.2"
 path = "./crossbeam-deque"
 
 [dependencies.crossbeam-epoch]
-version = "0.6"
+version = "0.6.1"
 path = "./crossbeam-epoch"
 
 [dependencies.crossbeam-utils]
-version = "0.6"
+version = "0.6.1"
 path = "./crossbeam-utils"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ cfg_if! {
 mod _epoch {
     pub extern crate crossbeam_epoch;
 }
+#[doc(inline)]
 pub use _epoch::crossbeam_epoch as epoch;
 
 mod arc_cell;
@@ -88,12 +89,14 @@ cfg_if! {
         mod _deque {
             pub extern crate crossbeam_deque;
         }
+        #[doc(inline)]
         pub use _deque::crossbeam_deque as deque;
 
         mod _channel {
             pub extern crate crossbeam_channel;
             pub use self::crossbeam_channel::*;
         }
+        #[doc(inline)]
         pub use _channel::crossbeam_channel as channel;
 
         // HACK(stjepang): This is the only way to reexport `select!` in Rust older than 1.30.0

--- a/tests/subcrates.rs
+++ b/tests/subcrates.rs
@@ -1,4 +1,4 @@
-//! Makes sure subcrates are properly reexported.
+//! Makes sure subcrates are properly re-exported.
 
 #[macro_use]
 extern crate crossbeam;


### PR DESCRIPTION
Two changes:

* Render subcrate docs properly.
* Specify minor versions of crossbeam subcrates (same as in [Tokio](https://github.com/tokio-rs/tokio/blob/master/Cargo.toml)).