### PR TITLE
skiplist: Simplify RefIter and RefRange

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ matrix:
   - rust: 1.26.0
     name: "crossbeam-epoch on 1.26.0"
     script: ./ci/crossbeam-epoch.sh
-  - rust: 1.26.0
-    name: "crossbeam-skiplist on 1.26.0"
+  - rust: 1.28.0
+    name: "crossbeam-skiplist on 1.28.0"
     script: ./ci/crossbeam-skiplist.sh
   - rust: 1.26.0
     name: "crossbeam-utils on 1.26.0"

--- a/crossbeam-skiplist/README.md
+++ b/crossbeam-skiplist/README.md
@@ -8,7 +8,7 @@ https://github.com/crossbeam-rs/crossbeam-skiplist)
 https://crates.io/crates/crossbeam-skiplist)
 [![Documentation](https://docs.rs/crossbeam-skiplist/badge.svg)](
 https://docs.rs/crossbeam-skiplist)
-[![Rust 1.26+](https://img.shields.io/badge/rust-1.26+-lightgray.svg)](
+[![Rust 1.28+](https://img.shields.io/badge/rust-1.28+-lightgray.svg)](
 https://www.rust-lang.org)
 
 **Note:** This crate is still a work in progress.
@@ -32,7 +32,7 @@ extern crate crossbeam_skiplist;
 
 ## Compatibility
 
-The minimum supported Rust version is 1.26.
+The minimum supported Rust version is 1.28.
 
 This crate can be used in `no_std` environments, but only on nightly Rust.
 

--- a/crossbeam-skiplist/src/base.rs
+++ b/crossbeam-skiplist/src/base.rs
@@ -1698,7 +1698,7 @@ where
     tail: Option<&'g Node<K, V>>,
     range: R,
     guard: &'g Guard,
-    _marker: PhantomData<fn(&R) -> Bound<&Q>>,
+    _marker: PhantomData<fn() -> Q>,
 }
 
 impl<'a: 'g, 'g, Q, R, K: 'a, V: 'a> Iterator for Range<'a, 'g, Q, R, K, V>
@@ -1794,7 +1794,7 @@ where
     pub(crate) head: Option<RefEntry<'a, K, V>>,
     pub(crate) tail: Option<RefEntry<'a, K, V>>,
     pub(crate) range: R,
-    _marker: PhantomData<fn(&R) -> Bound<&Q>>,
+    _marker: PhantomData<fn() -> Q>,
 }
 
 unsafe impl<'a, Q, R, K, V> Send for RefRange<'a, Q, R, K, V>

--- a/crossbeam-skiplist/src/base.rs
+++ b/crossbeam-skiplist/src/base.rs
@@ -1698,7 +1698,7 @@ where
     tail: Option<&'g Node<K, V>>,
     range: R,
     guard: &'g Guard,
-    _marker: PhantomData<fn() -> Q>,
+    _marker: PhantomData<fn() -> Q>, // covariant over `Q`
 }
 
 impl<'a: 'g, 'g, Q, R, K: 'a, V: 'a> Iterator for Range<'a, 'g, Q, R, K, V>
@@ -1794,7 +1794,7 @@ where
     pub(crate) head: Option<RefEntry<'a, K, V>>,
     pub(crate) tail: Option<RefEntry<'a, K, V>>,
     pub(crate) range: R,
-    _marker: PhantomData<fn() -> Q>,
+    _marker: PhantomData<fn() -> Q>, // covariant over `Q`
 }
 
 unsafe impl<'a, Q, R, K, V> Send for RefRange<'a, Q, R, K, V>

--- a/crossbeam-skiplist/src/base.rs
+++ b/crossbeam-skiplist/src/base.rs
@@ -479,15 +479,15 @@ where
     }
 
     /// Returns an iterator over a subset of entries in the skip list.
-    pub fn range<'a: 'g, 'g, T, R>(
+    pub fn range<'a: 'g, 'g, Q, R>(
         &'a self,
         range: R,
         guard: &'g Guard,
-    ) -> Range<'a, 'g, T, R, K, V>
+    ) -> Range<'a, 'g, Q, R, K, V>
     where
