### PR TITLE
channel: implementation for receiving multiple items at once

### DIFF
--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -702,6 +702,7 @@ impl<T> Receiver<T> {
             }
 
             let result = match &self.flavor {
+                //ReceiverFlavor::Array(chan) => chan.try_recv(),
                 ReceiverFlavor::Array(chan) => return chan.try_recv_many(buf, limit),
                 ReceiverFlavor::List(chan) => chan.try_recv(),
                 ReceiverFlavor::Zero(chan) => chan.try_recv(),

--- a/crossbeam-channel/src/flavors/array.rs
+++ b/crossbeam-channel/src/flavors/array.rs
@@ -333,10 +333,8 @@ impl<T> Channel<T> {
 
         loop {
             // Load the head/tail and deconstruct them.
-            let tail = self.tail.load(Ordering::Relaxed);
             let index = head & (self.mark_bit - 1);
             let lap = head & !(self.one_lap - 1);
-            let tail_index = tail & (self.mark_bit - 1);
 
             // Inspect the corresponding head slot.
             let slot = unsafe { &*self.buffer.add(index) };
@@ -344,6 +342,9 @@ impl<T> Channel<T> {
 
             // If the stamp is ahead of the head by 1, we may attempt to pop.
             if head + 1 == stamp {
+                let tail = self.tail.load(Ordering::Relaxed);
+                let tail_index = tail & (self.mark_bit - 1);
+
                 // See how many messages we have available to read.
                 let msgs_avail = if index < tail_index {
                     tail_index - index


### PR DESCRIPTION
This PR implements `try_recv_many`, which allows a caller to receive multiple items in a single call.  It is provided generally for all channels, but has a specific implementation override for bounded channels, and a few caveats:

- there are no timeout-based or blocking variants
- this will do almost nothing for some channels like after/zero because it uses the non-blocking try semantics
- callers must allocate an `Extend` capable container themselves
- mixed recv/recv_many performance may be suboptimal

This method fills a niche use case: single consumers that can benefit from grabbing and processing multiple items at a time.