### PR TITLE
crossbeam-epoch: Add Shared::deref_mut()

### DIFF
--- a/crossbeam-epoch/src/atomic.rs
+++ b/crossbeam-epoch/src/atomic.rs
@@ -942,23 +942,12 @@ impl<'g, T> Shared<'g, T> {
     ///
     /// # Safety
     ///
-    /// * Dereferencing a pointer is unsafe because it could be pointing to invalid memory.
-    ///
-    /// * Another concern is the possiblity of data races due to lack of proper synchronization.
-    ///   For example, consider the following scenario:
-    ///
-    ///   1. A thread creates a new object: `a.store(Owned::new(10), Relaxed)`
-    ///   2. Another thread reads it: `*a.load(Relaxed, guard).as_ref().unwrap()`
-    ///
-    ///   The problem is that relaxed orderings don't synchronize initialization of the object with
-    ///   the read from the second thread. This is a data race. A possible solution would be to use
-    ///   `Release` and `Acquire` orderings.
-    ///
     /// * There is no guarantee that there are no more threads attempting to read/write from/to the
     ///   actual object at the same time.
     ///
-    ///   The user must be know that there are no concurrent accesses towards the object itself
-    ///   and/or use `crossbeam_utils::atomic::AtomicCell` to wrap the object.
+    ///   The user must know that there are no concurrent accesses towards the object itself.
+    ///
+    /// * Other than the above, all safety concerns of `deref()` applies here.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
It is possible that the user would like to have one thread to be able to
update the value of the object pointed by Atomic. For that, they will
need to have a mutable refernce towards that object.

This is an unsafe function because there is no guarantee that there are
more threads attempting to read/write from/to the actual object in the
same time.
In order to proivde safety the user must be able to know that there are
no concurrent accesses towards the object itself and/or use
crossbeam_utils::atomic::AtomicCell to provide the needed guarantees.