-        K: Borrow<T>,
-        R: RangeBounds<T>,
-        T: Ord + ?Sized,
+        K: Borrow<Q>,
+        R: RangeBounds<Q>,
+        Q: Ord + ?Sized,
     {
         self.check_guard(guard);
         Range {
@@ -501,14 +501,14 @@ where
     }
 
     /// Returns an iterator over a subset of entries in the skip list.
-    pub fn ref_range<'a, 'g, T, R>(
+    pub fn ref_range<'a, 'g, Q, R>(
         &'a self,
         range: R,
-    ) -> RefRange<'a, T, R, K, V>
+    ) -> RefRange<'a, Q, R, K, V>
     where
-        K: Borrow<T>,
-        R: RangeBounds<T>,
-        T: Ord + ?Sized,
+        K: Borrow<Q>,
+        R: RangeBounds<Q>,
+        Q: Ord + ?Sized,
     {
         RefRange {
             parent: self,
@@ -1687,25 +1687,25 @@ where
 }
 
 /// An iterator over a subset of entries of a `SkipList`.
-pub struct Range<'a: 'g, 'g, T, R, K: 'a, V: 'a>
+pub struct Range<'a: 'g, 'g, Q, R, K: 'a, V: 'a>
 where
-    K: Ord + Borrow<T>,
-    R: RangeBounds<T>,
-    T: Ord + ?Sized,
+    K: Ord + Borrow<Q>,
+    R: RangeBounds<Q>,
+    Q: Ord + ?Sized,
 {
     parent: &'a SkipList<K, V>,
     head: Option<&'g Node<K, V>>,
     tail: Option<&'g Node<K, V>>,
     range: R,
     guard: &'g Guard,
-    _marker: PhantomData<T>,
+    _marker: PhantomData<Q>,
 }
 
-impl<'a: 'g, 'g, T, R, K: 'a, V: 'a> Iterator for Range<'a, 'g, T, R, K, V>
+impl<'a: 'g, 'g, Q, R, K: 'a, V: 'a> Iterator for Range<'a, 'g, Q, R, K, V>
 where
-    K: Ord + Borrow<T>,
-    R: RangeBounds<T>,
-    T: Ord + ?Sized,
+    K: Ord + Borrow<Q>,
+    R: RangeBounds<Q>,
+    Q: Ord + ?Sized,
 {
     type Item = Entry<'a, 'g, K, V>;
 
@@ -1736,11 +1736,11 @@ where
     }
 }
 
-impl<'a: 'g, 'g, T, R, K: 'a, V: 'a> DoubleEndedIterator for Range<'a, 'g, T, R, K, V>
+impl<'a: 'g, 'g, Q, R, K: 'a, V: 'a> DoubleEndedIterator for Range<'a, 'g, Q, R, K, V>
 where
-    K: Ord + Borrow<T>,
-    R: RangeBounds<T>,
-    T: Ord + ?Sized,
+    K: Ord + Borrow<Q>,
+    R: RangeBounds<Q>,
+    Q: Ord + ?Sized,
 {
     fn next_back(&mut self) -> Option<Entry<'a, 'g, K, V>> {
         self.tail = match self.tail {
@@ -1767,12 +1767,12 @@ where
     }
 }
 
-impl<'a, 'g, T, R, K, V> fmt::Debug for Range<'a, 'g, T, R, K, V>
+impl<'a, 'g, Q, R, K, V> fmt::Debug for Range<'a, 'g, Q, R, K, V>
 where
-    K: Ord + Borrow<T> + fmt::Debug,
+    K: Ord + Borrow<Q> + fmt::Debug,
     V: fmt::Debug,
-    R: RangeBounds<T> + fmt::Debug,
-    T: Ord + ?Sized,
+    R: RangeBounds<Q> + fmt::Debug,
+    Q: Ord + ?Sized,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Range")
@@ -1784,25 +1784,25 @@ where
 }
 
 /// An iterator over reference-counted subset of entries of a `SkipList`.
-pub struct RefRange<'a, T, R, K: 'a, V: 'a>
+pub struct RefRange<'a, Q, R, K: 'a, V: 'a>
 where
-    K: Ord + Borrow<T>,
-    R: RangeBounds<T>,
-    T: Ord + ?Sized,
+    K: Ord + Borrow<Q>,
+    R: RangeBounds<Q>,
+    Q: Ord + ?Sized,
 {
     parent: &'a SkipList<K, V>,
     pub(crate) head: Option<RefEntry<'a, K, V>>,
     pub(crate) tail: Option<RefEntry<'a, K, V>>,
     pub(crate) range: R,
-    _marker: PhantomData<T>,
+    _marker: PhantomData<Q>,
 }
 
-impl<'a, T, R, K, V> fmt::Debug for RefRange<'a, T, R, K, V>
+impl<'a, Q, R, K, V> fmt::Debug for RefRange<'a, Q, R, K, V>
 where
-    K: Ord + Borrow<T> + fmt::Debug,
+    K: Ord + Borrow<Q> + fmt::Debug,
     V: fmt::Debug,
-    R: RangeBounds<T> + fmt::Debug,
-    T: Ord + ?Sized,
+    R: RangeBounds<Q> + fmt::Debug,
+    Q: Ord + ?Sized,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("RefRange")
@@ -1813,11 +1813,11 @@ where
     }
 }
 
-impl<'a, T, R, K: 'a, V: 'a> RefRange<'a, T, R, K, V>
+impl<'a, Q, R, K: 'a, V: 'a> RefRange<'a, Q, R, K, V>
 where
-    K: Ord + Borrow<T>,
-    R: RangeBounds<T>,
-    T: Ord + ?Sized,
+    K: Ord + Borrow<Q>,
+    R: RangeBounds<Q>,
+    Q: Ord + ?Sized,
 {
     /// TODO
     pub fn next(&mut self, guard: &Guard) -> Option<RefEntry<'a, K, V>> {

--- a/crossbeam-skiplist/src/base.rs
+++ b/crossbeam-skiplist/src/base.rs
@@ -1698,7 +1698,7 @@ where
     tail: Option<&'g Node<K, V>>,
     range: R,
     guard: &'g Guard,
-    _marker: PhantomData<Q>,
+    _marker: PhantomData<fn(&R) -> Bound<&Q>>,
 }
 
 impl<'a: 'g, 'g, Q, R, K: 'a, V: 'a> Iterator for Range<'a, 'g, Q, R, K, V>
@@ -1794,8 +1794,22 @@ where
     pub(crate) head: Option<RefEntry<'a, K, V>>,
     pub(crate) tail: Option<RefEntry<'a, K, V>>,
     pub(crate) range: R,
-    _marker: PhantomData<Q>,
+    _marker: PhantomData<fn(&R) -> Bound<&Q>>,
 }
+
+unsafe impl<'a, Q, R, K, V> Send for RefRange<'a, Q, R, K, V>
+where
+    K: Ord + Borrow<Q>,
+    R: RangeBounds<Q>,
+    Q: Ord + ?Sized,
+{}
+
+unsafe impl<'a, Q, R, K, V> Sync for RefRange<'a, Q, R, K, V>
+where
+    K: Ord + Borrow<Q>,
+    R: RangeBounds<Q>,
+    Q: Ord + ?Sized,
+{}
 
 impl<'a, Q, R, K, V> fmt::Debug for RefRange<'a, Q, R, K, V>
 where

--- a/crossbeam-skiplist/src/map.rs
+++ b/crossbeam-skiplist/src/map.rs
@@ -109,14 +109,14 @@ where
     }
 
     /// Returns an iterator over a subset of entries in the skip list.
-    pub fn range<T, R>(
+    pub fn range<Q, R>(
         &self,
         range: R,
-    ) -> Range<'_, T, R, K, V>
+    ) -> Range<'_, Q, R, K, V>
     where
-        K: Borrow<T>,
-        R: RangeBounds<T>,
-        T: Ord + ?Sized,
+        K: Borrow<Q>,
+        R: RangeBounds<Q>,
+        Q: Ord + ?Sized,
     {
         Range {
             inner: self.inner.ref_range(range),
@@ -365,20 +365,20 @@ impl<'a, K, V> fmt::Debug for Iter<'a, K, V> {
 }
 
 /// An iterator over the entries of a `SkipMap`.
-pub struct Range<'a, T, R, K: 'a, V: 'a>
+pub struct Range<'a, Q, R, K: 'a, V: 'a>
 where
-    K: Ord + Borrow<T>,
-    R: RangeBounds<T>,
-    T: Ord + ?Sized,
+    K: Ord + Borrow<Q>,
+    R: RangeBounds<Q>,
+    Q: Ord + ?Sized,
 {
-    pub(crate) inner: base::RefRange<'a, T, R, K, V>,
+    pub(crate) inner: base::RefRange<'a, Q, R, K, V>,
 }
 
-impl<'a, T, R, K, V> Iterator for Range<'a, T, R, K, V>
+impl<'a, Q, R, K, V> Iterator for Range<'a, Q, R, K, V>
 where
-    K: Ord + Borrow<T>,
-    R: RangeBounds<T>,
-    T: Ord + ?Sized,
+    K: Ord + Borrow<Q>,
+    R: RangeBounds<Q>,
+    Q: Ord + ?Sized,
 {
     type Item = Entry<'a, K, V>;
 
@@ -388,11 +388,11 @@ where
     }
 }
 
-impl<'a, T, R, K, V> DoubleEndedIterator for Range<'a, T, R, K, V>
+impl<'a, Q, R, K, V> DoubleEndedIterator for Range<'a, Q, R, K, V>
 where
-    K: Ord + Borrow<T>,
-    R: RangeBounds<T>,
-    T: Ord + ?Sized,
+    K: Ord + Borrow<Q>,
+    R: RangeBounds<Q>,
+    Q: Ord + ?Sized,
 {
     fn next_back(&mut self) -> Option<Entry<'a, K, V>> {
         let guard = &epoch::pin();
@@ -400,12 +400,12 @@ where
     }
 }
 
-impl<'a, T, R, K, V> fmt::Debug for Range<'a, T, R, K, V>
+impl<'a, Q, R, K, V> fmt::Debug for Range<'a, Q, R, K, V>
 where
-    K: Ord + Borrow<T> + fmt::Debug,
+    K: Ord + Borrow<Q> + fmt::Debug,
     V: fmt::Debug,
-    R: RangeBounds<T> + fmt::Debug,
-    T: Ord + ?Sized,
+    R: RangeBounds<Q> + fmt::Debug,
+    Q: Ord + ?Sized,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Range")

--- a/crossbeam-skiplist/src/map.rs
+++ b/crossbeam-skiplist/src/map.rs
@@ -402,9 +402,9 @@ where
 
 impl<'a, T, R, K, V> fmt::Debug for Range<'a, T, R, K, V>
 where
-    K: fmt::Debug + Ord + Borrow<T>,
+    K: Ord + Borrow<T> + fmt::Debug,
     V: fmt::Debug,
-    R: fmt::Debug + RangeBounds<T>,
+    R: RangeBounds<T> + fmt::Debug,
     T: Ord + ?Sized,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/crossbeam-skiplist/src/map.rs
+++ b/crossbeam-skiplist/src/map.rs
@@ -3,7 +3,7 @@
 use std::borrow::Borrow;
 use std::fmt;
 use std::iter::FromIterator;
-use std::ops::Bound;
+use std::ops::{Bound, RangeBounds};
 
 use base::{self, try_pin_loop};
 use epoch;
@@ -109,18 +109,17 @@ where
     }
 
     /// Returns an iterator over a subset of entries in the skip list.
-    pub fn range<'a, 'k, Min, Max>(
-        &'a self,
-        lower_bound: Bound<&'k Min>,
-        upper_bound: Bound<&'k Max>,
-    ) -> Range<'a, 'k, Min, Max, K, V>
+    pub fn range<T, R>(
+        &self,
+        range: R,
+    ) -> Range<'_, T, R, K, V>
     where
-        K: Ord + Borrow<Min> + Borrow<Max>,
-        Min: Ord + ?Sized + 'k,
-        Max: Ord + ?Sized + 'k,
+        K: Borrow<T>,
+        R: RangeBounds<T>,
+        T: Ord + ?Sized,
     {
         Range {
-            inner: self.inner.ref_range(lower_bound, upper_bound),
+            inner: self.inner.ref_range(range),
         }
     }
 }
@@ -366,20 +365,20 @@ impl<'a, K, V> fmt::Debug for Iter<'a, K, V> {
 }
 
 /// An iterator over the entries of a `SkipMap`.
-pub struct Range<'a, 'k, Min, Max, K: 'a, V: 'a>
+pub struct Range<'a, T, R, K: 'a, V: 'a>
 where
-    K: Ord + Borrow<Min> + Borrow<Max>,
-    Min: Ord + ?Sized + 'k,
-    Max: Ord + ?Sized + 'k,
+    K: Ord + Borrow<T>,
+    R: RangeBounds<T>,
+    T: Ord + ?Sized,
 {
-    pub(crate) inner: base::RefRange<'a, 'k, Min, Max, K, V>,
+    pub(crate) inner: base::RefRange<'a, T, R, K, V>,
 }
 
-impl<'a, 'k, Min, Max, K, V> Iterator for Range<'a, 'k, Min, Max, K, V>
+impl<'a, T, R, K, V> Iterator for Range<'a, T, R, K, V>
 where
-    K: Ord + Borrow<Min> + Borrow<Max>,
-    Min: Ord + ?Sized + 'k,
-    Max: Ord + ?Sized + 'k,
+    K: Ord + Borrow<T>,
+    R: RangeBounds<T>,
+    T: Ord + ?Sized,
 {
     type Item = Entry<'a, K, V>;
 
@@ -389,11 +388,11 @@ where
     }
 }
 
-impl<'a, 'k, Min, Max, K, V> DoubleEndedIterator for Range<'a, 'k, Min, Max, K, V>
+impl<'a, T, R, K, V> DoubleEndedIterator for Range<'a, T, R, K, V>
 where
-    K: Ord + Borrow<Min> + Borrow<Max>,
-    Min: Ord + ?Sized + 'k,
-    Max: Ord + ?Sized + 'k,
+    K: Ord + Borrow<T>,
+    R: RangeBounds<T>,
+    T: Ord + ?Sized,
 {
     fn next_back(&mut self) -> Option<Entry<'a, K, V>> {
         let guard = &epoch::pin();
@@ -401,16 +400,18 @@ where
     }
 }
 
-impl<'a, 'k, Min, Max, K, V> fmt::Debug for Range<'a, 'k, Min, Max, K, V>
+impl<'a, T, R, K, V> fmt::Debug for Range<'a, T, R, K, V>
 where
-    K: Ord + Borrow<Min> + Borrow<Max>,
-    Min: fmt::Debug + Ord + ?Sized + 'k,
-    Max: fmt::Debug + Ord + ?Sized + 'k,
+    K: fmt::Debug + Ord + Borrow<T>,
+    V: fmt::Debug,
+    R: fmt::Debug + RangeBounds<T>,
+    T: Ord + ?Sized,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Range")
-            .field("lower_bound", &self.inner.lower_bound)
-            .field("upper_bound", &self.inner.upper_bound)
+            .field("range", &self.inner.range)
+            .field("head", &self.inner.head)
+            .field("tail", &self.inner.tail)
             .finish()
     }
 }

--- a/crossbeam-skiplist/src/set.rs
+++ b/crossbeam-skiplist/src/set.rs
@@ -101,14 +101,14 @@ where
     }
 
     /// Returns an iterator over a subset of entries in the skip list.
-    pub fn range<K, R>(
+    pub fn range<Q, R>(
         &self,
         range: R,
-    ) -> Range<'_, K, R, T>
+    ) -> Range<'_, Q, R, T>
     where
-        K: Ord + ?Sized,
-        R: RangeBounds<K>,
-        T: Borrow<K>,
+        T: Borrow<Q>,
+        R: RangeBounds<Q>,
+        Q: Ord + ?Sized,
     {
         Range {
             inner: self.inner.range(range),
@@ -335,20 +335,20 @@ impl<'a, T> fmt::Debug for Iter<'a, T> {
 }
 
 /// An iterator over the entries of a `SkipMap`.
-pub struct Range<'a, K, R, T: 'a>
+pub struct Range<'a, Q, R, T: 'a>
 where
-    K: Ord + ?Sized,
-    R: RangeBounds<K>,
-    T: Ord + Borrow<K>,
+    T: Ord + Borrow<Q>,
+    R: RangeBounds<Q>,
+    Q: Ord + ?Sized,
 {
-    inner: map::Range<'a, K, R, T, ()>,
+    inner: map::Range<'a, Q, R, T, ()>,
 }
 
-impl<'a, K, R, T> Iterator for Range<'a, K, R, T>
+impl<'a, Q, R, T> Iterator for Range<'a, Q, R, T>
 where
-    K: Ord + ?Sized,
-    R: RangeBounds<K>,
-    T: Ord + Borrow<K>,
+    T: Ord + Borrow<Q>,
+    R: RangeBounds<Q>,
+    Q: Ord + ?Sized,
 {
     type Item = Entry<'a, T>;
 
@@ -357,22 +357,22 @@ where
     }
 }
 
-impl<'a, K, R, T> DoubleEndedIterator for Range<'a, K, R, T>
+impl<'a, Q, R, T> DoubleEndedIterator for Range<'a, Q, R, T>
 where
-    K: Ord + ?Sized,
-    R: RangeBounds<K>,
-    T: Ord + Borrow<K>,
+    T: Ord + Borrow<Q>,
+    R: RangeBounds<Q>,
+    Q: Ord + ?Sized,
 {
     fn next_back(&mut self) -> Option<Entry<'a, T>> {
         self.inner.next_back().map(Entry::new)
     }
 }
 
-impl<'a, K, R, T> fmt::Debug for Range<'a, K, R, T>
+impl<'a, Q, R, T> fmt::Debug for Range<'a, Q, R, T>
 where
-    K: Ord + ?Sized,
-    R: RangeBounds<K> + fmt::Debug,
-    T: Ord + Borrow<K> + fmt::Debug,
+    T: Ord + Borrow<Q> + fmt::Debug,
+    R: RangeBounds<Q> + fmt::Debug,
+    Q: Ord + ?Sized,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Range")

--- a/crossbeam-skiplist/src/set.rs
+++ b/crossbeam-skiplist/src/set.rs
@@ -3,7 +3,7 @@
 use std::borrow::Borrow;
 use std::fmt;
 use std::iter::FromIterator;
-use std::ops::Bound;
+use std::ops::{Bound, RangeBounds};
 
 use map;
 
@@ -101,18 +101,17 @@ where
     }
 
     /// Returns an iterator over a subset of entries in the skip list.
-    pub fn range<'a, 'k, Min, Max>(
-        &'a self,
-        lower_bound: Bound<&'k Min>,
-        upper_bound: Bound<&'k Max>,
-    ) -> Range<'a, 'k, Min, Max, T>
+    pub fn range<K, R>(
+        &self,
+        range: R,
+    ) -> Range<'_, K, R, T>
     where
-        T: Ord + Borrow<Min> + Borrow<Max>,
-        Min: Ord + ?Sized + 'k,
-        Max: Ord + ?Sized + 'k,
+        K: Ord + ?Sized,
+        R: RangeBounds<K>,
+        T: Borrow<K>,
     {
         Range {
-            inner: self.inner.range(lower_bound, upper_bound),
+            inner: self.inner.range(range),
         }
     }
 }
@@ -336,20 +335,20 @@ impl<'a, T> fmt::Debug for Iter<'a, T> {
 }
 
 /// An iterator over the entries of a `SkipMap`.
-pub struct Range<'a, 'k, Min, Max, T: 'a>
+pub struct Range<'a, K, R, T: 'a>
 where
-    T: Ord + Borrow<Min> + Borrow<Max>,
-    Min: Ord + ?Sized + 'k,
-    Max: Ord + ?Sized + 'k,
+    K: Ord + ?Sized,
+    R: RangeBounds<K>,
+    T: Ord + Borrow<K>,
 {
-    inner: map::Range<'a, 'k, Min, Max, T, ()>,
+    inner: map::Range<'a, K, R, T, ()>,
 }
 
-impl<'a, 'k, Min, Max, T> Iterator for Range<'a, 'k, Min, Max, T>
+impl<'a, K, R, T> Iterator for Range<'a, K, R, T>
 where
-    T: Ord + Borrow<Min> + Borrow<Max>,
-    Min: Ord + ?Sized + 'k,
-    Max: Ord + ?Sized + 'k,
+    K: Ord + ?Sized,
+    R: RangeBounds<K>,
+    T: Ord + Borrow<K>,
 {
     type Item = Entry<'a, T>;
 
@@ -358,27 +357,28 @@ where
     }
 }
 
-impl<'a, 'k, Min, Max, T> DoubleEndedIterator for Range<'a, 'k, Min, Max, T>
+impl<'a, K, R, T> DoubleEndedIterator for Range<'a, K, R, T>
 where
-    T: Ord + Borrow<Min> + Borrow<Max>,
-    Min: Ord + ?Sized + 'k,
-    Max: Ord + ?Sized + 'k,
+    K: Ord + ?Sized,
+    R: RangeBounds<K>,
+    T: Ord + Borrow<K>,
 {
     fn next_back(&mut self) -> Option<Entry<'a, T>> {
         self.inner.next_back().map(Entry::new)
     }
 }
 
-impl<'a, 'k, Min, Max, T> fmt::Debug for Range<'a, 'k, Min, Max, T>
+impl<'a, K, R, T> fmt::Debug for Range<'a, K, R, T>
 where
-    T: Ord + Borrow<Min> + Borrow<Max>,
-    Min: fmt::Debug + Ord + ?Sized + 'k,
-    Max: fmt::Debug + Ord + ?Sized + 'k,
+    K: Ord + ?Sized,
+    R: fmt::Debug + RangeBounds<K>,
+    T: fmt::Debug + Ord + Borrow<K>,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Range")
-            .field("lower_bound", &self.inner.inner.lower_bound)
-            .field("upper_bound", &self.inner.inner.upper_bound)
+            .field("range", &self.inner.inner.range)
+            .field("head", &self.inner.inner.head.as_ref().map(|e| e.key()))
+            .field("tail", &self.inner.inner.tail.as_ref().map(|e| e.key()))
             .finish()
     }
 }

--- a/crossbeam-skiplist/src/set.rs
+++ b/crossbeam-skiplist/src/set.rs
@@ -371,8 +371,8 @@ where
 impl<'a, K, R, T> fmt::Debug for Range<'a, K, R, T>
 where
     K: Ord + ?Sized,
-    R: fmt::Debug + RangeBounds<K>,
-    T: fmt::Debug + Ord + Borrow<K>,
+    R: RangeBounds<K> + fmt::Debug,
+    T: Ord + Borrow<K> + fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Range")

--- a/crossbeam-skiplist/tests/base.rs
+++ b/crossbeam-skiplist/tests/base.rs
@@ -526,205 +526,205 @@ fn iter_range() {
         vec![90, 80, 70, 60, 50, 40, 30, 20, 10, 0]
     );
     assert_eq!(
-        s.range(Unbounded, Unbounded, guard)
+        s.range(.., guard)
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![0, 10, 20, 30, 40, 50, 60, 70, 80, 90]
     );
 
     assert_eq!(
-        s.range(Included(&0), Unbounded, guard)
+        s.range((Included(&0), Unbounded), guard)
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![0, 10, 20, 30, 40, 50, 60, 70, 80, 90]
     );
     assert_eq!(
-        s.range(Excluded(&0), Unbounded, guard)
+        s.range((Excluded(&0), Unbounded), guard)
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![10, 20, 30, 40, 50, 60, 70, 80, 90]
     );
     assert_eq!(
-        s.range(Included(&25), Unbounded, guard)
+        s.range((Included(&25), Unbounded), guard)
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![30, 40, 50, 60, 70, 80, 90]
     );
     assert_eq!(
-        s.range(Excluded(&25), Unbounded, guard)
+        s.range((Excluded(&25), Unbounded), guard)
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![30, 40, 50, 60, 70, 80, 90]
     );
     assert_eq!(
-        s.range(Included(&70), Unbounded, guard)
+        s.range((Included(&70), Unbounded), guard)
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![70, 80, 90]
     );
     assert_eq!(
-        s.range(Excluded(&70), Unbounded, guard)
+        s.range((Excluded(&70), Unbounded), guard)
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![80, 90]
     );
     assert_eq!(
-        s.range(Included(&100), Unbounded, guard)
+        s.range((Included(&100), Unbounded), guard)
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![]
     );
     assert_eq!(
-        s.range(Excluded(&100), Unbounded, guard)
+        s.range((Excluded(&100), Unbounded), guard)
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![]
     );
 
     assert_eq!(
-        s.range(Unbounded, Included(&90), guard)
+        s.range((Unbounded, Included(&90)), guard)
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![0, 10, 20, 30, 40, 50, 60, 70, 80, 90]
     );
     assert_eq!(
-        s.range(Unbounded, Excluded(&90), guard)
+        s.range((Unbounded, Excluded(&90)), guard)
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![0, 10, 20, 30, 40, 50, 60, 70, 80]
     );
     assert_eq!(
-        s.range(Unbounded, Included(&25), guard)
+        s.range((Unbounded, Included(&25)), guard)
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![0, 10, 20]
     );
     assert_eq!(
-        s.range(Unbounded, Excluded(&25), guard)
+        s.range((Unbounded, Excluded(&25)), guard)
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![0, 10, 20]
     );
     assert_eq!(
-        s.range(Unbounded, Included(&70), guard)
+        s.range((Unbounded, Included(&70)), guard)
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![0, 10, 20, 30, 40, 50, 60, 70]
     );
     assert_eq!(
-        s.range(Unbounded, Excluded(&70), guard)
+        s.range((Unbounded, Excluded(&70)), guard)
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![0, 10, 20, 30, 40, 50, 60]
     );
     assert_eq!(
-        s.range(Unbounded, Included(&-1), guard)
+        s.range((Unbounded, Included(&-1)), guard)
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![]
     );
     assert_eq!(
-        s.range(Unbounded, Excluded(&-1), guard)
+        s.range((Unbounded, Excluded(&-1)), guard)
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![]
     );
 
     assert_eq!(
-        s.range(Included(&25), Included(&80), guard)
+        s.range((Included(&25), Included(&80)), guard)
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![30, 40, 50, 60, 70, 80]
     );
     assert_eq!(
-        s.range(Included(&25), Excluded(&80), guard)
+        s.range((Included(&25), Excluded(&80)), guard)
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![30, 40, 50, 60, 70]
     );
     assert_eq!(
-        s.range(Excluded(&25), Included(&80), guard)
+        s.range((Excluded(&25), Included(&80)), guard)
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![30, 40, 50, 60, 70, 80]
     );
     assert_eq!(
-        s.range(Excluded(&25), Excluded(&80), guard)
+        s.range((Excluded(&25), Excluded(&80)), guard)
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![30, 40, 50, 60, 70]
     );
 
     assert_eq!(
-        s.range(Included(&25), Included(&25), guard)
+        s.range((Included(&25), Included(&25)), guard)
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![]
     );
     assert_eq!(
-        s.range(Included(&25), Excluded(&25), guard)
+        s.range((Included(&25), Excluded(&25)), guard)
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![]
     );
     assert_eq!(
-        s.range(Excluded(&25), Included(&25), guard)
+        s.range((Excluded(&25), Included(&25)), guard)
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![]
     );
     assert_eq!(
-        s.range(Excluded(&25), Excluded(&25), guard)
+        s.range((Excluded(&25), Excluded(&25)), guard)
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![]
     );
 
     assert_eq!(
-        s.range(Included(&50), Included(&50), guard)
+        s.range((Included(&50), Included(&50)), guard)
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![50]
     );
     assert_eq!(
-        s.range(Included(&50), Excluded(&50), guard)
+        s.range((Included(&50), Excluded(&50)), guard)
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![]
     );
     assert_eq!(
-        s.range(Excluded(&50), Included(&50), guard)
+        s.range((Excluded(&50), Included(&50)), guard)
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![]
     );
     assert_eq!(
-        s.range(Excluded(&50), Excluded(&50), guard)
+        s.range((Excluded(&50), Excluded(&50)), guard)
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![]
     );
 
     assert_eq!(
-        s.range(Included(&100), Included(&-2), guard)
+        s.range((Included(&100), Included(&-2)), guard)
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![]
     );
     assert_eq!(
-        s.range(Included(&100), Excluded(&-2), guard)
+        s.range((Included(&100), Excluded(&-2)), guard)
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![]
     );
     assert_eq!(
-        s.range(Excluded(&100), Included(&-2), guard)
+        s.range((Excluded(&100), Included(&-2)), guard)
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![]
     );
     assert_eq!(
-        s.range(Excluded(&100), Excluded(&-2), guard)
+        s.range((Excluded(&100), Excluded(&-2)), guard)
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![]

--- a/crossbeam-skiplist/tests/map.rs
+++ b/crossbeam-skiplist/tests/map.rs
@@ -52,205 +52,205 @@ fn iter_range() {
         vec![90, 80, 70, 60, 50, 40, 30, 20, 10, 0]
     );
     assert_eq!(
-        s.range(Unbounded, Unbounded)
+        s.range(..)
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![0, 10, 20, 30, 40, 50, 60, 70, 80, 90]
     );
 
     assert_eq!(
-        s.range(Included(&0), Unbounded)
+        s.range((Included(&0), Unbounded))
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![0, 10, 20, 30, 40, 50, 60, 70, 80, 90]
     );
     assert_eq!(
-        s.range(Excluded(&0), Unbounded)
+        s.range((Excluded(&0), Unbounded))
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![10, 20, 30, 40, 50, 60, 70, 80, 90]
     );
     assert_eq!(
-        s.range(Included(&25), Unbounded)
+        s.range((Included(&25), Unbounded))
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![30, 40, 50, 60, 70, 80, 90]
     );
     assert_eq!(
-        s.range(Excluded(&25), Unbounded)
+        s.range((Excluded(&25), Unbounded))
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![30, 40, 50, 60, 70, 80, 90]
     );
     assert_eq!(
-        s.range(Included(&70), Unbounded)
+        s.range((Included(&70), Unbounded))
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![70, 80, 90]
     );
     assert_eq!(
-        s.range(Excluded(&70), Unbounded)
+        s.range((Excluded(&70), Unbounded))
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![80, 90]
     );
     assert_eq!(
-        s.range(Included(&100), Unbounded)
+        s.range((Included(&100), Unbounded))
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![]
     );
     assert_eq!(
-        s.range(Excluded(&100), Unbounded)
+        s.range((Excluded(&100), Unbounded))
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![]
     );
 
     assert_eq!(
-        s.range(Unbounded, Included(&90))
+        s.range((Unbounded, Included(&90)))
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![0, 10, 20, 30, 40, 50, 60, 70, 80, 90]
     );
     assert_eq!(
-        s.range(Unbounded, Excluded(&90))
+        s.range((Unbounded, Excluded(&90)))
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![0, 10, 20, 30, 40, 50, 60, 70, 80]
     );
     assert_eq!(
-        s.range(Unbounded, Included(&25))
+        s.range((Unbounded, Included(&25)))
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![0, 10, 20]
     );
     assert_eq!(
-        s.range(Unbounded, Excluded(&25))
+        s.range((Unbounded, Excluded(&25)))
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![0, 10, 20]
     );
     assert_eq!(
-        s.range(Unbounded, Included(&70))
+        s.range((Unbounded, Included(&70)))
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![0, 10, 20, 30, 40, 50, 60, 70]
     );
     assert_eq!(
-        s.range(Unbounded, Excluded(&70))
+        s.range((Unbounded, Excluded(&70)))
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![0, 10, 20, 30, 40, 50, 60]
     );
     assert_eq!(
-        s.range(Unbounded, Included(&-1))
+        s.range((Unbounded, Included(&-1)))
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![]
     );
     assert_eq!(
-        s.range(Unbounded, Excluded(&-1))
+        s.range((Unbounded, Excluded(&-1)))
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![]
     );
 
     assert_eq!(
-        s.range(Included(&25), Included(&80))
+        s.range((Included(&25), Included(&80)))
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![30, 40, 50, 60, 70, 80]
     );
     assert_eq!(
-        s.range(Included(&25), Excluded(&80))
+        s.range((Included(&25), Excluded(&80)))
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![30, 40, 50, 60, 70]
     );
     assert_eq!(
-        s.range(Excluded(&25), Included(&80))
+        s.range((Excluded(&25), Included(&80)))
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![30, 40, 50, 60, 70, 80]
     );
     assert_eq!(
-        s.range(Excluded(&25), Excluded(&80))
+        s.range((Excluded(&25), Excluded(&80)))
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![30, 40, 50, 60, 70]
     );
 
     assert_eq!(
-        s.range(Included(&25), Included(&25))
+        s.range((Included(&25), Included(&25)))
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![]
     );
     assert_eq!(
-        s.range(Included(&25), Excluded(&25))
+        s.range((Included(&25), Excluded(&25)))
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![]
     );
     assert_eq!(
-        s.range(Excluded(&25), Included(&25))
+        s.range((Excluded(&25), Included(&25)))
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![]
     );
     assert_eq!(
-        s.range(Excluded(&25), Excluded(&25))
+        s.range((Excluded(&25), Excluded(&25)))
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![]
     );
 
     assert_eq!(
-        s.range(Included(&50), Included(&50))
+        s.range((Included(&50), Included(&50)))
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![50]
     );
     assert_eq!(
-        s.range(Included(&50), Excluded(&50))
+        s.range((Included(&50), Excluded(&50)))
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![]
     );
     assert_eq!(
-        s.range(Excluded(&50), Included(&50))
+        s.range((Excluded(&50), Included(&50)))
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![]
     );
     assert_eq!(
-        s.range(Excluded(&50), Excluded(&50))
+        s.range((Excluded(&50), Excluded(&50)))
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![]
     );
 
     assert_eq!(
-        s.range(Included(&100), Included(&-2))
+        s.range((Included(&100), Included(&-2)))
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![]
     );
     assert_eq!(
-        s.range(Included(&100), Excluded(&-2))
+        s.range((Included(&100), Excluded(&-2)))
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![]
     );
     assert_eq!(
-        s.range(Excluded(&100), Included(&-2))
+        s.range((Excluded(&100), Included(&-2)))
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![]
     );
     assert_eq!(
-        s.range(Excluded(&100), Excluded(&-2))
+        s.range((Excluded(&100), Excluded(&-2)))
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![]


### PR DESCRIPTION
This lets use use `RangeBounds` for `ref_iter()` and `ref_range()`.

Signatures of `iter()` and `range()` are unchanged, though.