### PR TITLE
Introduce crossbeam-circbuf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,10 @@ path = "./crossbeam-deque"
 default-features = false
 optional = true
 
+[dependencies.crossbeam-circbuf]
+version = "0.1.0"
+path = "./crossbeam-circbuf"
+
 [dependencies.crossbeam-epoch]
 version = "0.8"
 path = "./crossbeam-epoch"
@@ -85,5 +89,6 @@ members = [
   "crossbeam-epoch",
   "crossbeam-queue",
   "crossbeam-skiplist",
+  "crossbeam-circbuf",
   "crossbeam-utils",
 ]

--- a/crossbeam-circbuf/.travis.yml
+++ b/crossbeam-circbuf/.travis.yml
@@ -1,0 +1,12 @@
+language: rust
+
+rust:
+  - stable
+  - beta
+  - nightly
+
+script:
+  - cargo build
+  - cargo build --release
+  - cargo test
+  - cargo test --release

--- a/crossbeam-circbuf/Cargo.toml
+++ b/crossbeam-circbuf/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "crossbeam-circbuf"
+# When publishing a new version:
+# - Update CHANGELOG.md
+# - Update README.md
+# - Create "crossbeam-circbuf-X.Y.Z" git tag
+version = "0.1.0"
+authors = ["The Crossbeam Project Developers"]
+license = "MIT OR Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/crossbeam-rs/crossbeam"
+homepage = "https://github.com/crossbeam-rs/crossbeam"
+documentation = "https://docs.rs/crossbeam-circbuf"
+description = "Concurrent queues based on circular buffer"
+keywords = ["circular-buffer", "ring-buffer", "spsc", "spmc", "concurrent-queue"]
+categories = ["concurrency", "data-structures"]
+
+[dependencies]
+crossbeam-epoch = { path = "../crossbeam-epoch" }
+crossbeam-utils = { path = "../crossbeam-utils" }
+memoffset = "0.5.4"
+
+[dev-dependencies]
+rand = "0.7"

--- a/crossbeam-circbuf/LICENSE-APACHE
+++ b/crossbeam-circbuf/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/crossbeam-circbuf/LICENSE-MIT
+++ b/crossbeam-circbuf/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2010 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/crossbeam-circbuf/README.md
+++ b/crossbeam-circbuf/README.md
@@ -1,0 +1,48 @@
+# Concurrent queues based on circular buffer
+
+[![Build Status](https://travis-ci.org/crossbeam-rs/crossbeam.svg?branch=master)](
+https://travis-ci.org/crossbeam-rs/crossbeam)
+[![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](
+https://github.com/crossbeam-rs/crossbeam-circbuf)
+[![Cargo](https://img.shields.io/crates/v/crossbeam-circbuf.svg)](
+https://crates.io/crates/crossbeam-circbuf)
+[![Documentation](https://docs.rs/crossbeam-circbuf/badge.svg)](
+https://docs.rs/crossbeam-circbuf)
+[![Rust 1.26+](https://img.shields.io/badge/rust-1.26+-lightgray.svg)](
+https://www.rust-lang.org)
+
+This crate provides concurrent queues based on circular buffer.
+
+## Usage
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+crossbeam-circbuf = "0.1"
+```
+
+Next, add this to your crate:
+
+```rust
+extern crate crossbeam_circbuf as circbuf;
+```
+
+## Compatibility
+
+The minimum supported Rust version is 1.26.
+
+## License
+
+Licensed under either of
+
+ * Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.

--- a/crossbeam-circbuf/src/buffer.rs
+++ b/crossbeam-circbuf/src/buffer.rs
@@ -1,0 +1,151 @@
+use core::cell::UnsafeCell;
+use core::mem::{self, ManuallyDrop, MaybeUninit};
+use core::ops::{Deref, DerefMut};
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use epoch::{Owned, Pointable};
+
+/// A slot in buffer.
+#[derive(Debug)]
+pub struct Slot<T> {
+    /// The index of this slot's data.
+    ///
+    /// An index consists of an offset into the buffer and a lap, but packed into a single `usize`.
+    /// The lower bits represent the offset, while the upper bits represent the lap.  For example if
+    /// the buffer capacity is 4, then index 6 represents offset 2 in lap 1.
+    index: AtomicUsize,
+
+    /// The value in this slot.
+    ///
+    /// The allocated memory exhibit data races by `read`, `write`, `read_index`, and `write_index`,
+    /// which technically invoke undefined behavior.  We should be using relaxed accesses, but that
+    /// would cost too much performance.  Hence, as a HACK, we use volatile accesses instead.
+    /// Experimental evidence shows that this works.
+    data: UnsafeCell<ManuallyDrop<T>>,
+}
+
+/// A buffer that holds values in a queue.
+///
+/// This is just a buffer---dropping an instance of this struct will *not* drop the internal values.
+pub struct Buffer<T> {
+    inner: [MaybeUninit<Slot<T>>],
+}
+
+impl<T> Pointable for Buffer<T> {
+    const ALIGN: usize = <[MaybeUninit<Slot<T>>] as Pointable>::ALIGN;
+
+    type Init = <[MaybeUninit<Slot<T>>] as Pointable>::Init;
+
+    unsafe fn init(size: Self::Init) -> usize {
+        <[MaybeUninit<Slot<T>>] as Pointable>::init(size)
+    }
+
+    unsafe fn deref<'a>(ptr: usize) -> &'a Self {
+        &*(<[MaybeUninit<Slot<T>>] as Pointable>::deref(ptr) as *const _ as *const _)
+    }
+
+    unsafe fn deref_mut<'a>(ptr: usize) -> &'a mut Self {
+        &mut *(<[MaybeUninit<Slot<T>>] as Pointable>::deref_mut(ptr) as *mut _ as *mut _)
+    }
+
+    unsafe fn drop(ptr: usize) {
+        <[MaybeUninit<Slot<T>>] as Pointable>::drop(ptr)
+    }
+}
+
+impl<T> Deref for Buffer<T> {
+    type Target = [MaybeUninit<Slot<T>>];
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T> DerefMut for Buffer<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl<T> Buffer<T> {
+    /// Allocates a new buffer with the specified capacity.
+    pub fn new(size: usize) -> Owned<Self> {
+        // `size` should be a power of two.
+        debug_assert_eq!(size, size.next_power_of_two());
+
+        let mut buffer = Owned::<Self>::init(size);
+
+        // Marks all entries invalid.
+        for (i, slot) in buffer.deref_mut().iter_mut().enumerate() {
+            // Index `i + 1` for the `i`-th entry is invalid; only the indexes of the form `i + N *
+            // size` is valid.
+            unsafe {
+                (*slot.as_ptr()).index.store(i + 1, Ordering::Relaxed);
+            }
+        }
+
+        buffer
+    }
+
+    /// Returns the capacity of the buffer.
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Returns a pointer to the slot at the specified `index`.
+    pub fn get(&self, index: usize) -> *const Slot<T> {
+        // `array.size()` is always a power of two.
+        unsafe { self.inner.get_unchecked(index & (self.len() - 1)).as_ptr() }
+    }
+
+    /// Reads a value from the specified `index`.
+    ///
+    /// Returns `Some(v)` if `v` is at `index`; or `None` if there's no valid value for `index`.
+    pub unsafe fn read(&self, index: usize) -> Option<mem::ManuallyDrop<T>> {
+        let slot = &*self.get(index);
+
+        // Reads the index with `Acquire`.
+        let i = slot.index.load(Ordering::Acquire);
+
+        // If the index in the buffer mismatches with the queried index, there's no valid value.
+        if index != i {
+            return None;
+        }
+
+        // Returns the value.
+        Some((*slot).data.get().read_volatile())
+    }
+
+    /// Reads a value from the specified `index` without checking the index.
+    ///
+    /// Returns the value at `index` regardless or whether it's valid or not.
+    pub unsafe fn read_unchecked(&self, index: usize) -> mem::ManuallyDrop<T> {
+        let slot = &*self.get(index);
+        slot.data.get().read_volatile()
+    }
+
+    /// Reads the index from the specified slot.
+    pub unsafe fn read_index(&self, index: usize, ord: Ordering) -> usize {
+        let slot = &*self.get(index);
+        slot.index.load(ord)
+    }
+
+    /// Writes `value` into the specified `index`.
+    pub unsafe fn write(&self, index: usize, value: T) {
+        let slot = &*self.get(index);
+
+        // Writes the value.
+        slot.data
+            .get()
+            .write_volatile(mem::ManuallyDrop::new(value));
+
+        // Writes the index with `Release`.
+        slot.index.store(index, Ordering::Release);
+    }
+
+    /// Writes the specified `index` in the slot.
+    pub unsafe fn write_index(&self, index: usize, ord: Ordering) {
+        let slot = &*self.get(index);
+        slot.index.store(index, ord);
+    }
+}

--- a/crossbeam-circbuf/src/lib.rs
+++ b/crossbeam-circbuf/src/lib.rs
@@ -1,0 +1,25 @@
+//! Concurrent queues based on circular buffer.
+//!
+//! Currently, this crate provides the following flavors of queues:
+//!
+//! - bounded/unbounded SPSC (single-producer single-consumer)
+//! - bounded/unbounded SPMC (single-producer multiple-consumer)
+//! - bounded MPMC (multiple-producer multiple-consumer)
+
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
+
+extern crate core;
+extern crate crossbeam_epoch as epoch;
+extern crate crossbeam_utils as utils;
+
+mod buffer;
+mod try_recv;
+
+#[doc(hidden)] // for doc-tests
+pub mod sp_inner;
+
+pub use try_recv::TryRecv;
+
+pub mod mpmc;
+pub mod spmc;
+pub mod spsc;

--- a/crossbeam-circbuf/src/mpmc.rs
+++ b/crossbeam-circbuf/src/mpmc.rs
@@ -1,0 +1,293 @@
+//! Concurrent multiple-producer multiple-consumer queues based on circular buffer.
+
+/// Bounded MPMC queue based on fixed-sized concurrent circular buffer.
+///
+/// The implementation is based on Dmitry Vyukov's bounded MPMC queue:
+///
+/// * http://www.1024cores.net/home/lock-free-algorithms/queues/bounded-mpmc-queue
+/// * https://docs.google.com/document/d/1yIAYmbvL3JxOKOjuCyon7JhW4cSv1wy5hC0ApeGMV9s/pub
+///
+/// # Examples
+///
+/// ```
+/// use crossbeam_circbuf::mpmc::bounded::{Queue, TryRecv};
+/// use std::thread;
+/// use std::sync::Arc;
+///
+/// let q = Arc::new(Queue::<char>::new(16));
+/// let r = q.clone();
+///
+/// q.send('a').unwrap();
+/// r.send('b').unwrap();
+///
+/// assert_eq!(q.recv(), Some('a'));
+/// assert_eq!(r.recv(), Some('b'));
+/// ```
+pub mod bounded {
+    use epoch::{unprotected, Atomic};
+    use std::marker::PhantomData;
+    use std::mem::ManuallyDrop;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+    use utils::CachePadded;
+
+    use buffer::Buffer;
+    pub use TryRecv;
+
+    /// A bounded MPMC queue.
+    #[derive(Debug)]
+    pub struct Queue<T> {
+        /// The head index from which values are popped.
+        ///
+        /// The lap of the head index is always an odd number.
+        head: CachePadded<AtomicUsize>,
+
+        /// The tail index into which values are pushed.
+        ///
+        /// The lap in the tail is always an even number.
+        tail: CachePadded<AtomicUsize>,
+
+        /// The underlying buffer.
+        buffer: Atomic<Buffer<T>>,
+
+        /// The capacity of the queue.
+        cap: usize,
+
+        /// the size of one lap.
+        lap: usize,
+
+        /// Indicates that dropping an `ArrayQueue<T>` may drop values of type `T`.
+        _marker: PhantomData<T>,
+    }
+
+    unsafe impl<T: Send> Sync for Queue<T> {}
+    unsafe impl<T: Send> Send for Queue<T> {}
+
+    impl<T> Queue<T> {
+        /// Creates a new queue of capacity at least `cap`.
+        pub fn new(cap: usize) -> Self {
+            // One lap is the smallest power of two greater than or equal to `cap`.
+            let lap = cap.next_power_of_two();
+
+            // Head is initialized to `{ lap: 1, offset: 0 }`.
+            // Tail is initialized to `{ lap: 0, offset: 0 }`.
+            let head = lap;
+            let tail = 0;
+
+            // Allocate a buffer of `lap` slots.
+            let buffer = Atomic::<Buffer<T>>::init(lap);
+
+            // Initialize stamps in the slots.
+            unsafe {
+                let buffer_ref = buffer.load(Ordering::Relaxed, unprotected());
+                for i in 0..lap {
+                    // Set the index to `{ lap: 0, offset: i }`.
+                    buffer_ref.deref().write_index(i, Ordering::Relaxed);
+                }
+            }
+
+            Self {
+                head: CachePadded::new(AtomicUsize::new(head)),
+                tail: CachePadded::new(AtomicUsize::new(tail)),
+                buffer,
+                cap,
+                lap,
+                _marker: PhantomData,
+            }
+        }
+
+        /// Returns the size of one lap.
+        #[inline]
+        pub fn lap(&self) -> usize {
+            self.lap
+        }
+
+        /// Returns the capacity of the queue.
+        #[inline]
+        pub fn cap(&self) -> usize {
+            self.cap
+        }
+
+        /// Attempts to send a value to the queue.
+        pub fn send(&self, value: T) -> Result<(), T> {
+            loop {
+                // Loads the tail and deconstruct it.
+                let tail = self.tail.load(Ordering::Acquire);
+                let offset = tail & (self.lap() - 1);
+                let lap = tail & !(self.lap() - 1);
+
+                // Inspects the corresponding slot.
+                let buffer_ref = unsafe { self.buffer.load(Ordering::Relaxed, unprotected()) };
+                let index = unsafe { buffer_ref.deref().read_index(offset, Ordering::Acquire) };
+
+                // If the tail and the stamp match, we may attempt to push.
+                if tail == index {
+                    let new_tail = if offset + 1 < self.cap() {
+                        // Same lap, incremented index.
+                        // Set to `{ lap: lap, offset: offset + 1 }`.
+                        tail + 1
+                    } else {
+                        // Two laps forward, index wraps around to zero.
+                        // Set to `{ lap: lap.wrapping_add(2), offset: 0 }`.
+                        lap.wrapping_add(self.lap().wrapping_mul(2))
+                    };
+
+                    // Tries moving the tail.
+                    if self
+                        .tail
+                        .compare_exchange_weak(tail, new_tail, Ordering::AcqRel, Ordering::Relaxed)
+                        .is_ok()
+                    {
+                        // Writes the value into the slot and update the stamp.
+                        unsafe {
+                            buffer_ref
+                                .deref()
+                                .write(index.wrapping_add(self.lap()), value)
+                        };
+                        return Ok(());
+                    }
+                // But if the slot lags one lap behind the tail...
+                } else if index.wrapping_add(self.lap()) == tail {
+                    let head = self.head.load(Ordering::Acquire);
+
+                    // ...and if the head lags one lap behind the tail as well...
+                    if head.wrapping_add(self.lap()) == tail {
+                        // ...then the queue is full.
+                        return Err(value);
+                    }
+                }
+            }
+        }
+
+        /// Attempts to pop a value from the queue.
+        pub fn recv(&self) -> Option<T> {
+            loop {
+                // Loads the head and deconstruct it.
+                let head = self.head.load(Ordering::Acquire);
+                let offset = head & (self.lap() - 1);
+                let lap = head & !(self.lap() - 1);
+
+                // Inspects the corresponding slot.
+                let buffer_ref = unsafe { self.buffer.load(Ordering::Relaxed, unprotected()) };
+                let index = unsafe { buffer_ref.deref().read_index(offset, Ordering::Acquire) };
+
+                // If the the head and the stamp match, we may attempt to pop.
+                if head == index {
+                    let new = if offset + 1 < self.cap() {
+                        // Same lap, incremented index.
+                        // Set to `{ lap: lap, offset: offset + 1 }`.
+                        head + 1
+                    } else {
+                        // Two laps forward, index wraps around to zero.
+                        // Set to `{ lap: lap.wrapping_add(2), offset: 0 }`.
+                        lap.wrapping_add(self.lap().wrapping_mul(2))
+                    };
+
+                    // Tries moving the head.
+                    if self
+                        .head
+                        .compare_exchange_weak(head, new, Ordering::AcqRel, Ordering::Relaxed)
+                        .is_ok()
+                    {
+                        // Reads the value from the slot and update the stamp.
+                        let value = unsafe { buffer_ref.deref().read_unchecked(index) };
+                        unsafe {
+                            buffer_ref
+                                .deref()
+                                .write_index(index.wrapping_add(self.lap()), Ordering::Release)
+                        };
+                        return Some(ManuallyDrop::into_inner(value));
+                    }
+                // But if the slot lags one lap behind the head...
+                } else if index.wrapping_add(self.lap()) == head {
+                    let tail = self.tail.load(Ordering::Acquire);
+
+                    // ...and if the tail lags one lap behind the head as well, that means the queue
+                    // is empty.
+                    if tail.wrapping_add(self.lap()) == head {
+                        return None;
+                    }
+                }
+            }
+        }
+
+        /// Returns `true` if the queue is empty.
+        ///
+        /// Inaccurate in the presence of concurrent method invocations.
+        pub fn is_empty(&self) -> bool {
+            let head = self.head.load(Ordering::Relaxed);
+            let tail = self.tail.load(Ordering::Relaxed);
+
+            // Is the tail lagging one lap behind head?
+            //
+            // Note: If the head changes just before we load the tail, that means there was a moment
+            // when the queue was not empty, so it is safe to just return `false`.
+            tail.wrapping_add(self.lap()) == head
+        }
+
+        /// Returns `true` if the queue is full.
+        ///
+        /// Inaccurate in the presence of concurrent method invocations.
+        pub fn is_full(&self) -> bool {
+            let tail = self.tail.load(Ordering::Relaxed);
+            let head = self.head.load(Ordering::Relaxed);
+
+            // Is the head lagging one lap behind tail?
+            //
+            // Note: If the tail changes just before we load the head, that means there was a moment
+            // when the queue was not full, so it is safe to just return `false`.
+            head.wrapping_add(self.lap()) == tail
+        }
+
+        /// Returns the current number of elements inside the queue.
+        ///
+        /// Inaccurate in the presence of concurrent method invocations.
+        pub fn len(&self) -> usize {
+            // Load the tail, then load the head.
+            let tail = self.tail.load(Ordering::Relaxed);
+            let head = self.head.load(Ordering::Relaxed);
+
+            let hix = head & (self.lap() - 1);
+            let tix = tail & (self.lap() - 1);
+
+            if hix < tix {
+                tix - hix
+            } else if hix > tix {
+                self.cap() - hix + tix
+            } else if tail.wrapping_add(self.lap()) == head {
+                0
+            } else {
+                self.cap()
+            }
+        }
+    }
+
+    impl<T> Drop for Queue<T> {
+        fn drop(&mut self) {
+            // Get the index of the head.
+            let hix = self.head.load(Ordering::Relaxed) & (self.lap() - 1);
+
+            // Loop over all slots that hold a message and drop them.
+            for i in 0..self.len() {
+                // Compute the index of the next slot holding a message.
+                let index = if hix + i < self.cap() {
+                    hix + i
+                } else {
+                    hix + i - self.cap()
+                };
+
+                unsafe {
+                    let buffer_ref = self.buffer.load(Ordering::Relaxed, unprotected());
+                    let mut value = buffer_ref.deref().read_unchecked(index);
+                    ManuallyDrop::drop(&mut value);
+                }
+            }
+
+            unsafe {
+                let guard = unprotected();
+                let buffer_ref = self.buffer.load(Ordering::Relaxed, guard);
+                guard.defer_destroy(buffer_ref);
+            }
+        }
+    }
+}

--- a/crossbeam-circbuf/src/sp_inner.rs
+++ b/crossbeam-circbuf/src/sp_inner.rs
@@ -541,7 +541,7 @@ impl<T> DynamicCircBuf<T> {
         // Copies data from the old buffer to the new one.
         let mut i = rx;
         while i != tx {
-            ptr::copy_nonoverlapping(buffer.deref().get(i), new.get(i) as *mut _, 1);
+            ptr::copy_nonoverlapping(buffer.deref().get(i), new.get(i) as *const _ as *mut _, 1);
             i = i.wrapping_add(1);
         }
 

--- a/crossbeam-circbuf/src/sp_inner.rs
+++ b/crossbeam-circbuf/src/sp_inner.rs
@@ -1,0 +1,1126 @@
+//! Concurrent single-producer queues based on circular buffer.
+//!
+//! [`CircBuf`] is a circular buffer, which is basically a fixed-sized array that has two ends: tx
+//! and rx. A [`CircBuf`] can [`send`] values into the tx end and [`CircBuf::try_recv`] values from
+//! the rx end. A [`CircBuf`] doesn't implement `Sync` so it cannot be shared among multiple
+//! threads. However, it can create [`Receiver`]s, and those can be easily cloned, shared, and sent
+//! to other threads. [`Receiver`]s can only [`Receiver::try_recv`] values from the rx end.
+//!
+//! Here's a visualization of a [`CircBuf`] of capacity 4, consisting of 2 values `a` and `b`.
+//!
+//! ```text
+//!    ___
+//!   | a | <- rx (CircBuf::try_recv, Receiver::try_recv)
+//!   | b |
+//!   |   | <- tx (CircBuf::send)
+//!   |   |
+//!    ¯¯¯
+//! ```
+//!
+//! [`DynamicCircBuf`] is a dynamically growable and shrinkable circular buffer. Internally,
+//! [`DynamicCircBuf`] has a [`CircBuf`] and resizes it when necessary.
+//!
+//!
+//! # Usage: fair work-stealing schedulers
+//!
+//! This data structure can be used in fair work-stealing schedulers for multiple threads as
+//! follows.
+//!
+//! Each thread owns a [`CircBuf`] (or [`DynamicCircBuf`]) and creates a [`Receiver`] that is shared
+//! among all other threads (or creates one [`Receiver`] for each of the other threads).
+//!
+//! Each thread is executing a loop in which it attempts to [`CircBuf::try_recv`] some task from its
+//! own [`CircBuf`] and perform it. If the buffer is empty, it attempts to [`Receiver::try_recv`]
+//! work from other threads instead. When performing a task, a thread may produce more tasks by
+//! [`send`]ing them to its buffer.
+//!
+//! It is worth noting that it is discouraged to use work-stealing deque for fair schedulers,
+//! because its `pop()` may return a task that is just `push()`ed, effectively scheduling the same
+//! work repeatedly.
+//!
+//! [`CircBuf`]: struct.CircBuf.html
+//! [`DynamicCircBuf`]: struct.DynamicCircBuf.html
+//! [`Receiver`]: struct.Receiver.html
+//! [`send`]: struct.CircBuf.html#method.send
+//! [`CircBuf::try_recv`]: struct.CircBuf.html#method.try_recv
+//! [`Receiver::try_recv`]: struct.Receiver.html#method.try_recv
+
+use std::cell::Cell;
+use std::fmt;
+use std::marker::PhantomData;
+use std::mem::{self, ManuallyDrop};
+use std::ptr;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use epoch::{self, Atomic};
+use utils::CachePadded;
+
+use buffer::Buffer;
+pub use TryRecv;
+
+/// Internal data shared among a circular buffer and its receivers.
+#[derive(Debug)]
+struct Inner<T> {
+    /// The rx index.
+    rx: CachePadded<AtomicUsize>,
+
+    /// The tx index.
+    tx: CachePadded<AtomicUsize>,
+
+    /// The underlying buffer.
+    buffer: Atomic<Buffer<T>>,
+}
+
+impl<T> Inner<T> {
+    /// Returns a new `Inner` with minimum capacity of `min_cap` rounded to the next power of two.
+    fn new(cap: usize) -> Self {
+        debug_assert_eq!(cap, cap.next_power_of_two());
+
+        let buffer = Buffer::new(cap);
+
+        Inner {
+            rx: CachePadded::new(AtomicUsize::new(0)),
+            tx: CachePadded::new(AtomicUsize::new(0)),
+            buffer: buffer.into(),
+        }
+    }
+}
+
+impl<T> Drop for Inner<T> {
+    fn drop(&mut self) {
+        // Loads rx, tx, and buffer.
+        let rx = self.rx.load(Ordering::Relaxed);
+        let tx = self.tx.load(Ordering::Relaxed);
+
+        unsafe {
+            let buffer = self.buffer.load(Ordering::Relaxed, epoch::unprotected());
+
+            // Drops the values from rx to tx in the buffer.
+            for i in 0..tx.wrapping_sub(rx) {
+                let mut value = buffer.deref().read_unchecked(rx.wrapping_add(i));
+                ManuallyDrop::drop(&mut value);
+            }
+
+            // Free the memory allocated by the buffer.
+            drop(buffer.into_owned());
+        }
+    }
+}
+
+/// A fixed-sized concurrent circular buffer.
+///
+/// A circular buffer has two ends: rx and tx. Values can be [`send`]ed to the tx end and
+/// [`CircBuf::try_recv`]ed from the rx end. The rx end is special in that receivers can also
+/// receive from the rx end using [`Receiver::try_recv`] method.
+///
+/// # Receivers
+///
+/// [`CircBuf`] may create [`Receiver`]s that can be shared among multiple threads. [`Receiver`]s
+/// can only [`Receiver::try_recv`] values from the rx end of the circular buffer.
+///
+/// # Capacity
+///
+/// The capacity of a buffer is fixed when created.
+///
+/// [`CircBuf`]: struct.CircBuf.html
+/// [`Receiver`]: struct.Receiver.html
+/// [`send`]: struct.CircBuf.html#method.send
+/// [`CircBuf::try_recv`]: struct.CircBuf.html#method.try_recv
+/// [`Receiver::try_recv`]: struct.Receiver.html#method.try_recv
+pub struct CircBuf<T> {
+    /// Internal data of the underlying circular buffer.
+    inner: Arc<Inner<T>>,
+
+    /// The lower bound of the rx end in the view of the sender.
+    rx_lb: Cell<usize>,
+
+    _marker: PhantomData<*mut ()>, // !Send + !Sync
+}
+
+unsafe impl<T: Send> Send for CircBuf<T> {}
+
+impl<T> CircBuf<T> {
+    /// Returns a new circular buffer with the specified capacity.
+    ///
+    /// If the capacity is not a power of two, it will be rounded up to the next one.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_circbuf::sp_inner::CircBuf;
+    ///
+    /// // The capacity will be rounded up to 1024.
+    /// let cb = CircBuf::<i32>::new(1000);
+    /// ```
+    pub fn new(cap: usize) -> CircBuf<T> {
+        let power = cap.next_power_of_two();
+        assert!(power >= cap, "capacity too large: {}", cap);
+
+        Self {
+            inner: Arc::new(Inner::new(power)),
+            rx_lb: Cell::new(0),
+            _marker: PhantomData,
+        }
+    }
+
+    /// Sends a value to the tx end of the circular buffer.
+    ///
+    /// Returns `Ok(())` if the value is successfully sent; or `Err(value)` if the circular buffer
+    /// is full and we failed to send `value`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_circbuf::sp_inner::CircBuf;
+    ///
+    /// let cb = CircBuf::new(16);
+    /// cb.send(1).unwrap();
+    /// cb.send(2).unwrap();
+    /// ```
+    pub fn send(&self, value: T) -> Result<(), T> {
+        self.send_inner(value).map_err(|(value, _, _)| value)
+    }
+
+    /// Receives a value from the rx end of the circular buffer.
+    ///
+    /// Returns `TryRecv::Data(v)` if a value `v` is received; `TryRecv::Empty` if the circular
+    /// buffer is empty; or [`TryRecv::Retry`] if another operation gets in the way while attempting
+    /// to receive data.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_circbuf::sp_inner::{CircBuf, TryRecv};
+    ///
+    /// let cb = CircBuf::new(16);
+    /// cb.send(1).unwrap();
+    /// cb.send(2).unwrap();
+    ///
+    /// // Attempt to receive a value.
+    /// //
+    /// // It should return `TryRecv::Data(v)` for a value `v`, or `Err(TryRecv::Retry)`.
+    /// assert_ne!(cb.try_recv(), TryRecv::Empty);
+    /// ```
+    ///
+    /// [`TryRecv::Retry`]: enum.TryRecv.html#variant.Retry
+    pub fn try_recv(&self) -> TryRecv<T> {
+        self.try_recv_inner().map(|v| v.0)
+    }
+
+    /// Helper function for [`CircBuf::send`] and [`DynamicCircBuf::send`].
+    ///
+    /// returns `Ok(())` if the value is successfully sent; or `Err((value, tx, cap))` if the
+    /// circular buffer is full and we failed to send `value`.
+    ///
+    /// [`CircBuf::send`]: struct.CircBuf.html#method.send
+    /// [`DynamicCircBuf::send`]: struct.DynamicCircBuf.html#method.send
+    #[inline]
+    fn send_inner(&self, value: T) -> Result<(), (T, usize, usize)> {
+        unsafe {
+            // Loads rx, tx, and buffer. The buffer doesn't have to be epoch-protected because the
+            // current thread (the worker) is the only one that grows and shrinks it.
+            let buffer = self
+                .inner
+                .buffer
+                .load(Ordering::Relaxed, epoch::unprotected());
+            let tx = self.inner.tx.load(Ordering::Relaxed);
+            let rx_lb = self.rx_lb.get();
+
+            // Calculates the length and the capacity of the circular buffer.
+            let len = tx.wrapping_sub(rx_lb) as isize;
+            let cap = buffer.deref().len();
+
+            // If the circular buffer is full, grows the underlying buffer.
+            if len >= cap as isize {
+                let rx = self.inner.rx.load(Ordering::Acquire);
+                self.rx_lb.set(rx);
+                let len = tx.wrapping_sub(rx) as isize;
+
+                if len >= cap as isize {
+                    return Err((value, tx, cap));
+                }
+            }
+
+            // Writes `value` to the right slot and increments `tx`.
+            buffer.deref().write(tx, value);
+            self.inner.tx.store(tx.wrapping_add(1), Ordering::Release);
+            Ok(())
+        }
+    }
+
+    /// Helper function for [`CircBuf::try_recv`] and [`DynamicCircBuf::try_recv`].
+    ///
+    /// The return value is similar to [`CircBuf::try_recv`], but `TryRecv::Data((value,
+    /// Some(cap)))` means `cap` is the current capacity of the buffer, and it's worth shrinking the
+    /// buffer; and `TryRecv::Data((value, None))` means it's not worth shrinking the buffer.
+    ///
+    /// [`CircBuf::try_recv`]: struct.CircBuf.html#method.try_recv
+    /// [`DynamicCircBuf::try_recv`]: struct.DynamicCircBuf.html#method.try_recv
+    #[inline]
+    fn try_recv_inner(&self) -> TryRecv<(T, Option<usize>)> {
+        // Loads tx and rx.
+        let tx = self.inner.tx.load(Ordering::Relaxed);
+        let rx = self.inner.rx.load(Ordering::Acquire);
+        let len = tx.wrapping_sub(rx) as isize;
+
+        // Is the circular buffer empty?
+        if len <= 0 {
+            self.rx_lb.set(rx);
+            return TryRecv::Empty;
+        }
+
+        // Tries incrementing rx to receive a value.
+        let rx_new = rx.wrapping_add(1);
+        if self
+            .inner
+            .rx
+            .compare_exchange_weak(rx, rx_new, Ordering::Acquire, Ordering::Acquire)
+            .map_err(|rx_cur| self.rx_lb.set(rx_cur))
+            .is_err()
+        {
+            return TryRecv::Retry;
+        }
+
+        // Sets the lower bound of rx.
+        self.rx_lb.set(rx_new);
+
+        // Loads the value at the rx end of the buffer.
+        unsafe {
+            let buffer = self
+                .inner
+                .buffer
+                .load(Ordering::Relaxed, epoch::unprotected());
+
+            // Because len > 0, we should read a valid value.
+            let value = buffer.deref().read_unchecked(rx);
+
+            // Shrinks the buffer if `len - 1` is less than one fourth of `self.min_cap`.
+            let cap = buffer.deref().len();
+            let resize = if len <= cap as isize / 4 {
+                Some(cap)
+            } else {
+                None
+            };
+
+            TryRecv::Data((ManuallyDrop::into_inner(value), resize))
+        }
+    }
+
+    /// Creates a receiver that can be shared with other threads.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_circbuf::sp_inner::{CircBuf, TryRecv};
+    /// use std::thread;
+    ///
+    /// let cb = CircBuf::new(16);
+    /// cb.send(1).unwrap();
+    /// cb.send(2).unwrap();
+    ///
+    /// let r = cb.receiver();
+    ///
+    /// thread::spawn(move || {
+    ///     assert_eq!(r.try_recv(), TryRecv::Data(1));
+    /// }).join().unwrap();
+    /// ```
+    pub fn receiver(&self) -> Receiver<T> {
+        Receiver {
+            inner: self.inner.clone(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T> fmt::Debug for CircBuf<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "CircBuf {{ ... }}")
+    }
+}
+
+/// A dynamic-sized concurrent circular buffer.
+///
+/// A circular buffer has two ends: rx and tx. Values can be [`send`]ed to the tx end and
+/// [`DynamicCircBuf::try_recv`]ed from the rx end. The rx end is special in that receivers can also
+/// receive from the rx end using [`Receiver::try_recv`] method.
+///
+/// # Receivers
+///
+/// [`CircBuf`] may create [`Receiver`]s that can be shared among multiple threads. [`Receiver`]s
+/// can only [`Receiver::try_recv`] values from the rx end of the circular buffer.
+///
+/// # Capacity
+///
+/// A buffer grows and shrinks as values are inserted and removed from it. If the internal buffer
+/// gets full, a new one twice the size of the original is allocated. Similarly, if it is less than
+/// a quarter full, a new buffer half the size of the original is allocated.
+///
+/// In order to prevent frequent resizing (reallocations may be costly), it is possible to specify a
+/// large minimum capacity for the circular buffer by calling
+/// [`DynamicCircBuf::with_min_capacity`]. This constructor will make sure that the internal buffer
+/// never shrinks below that size.
+///
+/// [`DynamicCircBuf`]: struct.DynamicCircBuf.html
+/// [`Receiver`]: struct.Receiver.html
+/// [`send`]: struct.DynamicCircBuf.html#method.send
+/// [`DynamicCircBuf::with_min_capacity`]: struct.DynamicCircBuf.html#method.with_min_capacity
+/// [`DynamicCircBuf::try_recv`]: struct.DynamicCircBuf.html#method.try_recv
+/// [`Receiver::try_recv`]: struct.Receiver.html#method.try_recv
+pub struct DynamicCircBuf<T> {
+    /// The underlying circular buffer.
+    inner: CircBuf<T>,
+
+    /// Minimum capacity of the buffer. Always a power of two.
+    min_cap: usize,
+
+    _marker: PhantomData<*mut ()>, // !Send + !Sync
+}
+
+unsafe impl<T: Send> Send for DynamicCircBuf<T> {}
+
+impl<T> DynamicCircBuf<T> {
+    /// Minimum capacity for a dynamic circular buffer.
+    const DEFAULT_MIN_CAP: usize = 1 << 4;
+
+    /// If an buffer of at least this size is retired, thread-local garbage is flushed so that it
+    /// gets deallocated as soon as possible.
+    const FLUSH_THRESHOLD_BYTES: usize = 1 << 10;
+
+    /// Returns a new circular buffer.
+    ///
+    /// The internal buffer is destructed as soon as the circular buffer and all its receivers get
+    /// dropped.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_circbuf::sp_inner::DynamicCircBuf;
+    ///
+    /// let cb = DynamicCircBuf::<i32>::new();
+    /// ```
+    #[inline]
+    pub fn new() -> DynamicCircBuf<T> {
+        Self::with_min_capacity(Self::DEFAULT_MIN_CAP)
+    }
+
+    /// Returns a new circular buffer with the specified minimum capacity.
+    ///
+    /// If the capacity is not a power of two, it will be rounded up to the next one.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_circbuf::sp_inner::DynamicCircBuf;
+    ///
+    /// // The minimum capacity will be rounded up to 1024.
+    /// let cb = DynamicCircBuf::<i32>::with_min_capacity(1000);
+    /// ```
+    pub fn with_min_capacity(cap: usize) -> DynamicCircBuf<T> {
+        let power = cap.next_power_of_two();
+        assert!(power >= cap, "capacity too large: {}", cap);
+
+        Self {
+            inner: CircBuf::new(power),
+            min_cap: power,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Sends a value to the tx end of the circular buffer.
+    ///
+    /// If the internal buffer is full, a new one twice the capacity of the current one will be
+    /// allocated.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_circbuf::sp_inner::DynamicCircBuf;
+    ///
+    /// let cb = DynamicCircBuf::new();
+    /// cb.send(1);
+    /// cb.send(2);
+    /// ```
+    pub fn send(&self, value: T) {
+        self.inner
+            .send_inner(value)
+            .unwrap_or_else(|(value, tx, cap)| unsafe {
+                // The circular buffer is full. Grows the buffer.
+                self.resize(2 * cap);
+                let buffer = self
+                    .inner
+                    .inner
+                    .buffer
+                    .load(Ordering::Relaxed, epoch::unprotected());
+
+                // Writes `value` to the right slot and increment `tx`.
+                buffer.deref().write(tx, value);
+                self.inner
+                    .inner
+                    .tx
+                    .store(tx.wrapping_add(1), Ordering::Release);
+            })
+    }
+
+    /// Receives a value from the rx end of the circular buffer.
+    ///
+    /// Returns `TryRecv::Data(v)` if a value `v` is received; `TryRecv::Empty` if the circular
+    /// buffer is empty; or [`TryRecv::Retry`] if another operation gets in the way while attempting
+    /// to receive data.
+    ///
+    /// If the internal buffer is less than a quarter full, a new buffer half the capacity of the
+    /// current one will be allocated.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_circbuf::sp_inner::{DynamicCircBuf, TryRecv};
+    ///
+    /// let cb = DynamicCircBuf::new();
+    /// cb.send(1);
+    /// cb.send(2);
+    ///
+    /// // Attempt to receive a value.
+    /// //
+    /// // It should return `TryRecv::Data(v)` for a value `v`, or `Err(TryRecv::Retry)`.
+    /// assert_ne!(cb.try_recv(), TryRecv::Empty);
+    /// ```
+    ///
+    /// [`TryRecv::Retry`]: enum.TryRecv.html#variant.Retry
+    pub fn try_recv(&self) -> TryRecv<T> {
+        self.inner.try_recv_inner().map(|(r, resize)| {
+            // Shrinks the buffer if it's worth.
+            if let Some(cap) = resize {
+                if cap > self.min_cap {
+                    unsafe {
+                        self.resize(cap / 2);
+                    }
+                }
+            }
+
+            // Returns the received value.
+            r
+        })
+    }
+
+    /// Creates a receiver that can be shared with other threads.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_circbuf::sp_inner::{DynamicCircBuf, TryRecv};
+    /// use std::thread;
+    ///
+    /// let cb = DynamicCircBuf::new();
+    /// cb.send(1);
+    /// cb.send(2);
+    ///
+    /// let r = cb.receiver();
+    ///
+    /// thread::spawn(move || {
+    ///     assert_eq!(r.try_recv(), TryRecv::Data(1));
+    /// }).join().unwrap();
+    /// ```
+    pub fn receiver(&self) -> Receiver<T> {
+        self.inner.receiver()
+    }
+
+    /// Resizes the internal buffer to the new capacity of `new_cap`.
+    #[cold]
+    unsafe fn resize(&self, new_cap: usize) {
+        let inner = &self.inner.inner;
+        // Loads rx, tx, and buffer.
+        let rx = inner.rx.load(Ordering::Relaxed);
+        let tx = inner.tx.load(Ordering::Relaxed);
+        let buffer = inner.buffer.load(Ordering::Relaxed, epoch::unprotected());
+
+        // Allocates a new buffer.
+        let new = Buffer::new(new_cap);
+
+        // Copies data from the old buffer to the new one.
+        let mut i = rx;
+        while i != tx {
+            ptr::copy_nonoverlapping(buffer.deref().get(i), new.get(i) as *mut _, 1);
+            i = i.wrapping_add(1);
+        }
+
+        // Stores the new buffer.
+        inner.buffer.store(new, Ordering::Release);
+
+        let guard = epoch::pin();
+
+        // Destroys the old buffer later.
+        guard.defer_destroy(buffer);
+
+        // Flushes the thread-local garbage in order to deallocate it as soon as possible if the
+        // buffer is very large.
+        if mem::size_of::<T>() * new_cap >= Self::FLUSH_THRESHOLD_BYTES {
+            guard.flush();
+        }
+    }
+}
+
+impl<T> Default for DynamicCircBuf<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> fmt::Debug for DynamicCircBuf<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "DynamicCircBuf {{ ... }}")
+    }
+}
+
+/// A receiver that receives values from the rx end of a circular buffer.
+///
+/// You can receive a value from the rx end using [`try_recv`]. If there are no concurrent receive
+/// operation, you can receive a value from the rx end using [`recv_exclusive`].
+///
+/// Receivers implement `Clone`, `Send`, and `Sync` so that they can be shared among multiple
+/// threads.
+///
+/// [`try_recv`]: struct.Receiver.html#method.try_recv
+/// [`recv_exclusive`]: struct.Receiver.html#method.recv_exclusive
+pub struct Receiver<T> {
+    inner: Arc<Inner<T>>,
+    _marker: PhantomData<*mut ()>, // !Send + !Sync
+}
+
+unsafe impl<T: Send> Send for Receiver<T> {}
+unsafe impl<T: Send> Sync for Receiver<T> {}
+
+impl<T> Receiver<T> {
+    /// Receives a value from the rx end of its circular buffer.
+    ///
+    /// Returns `TryRecv::Data(v)` if a value `v` is received; `TryRecv::Empty` if the circular
+    /// buffer is empty; or [`TryRecv::Retry`] if another operation gets in the way while attempting
+    /// to receive data.
+    ///
+    /// This method will not attempt to resize the internal buffer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_circbuf::sp_inner::{DynamicCircBuf, TryRecv};
+    ///
+    /// let cb = DynamicCircBuf::new();
+    /// let r = cb.receiver();
+    /// cb.send(1);
+    /// cb.send(2);
+    ///
+    /// // Attempt to receive a value, but keep retrying if we get `Retry`.
+    /// let stolen = loop {
+    ///     match r.try_recv() {
+    ///         TryRecv::Data(r) => break Some(r),
+    ///         TryRecv::Empty => break None,
+    ///         TryRecv::Retry => {}
+    ///     }
+    /// };
+    /// assert_eq!(stolen, Some(1));
+    /// ```
+    ///
+    /// [`TryRecv::Retry`]: enum.TryRecv.html#variant.Retry
+    pub fn try_recv(&self) -> TryRecv<T> {
+        // Loads rx.
+        let rx = self.inner.rx.load(Ordering::Relaxed);
+
+        // Loads the value at the rx end of the buffer.
+        let value = {
+            let guard = epoch::pin();
+            let buffer = self.inner.buffer.load_consume(&guard);
+            match unsafe { buffer.deref().read(rx) } {
+                None => return TryRecv::Empty,
+                Some(value) => value,
+            }
+        };
+
+        // Tries incrementing rx to receive the value.
+        if self
+            .inner
+            .rx
+            .compare_exchange(rx, rx.wrapping_add(1), Ordering::Release, Ordering::Relaxed)
+            .is_err()
+        {
+            return TryRecv::Retry;
+        }
+
+        TryRecv::Data(ManuallyDrop::into_inner(value))
+    }
+
+    /// Receives half the values from the rx end of its circular buffer.
+    ///
+    /// Returns `TryRecv::Data(v)` if a value `v` is received; `TryRecv::Empty` if the circular
+    /// buffer is empty; or [`TryRecv::Retry`] if another operation gets in the way while attempting
+    /// to receive data.
+    ///
+    /// This method will not attempt to resize the internal buffer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_circbuf::sp_inner::{DynamicCircBuf, TryRecv};
+    ///
+    /// let cb = DynamicCircBuf::new();
+    /// let r = cb.receiver();
+    /// cb.send(1);
+    /// cb.send(2);
+    ///
+    /// // Attempt to receive a value, but keep retrying if we get `Retry`.
+    /// let stolen = loop {
+    ///     match r.try_recv_half() {
+    ///         TryRecv::Data(r) => break Some(r),
+    ///         TryRecv::Empty => break None,
+    ///         TryRecv::Retry => {}
+    ///     }
+    /// };
+    /// assert_eq!(stolen, Some(vec![1]));
+    /// ```
+    ///
+    /// [`TryRecv::Retry`]: enum.TryRecv.html#variant.Retry
+    pub fn try_recv_half(&self) -> TryRecv<Vec<T>> {
+        // Loads rx and tx, and calculate the length of the buffer.
+        let rx = self.inner.rx.load(Ordering::Relaxed);
+        let tx = self.inner.tx.load(Ordering::Acquire);
+        let len = tx.wrapping_sub(rx) as isize;
+
+        if len <= 0 {
+            return TryRecv::Empty;
+        }
+
+        // Calculates the number of values to receive.
+        let num = ((len + 1) / 2) as usize;
+
+        // Loads the values at [rx, rx + num).
+        let values = {
+            let guard = epoch::pin();
+            let buffer = unsafe { self.inner.buffer.load_consume(&guard).deref() };
+            (0..num)
+                .map(|i| unsafe { buffer.read(rx.wrapping_add(i)) })
+                .collect::<Option<Vec<ManuallyDrop<T>>>>()
+        };
+
+        let values = match values {
+            None => {
+                // The buffer is already wrapped around, because we already acknowledged the values
+                // in the range [rx, tx) thanks to release/acquire synchronization via `tx`.
+                return TryRecv::Retry;
+            }
+            Some(values) => values,
+        };
+
+        if values.is_empty() {
+            return TryRecv::Empty;
+        }
+
+        // Tries incrementing rx to receive the values.
+        if self
+            .inner
+            .rx
+            .compare_exchange(
+                rx,
+                rx.wrapping_add(num),
+                Ordering::Release,
+                Ordering::Relaxed,
+            )
+            .is_err()
+        {
+            // We didn't receive the values.
+            return TryRecv::Retry;
+        }
+
+        TryRecv::Data(values.into_iter().map(ManuallyDrop::into_inner).collect())
+    }
+
+    /// Receives a value from the rx end of its circular buffer.
+    ///
+    /// Returns `Some(v)` if a value `v` is received; or `None` if the circular buffer is empty.
+    ///
+    /// This method will not attempt to resize the internal buffer.
+    ///
+    /// # Safety
+    ///
+    /// You have to guarantee that there are no concurrent receive operations, such as
+    /// [`CircBuf::try_recv`], [`DynamicCircBuf::try_recv`], [`Receiver::try_recv`], and
+    /// [`recv_exclusive`]. In other words, other receive operations should happen either before or
+    /// after it.
+    ///
+    /// This method will not attempt to resize the internal buffer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_circbuf::sp_inner::{DynamicCircBuf, TryRecv};
+    ///
+    /// let cb = DynamicCircBuf::new();
+    /// let r = cb.receiver();
+    /// cb.send(1);
+    /// cb.send(2);
+    ///
+    /// // Attempt to receive a value.
+    /// let stolen = unsafe { r.recv_exclusive() };
+    /// assert_eq!(stolen, Some(1));
+    /// ```
+    ///
+    /// [`TryRecv::Retry`]: enum.TryRecv.html#variant.Retry
+    /// [`CircBuf::try_recv`]: struct.CircBuf.html#method.try_recv
+    /// [`DynamicCircBuf::try_recv`]: struct.DynamicCircBuf.html#method.try_recv
+    /// [`Receiver::try_recv`]: struct.Receiver.html#method.try_recv
+    /// [`recv_exclusive`]: struct.Receiver.html#method.recv_exclusive
+    pub unsafe fn recv_exclusive(&self) -> Option<T> {
+        // Loads rx.
+        let rx = self.inner.rx.load(Ordering::Relaxed);
+
+        // Loads the value at the rx end of the buffer.
+        let value = {
+            let guard = epoch::pin();
+            let buffer = self.inner.buffer.load_consume(&guard);
+            match buffer.deref().read(rx) {
+                None => return None,
+                Some(value) => value,
+            }
+        };
+
+        // Increments rx to receive the value.
+        self.inner.rx.store(rx.wrapping_add(1), Ordering::Release);
+        Some(ManuallyDrop::into_inner(value))
+    }
+}
+
+impl<T> Clone for Receiver<T> {
+    /// Creates another receiver.
+    fn clone(&self) -> Receiver<T> {
+        Receiver {
+            inner: self.inner.clone(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T> fmt::Debug for Receiver<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Receiver {{ ... }}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate rand;
+
+    use std::sync::atomic::Ordering::SeqCst;
+    use std::sync::atomic::{AtomicBool, AtomicUsize};
+    use std::sync::{Arc, Mutex};
+    use std::thread;
+
+    use self::rand::Rng;
+
+    use epoch;
+
+    use super::{DynamicCircBuf, TryRecv};
+
+    fn retry<T, F: Fn() -> TryRecv<T>>(f: F) -> Option<T> {
+        loop {
+            match f() {
+                TryRecv::Data(r) => return Some(r),
+                TryRecv::Empty => return None,
+                TryRecv::Retry => {}
+            }
+        }
+    }
+
+    #[test]
+    fn smoke() {
+        let cb = DynamicCircBuf::new();
+        let r = cb.receiver();
+
+        assert_eq!(retry(|| cb.try_recv()), None);
+        assert_eq!(retry(|| r.try_recv()), None);
+
+        cb.send(1);
+        assert_eq!(retry(|| cb.try_recv()), Some(1));
+        assert_eq!(retry(|| cb.try_recv()), None);
+        assert_eq!(retry(|| r.try_recv()), None);
+
+        cb.send(2);
+        assert_eq!(retry(|| r.try_recv()), Some(2));
+        assert_eq!(retry(|| r.try_recv()), None);
+        assert_eq!(retry(|| cb.try_recv()), None);
+
+        cb.send(3);
+        cb.send(4);
+        cb.send(5);
+        assert_eq!(retry(|| cb.try_recv()), Some(3));
+        assert_eq!(retry(|| r.try_recv()), Some(4));
+        assert_eq!(retry(|| cb.try_recv()), Some(5));
+        assert_eq!(retry(|| cb.try_recv()), None);
+    }
+
+    #[test]
+    fn try_recv_send() {
+        const STEPS: usize = 50_000;
+
+        let cb = DynamicCircBuf::new();
+        let r = cb.receiver();
+        let t = thread::spawn(move || {
+            for i in 0..STEPS {
+                loop {
+                    if let TryRecv::Data(v) = r.try_recv() {
+                        assert_eq!(i, v);
+                        break;
+                    }
+                }
+            }
+        });
+
+        for i in 0..STEPS {
+            cb.send(i);
+        }
+        t.join().unwrap();
+    }
+
+    #[test]
+    fn try_recv_half_send() {
+        const STEPS: usize = 50_000;
+
+        let cb = DynamicCircBuf::new();
+        let r = cb.receiver();
+        let t = thread::spawn(move || {
+            let mut i = 0;
+            loop {
+                if let TryRecv::Data(v) = r.try_recv_half() {
+                    for j in v {
+                        assert_eq!(i, j);
+                        i += 1;
+                    }
+
+                    if i == STEPS {
+                        break;
+                    }
+                }
+            }
+        });
+
+        for i in 0..STEPS {
+            cb.send(i);
+        }
+        t.join().unwrap();
+    }
+
+    #[test]
+    fn stampede() {
+        const COUNT: usize = 50_000;
+
+        let cb = DynamicCircBuf::new();
+
+        for i in 0..COUNT {
+            cb.send(Box::new(i + 1));
+        }
+        let remaining = Arc::new(AtomicUsize::new(COUNT));
+
+        let threads = (0..8)
+            .map(|_| {
+                let r = cb.receiver();
+                let remaining = remaining.clone();
+
+                thread::spawn(move || {
+                    let mut last = 0;
+                    while remaining.load(SeqCst) > 0 {
+                        if let TryRecv::Data(x) = r.try_recv() {
+                            assert!(last < *x);
+                            last = *x;
+                            remaining.fetch_sub(1, SeqCst);
+                        }
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+
+        while remaining.load(SeqCst) > 0 {
+            if let TryRecv::Data(_) = cb.try_recv() {
+                remaining.fetch_sub(1, SeqCst);
+            }
+        }
+
+        for t in threads {
+            t.join().unwrap();
+        }
+    }
+
+    fn run_stress() {
+        const COUNT: usize = 50_000;
+
+        let cb = DynamicCircBuf::new();
+        let done = Arc::new(AtomicBool::new(false));
+        let hits = Arc::new(AtomicUsize::new(0));
+
+        let threads = (0..8)
+            .map(|_| {
+                let r = cb.receiver();
+                let done = done.clone();
+                let hits = hits.clone();
+
+                thread::spawn(move || {
+                    while !done.load(SeqCst) {
+                        if let TryRecv::Data(_) = r.try_recv() {
+                            hits.fetch_add(1, SeqCst);
+                        }
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let mut rng = rand::thread_rng();
+        let mut expected = 0;
+        while expected < COUNT {
+            if rng.gen_range(0, 3) == 0 {
+                if let TryRecv::Data(_) = cb.try_recv() {
+                    hits.fetch_add(1, SeqCst);
+                }
+            } else {
+                cb.send(expected);
+                expected += 1;
+            }
+        }
+
+        while hits.load(SeqCst) < COUNT {
+            if let TryRecv::Data(_) = cb.try_recv() {
+                hits.fetch_add(1, SeqCst);
+            }
+        }
+        done.store(true, SeqCst);
+
+        for t in threads {
+            t.join().unwrap();
+        }
+    }
+
+    #[test]
+    fn stress() {
+        run_stress();
+    }
+
+    #[test]
+    fn stress_pinned() {
+        let _guard = epoch::pin();
+        run_stress();
+    }
+
+    #[test]
+    fn no_starvation() {
+        const COUNT: usize = 50_000;
+
+        let cb = DynamicCircBuf::new();
+        let done = Arc::new(AtomicBool::new(false));
+
+        let (threads, hits): (Vec<_>, Vec<_>) = (0..8)
+            .map(|_| {
+                let r = cb.receiver();
+                let done = done.clone();
+                let hits = Arc::new(AtomicUsize::new(0));
+
+                let t = {
+                    let hits = hits.clone();
+                    thread::spawn(move || {
+                        while !done.load(SeqCst) {
+                            if let TryRecv::Data(_) = r.try_recv() {
+                                hits.fetch_add(1, SeqCst);
+                            }
+                        }
+                    })
+                };
+
+                (t, hits)
+            })
+            .unzip();
+
+        let mut rng = rand::thread_rng();
+        let mut my_hits = 0;
+        loop {
+            for i in 0..rng.gen_range(0, COUNT) {
+                if rng.gen_range(0, 3) == 0 && my_hits == 0 {
+                    if let TryRecv::Data(_) = cb.try_recv() {
+                        my_hits += 1;
+                    }
+                } else {
+                    cb.send(i);
+                }
+            }
+
+            if my_hits > 0 && hits.iter().all(|h| h.load(SeqCst) > 0) {
+                break;
+            }
+        }
+        done.store(true, SeqCst);
+
+        for t in threads {
+            t.join().unwrap();
+        }
+    }
+
+    #[test]
+    fn destructors() {
+        const COUNT: usize = 50_000;
+
+        struct Elem(usize, Arc<Mutex<Vec<usize>>>);
+
+        impl Drop for Elem {
+            fn drop(&mut self) {
+                self.1.lock().unwrap().push(self.0);
+            }
+        }
+
+        let cb = DynamicCircBuf::new();
+
+        let dropped = Arc::new(Mutex::new(Vec::new()));
+        let remaining = Arc::new(AtomicUsize::new(COUNT));
+        for i in 0..COUNT {
+            cb.send(Elem(i, dropped.clone()));
+        }
+
+        let threads = (0..8)
+            .map(|_| {
+                let r = cb.receiver();
+                let remaining = remaining.clone();
+
+                thread::spawn(move || {
+                    for _ in 0..1000 {
+                        if let TryRecv::Data(_) = r.try_recv() {
+                            remaining.fetch_sub(1, SeqCst);
+                        }
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for _ in 0..1000 {
+            if let TryRecv::Data(_) = cb.try_recv() {
+                remaining.fetch_sub(1, SeqCst);
+            }
+        }
+
+        for t in threads {
+            t.join().unwrap();
+        }
+
+        let rem = remaining.load(SeqCst);
+        assert!(rem > 0);
+
+        {
+            let mut v = dropped.lock().unwrap();
+            assert_eq!(v.len(), COUNT - rem);
+            v.clear();
+        }
+
+        drop(cb);
+
+        {
+            let mut v = dropped.lock().unwrap();
+            assert_eq!(v.len(), rem);
+            v.sort();
+            for pair in v.windows(2) {
+                assert_eq!(pair[0] + 1, pair[1]);
+            }
+        }
+    }
+}

--- a/crossbeam-circbuf/src/spmc.rs
+++ b/crossbeam-circbuf/src/spmc.rs
@@ -1,0 +1,383 @@
+//! Concurrent single-producer multiple-consumer queues based on circular buffer.
+
+/// Bounded SPMC queue based on fixed-sized concurrent circular buffer.
+///
+/// # Examples
+///
+/// ```
+/// use crossbeam_circbuf::TryRecv;
+/// use crossbeam_circbuf::spmc::bounded::{Queue, Receiver};
+/// use std::thread;
+///
+/// let c = Queue::<char>::new(16);
+/// let r = c.receiver();
+///
+/// c.send('a').unwrap();
+/// c.send('b').unwrap();
+/// c.send('c').unwrap();
+///
+/// assert_ne!(c.try_recv(), TryRecv::Empty); // TryRecv::Data('a') or TryRecv::Retry
+/// drop(c);
+///
+/// thread::spawn(move || {
+///     assert_ne!(r.try_recv(), TryRecv::Empty);
+///     assert_ne!(r.try_recv(), TryRecv::Empty);
+/// }).join().unwrap();
+/// ```
+pub mod bounded {
+    use crate::{sp_inner, TryRecv};
+
+    /// A bounded SPMC queue.
+    #[derive(Debug)]
+    pub struct Queue<T>(sp_inner::CircBuf<T>);
+
+    /// The receiver of a bounded SPMC queue.
+    #[derive(Debug)]
+    pub struct Receiver<T>(sp_inner::Receiver<T>);
+
+    impl<T> Queue<T> {
+        /// Creates a bounded SPMC queue with the specified capacity.
+        ///
+        /// If the capacity is not a power of two, it will be rounded up to the next one.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use crossbeam_circbuf::spmc::bounded::{Queue, Receiver};
+        ///
+        /// let c = Queue::<u32>::new(16);
+        /// ```
+        pub fn new(cap: usize) -> Self {
+            Queue {
+                0: sp_inner::CircBuf::new(cap),
+            }
+        }
+
+        /// Attempts to send a value to the queue.
+        ///
+        /// Returns `Ok(())` if the value is successfully sent; or `Err(value)` if the buffer is
+        /// full and we failed to send `value`.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use crossbeam_circbuf::spmc::bounded::{Queue, Receiver};
+        ///
+        /// let c = Queue::<u32>::new(16);
+        /// c.send(1).unwrap();
+        /// c.send(2).unwrap();
+        /// ```
+        pub fn send(&self, value: T) -> Result<(), T> {
+            self.0.send(value)
+        }
+
+        /// Receives a value from the queue.
+        ///
+        /// Returns `TryRecv::Data(v)` if a value `v` is received; `TryRecv::Empty` if the circular
+        /// buffer is empty; or [`TryRecv::Retry`] if another operation gets in the way while
+        /// attempting to receive data.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use crossbeam_circbuf::TryRecv;
+        /// use crossbeam_circbuf::spmc::bounded::{Queue, Receiver};
+        ///
+        /// let c = Queue::<u32>::new(16);
+        /// c.send(1).unwrap();
+        /// c.send(2).unwrap();
+        ///
+        /// assert_ne!(c.try_recv(), TryRecv::Empty);
+        /// assert_ne!(c.try_recv(), TryRecv::Empty);
+        /// ```
+        ///
+        /// [`TryRecv::Data`]: enum.TryRecv.html#variant.Data
+        /// [`TryRecv::Empty`]: enum.TryRecv.html#variant.Empty
+        /// [`TryRecv::Retry`]: enum.TryRecv.html#variant.Retry
+        pub fn try_recv(&self) -> TryRecv<T> {
+            self.0.try_recv()
+        }
+
+        /// Creates a receiver for the queue.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use crossbeam_circbuf::spmc::bounded::{Queue, Receiver};
+        ///
+        /// let c = Queue::<u32>::new(16);
+        /// let r = c.receiver();
+        /// ```
+        pub fn receiver(&self) -> Receiver<T> {
+            Receiver {
+                0: self.0.receiver(),
+            }
+        }
+    }
+
+    impl<T> Receiver<T> {
+        /// Receives a value from the queue.
+        ///
+        /// Returns `TryRecv::Data(v)` if a value `v` is received; `TryRecv::Empty` if the circular
+        /// buffer is empty; or [`TryRecv::Retry`] if another operation gets in the way while
+        /// attempting to receive data.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use crossbeam_circbuf::TryRecv;
+        /// use crossbeam_circbuf::spmc::bounded::{Queue, Receiver};
+        ///
+        /// let c = Queue::<u32>::new(16);
+        /// c.send(1).unwrap();
+        /// c.send(2).unwrap();
+        ///
+        /// let r = c.receiver();
+        /// assert_ne!(r.try_recv(), TryRecv::Empty);
+        /// assert_ne!(r.try_recv(), TryRecv::Empty);
+        /// ```
+        ///
+        /// [`TryRecv::Data`]: enum.TryRecv.html#variant.Data
+        /// [`TryRecv::Empty`]: enum.TryRecv.html#variant.Empty
+        /// [`TryRecv::Retry`]: enum.TryRecv.html#variant.Retry
+        pub fn try_recv(&self) -> TryRecv<T> {
+            self.0.try_recv()
+        }
+
+        /// Receives half the values from the queue.
+        ///
+        /// Returns `TryRecv::Data(v)` if a value `v` is received; `TryRecv::Empty` if the circular
+        /// buffer is empty; or [`TryRecv::Retry`] if another operation gets in the way while
+        /// attempting to receive data.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use crossbeam_circbuf::TryRecv;
+        /// use crossbeam_circbuf::spmc::bounded::{Queue, Receiver};
+        ///
+        /// let c = Queue::<u32>::new(16);
+        /// c.send(1).unwrap();
+        /// c.send(2).unwrap();
+        ///
+        /// let r = c.receiver();
+        /// assert_eq!(r.try_recv_half(), TryRecv::Data(vec![1]));
+        /// assert_eq!(r.try_recv_half(), TryRecv::Data(vec![2]));
+        /// ```
+        ///
+        /// [`TryRecv::Data`]: enum.TryRecv.html#variant.Data
+        /// [`TryRecv::Empty`]: enum.TryRecv.html#variant.Empty
+        /// [`TryRecv::Retry`]: enum.TryRecv.html#variant.Retry
+        pub fn try_recv_half(&self) -> TryRecv<Vec<T>> {
+            self.0.try_recv_half()
+        }
+    }
+
+    impl<T> Clone for Receiver<T> {
+        /// Creates another receiver.
+        fn clone(&self) -> Self {
+            Self { 0: self.0.clone() }
+        }
+    }
+}
+
+/// Unbounded SPMC queue based on dynamically growable and shrinkable concurrent circular buffer.
+///
+/// # Examples
+///
+/// ```
+/// use crossbeam_circbuf::TryRecv;
+/// use crossbeam_circbuf::spmc::unbounded::{Queue, Receiver};
+/// use std::thread;
+///
+/// let c = Queue::<char>::new();
+/// let r = c.receiver();
+///
+/// c.send('a');
+/// c.send('b');
+/// c.send('c');
+///
+/// assert_ne!(c.try_recv(), TryRecv::Empty); // TryRecv::Data('a') or TryRecv::Retry
+/// drop(c);
+///
+/// thread::spawn(move || {
+///     assert_ne!(r.try_recv(), TryRecv::Empty);
+///     assert_ne!(r.try_recv(), TryRecv::Empty);
+/// }).join().unwrap();
+/// ```
+pub mod unbounded {
+    use crate::sp_inner;
+    use TryRecv;
+
+    /// an unbounded SPMC queue.
+    #[derive(Debug)]
+    pub struct Queue<T>(sp_inner::DynamicCircBuf<T>);
+
+    /// The receiver of an unbounded SPMC queue.
+    #[derive(Debug)]
+    pub struct Receiver<T>(sp_inner::Receiver<T>);
+
+    impl<T> Queue<T> {
+        /// Creates an unbounded SPMC queue.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use crossbeam_circbuf::spmc::unbounded::{Queue, Receiver};
+        ///
+        /// let c = Queue::<u32>::new();
+        /// ```
+        pub fn new() -> Self {
+            Queue {
+                0: sp_inner::DynamicCircBuf::new(),
+            }
+        }
+
+        /// Creates an unbounded SPMC queue with the specified minimal capacity.
+        ///
+        /// If the capacity is not a power of two, it will be rounded up to the next one.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use crossbeam_circbuf::spmc::unbounded::{Queue, Receiver};
+        ///
+        /// // The minimum capacity will be rounded up to 1024.
+        /// let c = Queue::<u32>::with_min_capacity(1000);
+        /// ```
+        pub fn with_min_capacity(min_cap: usize) -> Self {
+            Queue {
+                0: sp_inner::DynamicCircBuf::with_min_capacity(min_cap),
+            }
+        }
+
+        /// Attempts to send a value to the queue.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use crossbeam_circbuf::spmc::unbounded::{Queue, Receiver};
+        ///
+        /// let c = Queue::<u32>::new();
+        /// c.send(1);
+        /// c.send(2);
+        /// ```
+        pub fn send(&self, value: T) {
+            self.0.send(value)
+        }
+
+        /// Receives a value from the queue.
+        ///
+        /// Returns `TryRecv::Data(v)` if a value `v` is received; `TryRecv::Empty` if the circular
+        /// buffer is empty; or [`TryRecv::Retry`] if another operation gets in the way while
+        /// attempting to receive data.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use crossbeam_circbuf::TryRecv;
+        /// use crossbeam_circbuf::spmc::unbounded::{Queue, Receiver};
+        ///
+        /// let c = Queue::<u32>::new();
+        /// c.send(1);
+        /// c.send(2);
+        ///
+        /// assert_ne!(c.try_recv(), TryRecv::Empty);
+        /// assert_ne!(c.try_recv(), TryRecv::Empty);
+        /// ```
+        ///
+        /// [`TryRecv::Data`]: enum.TryRecv.html#variant.Data
+        /// [`TryRecv::Empty`]: enum.TryRecv.html#variant.Empty
+        /// [`TryRecv::Retry`]: enum.TryRecv.html#variant.Retry
+        pub fn try_recv(&self) -> TryRecv<T> {
+            self.0.try_recv()
+        }
+
+        /// Creates a receiver for the queue.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use crossbeam_circbuf::spmc::unbounded::{Queue, Receiver};
+        ///
+        /// let c = Queue::<u32>::new();
+        /// let r = c.receiver();
+        /// ```
+        pub fn receiver(&self) -> Receiver<T> {
+            Receiver {
+                0: self.0.receiver(),
+            }
+        }
+    }
+
+    impl<T> Default for Queue<T> {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl<T> Receiver<T> {
+        /// Receives a value from the queue.
+        ///
+        /// Returns `TryRecv::Data(v)` if a value `v` is received; `TryRecv::Empty` if the circular
+        /// buffer is empty; or [`TryRecv::Retry`] if another operation gets in the way while
+        /// attempting to receive data.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use crossbeam_circbuf::TryRecv;
+        /// use crossbeam_circbuf::spmc::unbounded::{Queue, Receiver};
+        ///
+        /// let c = Queue::<u32>::new();
+        /// c.send(1);
+        /// c.send(2);
+        ///
+        /// let r = c.receiver();
+        /// assert_ne!(r.try_recv(), TryRecv::Empty);
+        /// assert_ne!(r.try_recv(), TryRecv::Empty);
+        /// ```
+        ///
+        /// [`TryRecv::Data`]: enum.TryRecv.html#variant.Data
+        /// [`TryRecv::Empty`]: enum.TryRecv.html#variant.Empty
+        /// [`TryRecv::Retry`]: enum.TryRecv.html#variant.Retry
+        pub fn try_recv(&self) -> TryRecv<T> {
+            self.0.try_recv()
+        }
+
+        /// Receives half the values from the queue.
+        ///
+        /// Returns `TryRecv::Data(v)` if a value `v` is received; `TryRecv::Empty` if the circular
+        /// buffer is empty; or [`TryRecv::Retry`] if another operation gets in the way while
+        /// attempting to receive data.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use crossbeam_circbuf::TryRecv;
+        /// use crossbeam_circbuf::spmc::unbounded::{Queue, Receiver};
+        ///
+        /// let c = Queue::<u32>::new();
+        /// c.send(1);
+        /// c.send(2);
+        ///
+        /// let r = c.receiver();
+        /// assert_eq!(r.try_recv_half(), TryRecv::Data(vec![1]));
+        /// assert_eq!(r.try_recv_half(), TryRecv::Data(vec![2]));
+        /// ```
+        ///
+        /// [`TryRecv::Data`]: enum.TryRecv.html#variant.Data
+        /// [`TryRecv::Empty`]: enum.TryRecv.html#variant.Empty
+        /// [`TryRecv::Retry`]: enum.TryRecv.html#variant.Retry
+        pub fn try_recv_half(&self) -> TryRecv<Vec<T>> {
+            self.0.try_recv_half()
+        }
+    }
+
+    impl<T> Clone for Receiver<T> {
+        /// Creates another receiver.
+        fn clone(&self) -> Self {
+            Self { 0: self.0.clone() }
+        }
+    }
+}

--- a/crossbeam-circbuf/src/spsc.rs
+++ b/crossbeam-circbuf/src/spsc.rs
@@ -1,0 +1,212 @@
+//! Concurrent single-producer single-consumer queues based on circular buffer.
+
+/// Bounded SPSC queue based on fixed-sized concurrent circular buffer.
+///
+/// # Examples
+///
+/// ```
+/// use crossbeam_circbuf::spsc::bounded as spsc;
+/// use std::thread;
+///
+/// let (tx, rx) = spsc::new::<char>(16);
+///
+/// tx.send('a').unwrap();
+/// tx.send('b').unwrap();
+/// tx.send('c').unwrap();
+///
+/// assert_eq!(rx.recv(), Some('a'));
+/// drop(tx);
+///
+/// thread::spawn(move || {
+///     assert_eq!(rx.recv(), Some('b'));
+///     assert_eq!(rx.recv(), Some('c'));
+/// }).join().unwrap();
+/// ```
+pub mod bounded {
+    use crate::sp_inner;
+    pub use TryRecv;
+
+    /// The sender of a bounded SPSC queue.
+    #[derive(Debug)]
+    pub struct Sender<T>(sp_inner::CircBuf<T>);
+
+    /// The receiver of a bounded SPSC queue.
+    #[derive(Debug)]
+    pub struct Receiver<T>(sp_inner::Receiver<T>);
+
+    unsafe impl<T> Send for Receiver<T> {}
+
+    /// Creates a bounded SPSC queue with the specified capacity, and returns its sender and
+    /// receiver.
+    ///
+    /// If the capacity is not a power of two, it will be rounded up to the next one.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_circbuf::spsc::bounded as spsc;
+    ///
+    /// let (tx, rx) = spsc::new::<u32>(16);
+    /// ```
+    pub fn new<T>(cap: usize) -> (Sender<T>, Receiver<T>) {
+        let circbuf = sp_inner::CircBuf::new(cap);
+        let receiver = circbuf.receiver();
+        let sender = Sender { 0: circbuf };
+        let receiver = Receiver { 0: receiver };
+        (sender, receiver)
+    }
+
+    impl<T> Sender<T> {
+        /// Attempts to send a value to the queue.
+        ///
+        /// Returns `Ok(())` if the value is successfully sent; or `Err(value)` if the buffer is
+        /// full and we failed to send `value`.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use crossbeam_circbuf::spsc::bounded as spsc;
+        ///
+        /// let (tx, rx) = spsc::new::<u32>(16);
+        /// tx.send(1).unwrap();
+        /// tx.send(2).unwrap();
+        /// ```
+        pub fn send(&self, value: T) -> Result<(), T> {
+            self.0.send(value)
+        }
+    }
+
+    impl<T> Receiver<T> {
+        /// Receives a value from the queue.
+        ///
+        /// Returns `Some(v)` if `v` is received; or `None` if the queue is empty.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use crossbeam_circbuf::spsc::bounded as spsc;
+        ///
+        /// let (tx, rx) = spsc::new::<u32>(16);
+        /// tx.send(32).unwrap();
+        /// assert_eq!(rx.recv(), Some(32));
+        /// ```
+        pub fn recv(&self) -> Option<T> {
+            // I'm the only receiver because (1) `Sender` doesn't receive, and (2) `Receiver` is not
+            // `Sync`.
+            unsafe { self.0.recv_exclusive() }
+        }
+    }
+}
+
+/// Unbounded SPSC queue based on dynamically growable and shrinkable concurrent circular buffer.
+///
+/// # Examples
+///
+/// ```
+/// use crossbeam_circbuf::spsc::unbounded as spsc;
+/// use std::thread;
+///
+/// let (tx, rx) = spsc::new::<char>();
+///
+/// tx.send('a');
+/// tx.send('b');
+/// tx.send('c');
+///
+/// assert_eq!(rx.recv(), Some('a'));
+/// drop(tx);
+///
+/// thread::spawn(move || {
+///     assert_eq!(rx.recv(), Some('b'));
+///     assert_eq!(rx.recv(), Some('c'));
+/// }).join().unwrap();
+/// ```
+pub mod unbounded {
+    use crate::sp_inner;
+    pub use TryRecv;
+
+    /// The sender of an unbounded SPSC queue.
+    #[derive(Debug)]
+    pub struct Sender<T>(sp_inner::DynamicCircBuf<T>);
+
+    /// The receiver of an unbounded SPSC queue.
+    #[derive(Debug)]
+    pub struct Receiver<T>(sp_inner::Receiver<T>);
+
+    unsafe impl<T> Send for Receiver<T> {}
+
+    /// Creates an unbounded SPSC queue, and returns its sender and receiver.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_circbuf::spsc::unbounded as spsc;
+    ///
+    /// let (tx, rx) = spsc::new::<u32>();
+    /// ```
+    pub fn new<T>() -> (Sender<T>, Receiver<T>) {
+        let circbuf = sp_inner::DynamicCircBuf::new();
+        let receiver = circbuf.receiver();
+        let sender = Sender { 0: circbuf };
+        let receiver = Receiver { 0: receiver };
+        (sender, receiver)
+    }
+
+    /// Creates an unbounded SPSC queue with the specified minimal capacity, and returns its sender and
+    /// receiver.
+    ///
+    /// If the capacity is not a power of two, it will be rounded up to the next one.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_circbuf::spsc::unbounded as spsc;
+    ///
+    /// // The minimum capacity will be rounded up to 1024.
+    /// let (tx, rx) = spsc::with_min_capacity::<u32>(1000);
+    /// ```
+    pub fn with_min_capacity<T>(min_cap: usize) -> (Sender<T>, Receiver<T>) {
+        let circbuf = sp_inner::DynamicCircBuf::with_min_capacity(min_cap);
+        let receiver = circbuf.receiver();
+        let sender = Sender { 0: circbuf };
+        let receiver = Receiver { 0: receiver };
+        (sender, receiver)
+    }
+
+    impl<T> Sender<T> {
+        /// Attempts to send a value to the queue.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use crossbeam_circbuf::spsc::unbounded as spsc;
+        ///
+        /// let (tx, rx) = spsc::new::<u32>();
+        /// tx.send(1);
+        /// tx.send(2);
+        /// ```
+        pub fn send(&self, value: T) {
+            self.0.send(value)
+        }
+    }
+
+    impl<T> Receiver<T> {
+        /// Receives a value from the queue.
+        ///
+        /// Returns `Some(v)` if `v` is received; or `None` if the queue is empty.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use crossbeam_circbuf::spsc::unbounded as spsc;
+        ///
+        /// let (tx, rx) = spsc::new::<u32>();
+        /// tx.send(32);
+        /// assert_eq!(rx.recv(), Some(32));
+        /// ```
+        pub fn recv(&self) -> Option<T> {
+            // I'm the only receiver because (1) `Sender` doesn't receive, and (2) `Receiver` is not
+            // `Sync`.
+            unsafe { self.0.recv_exclusive() }
+        }
+    }
+}

--- a/crossbeam-circbuf/src/spsc.rs
+++ b/crossbeam-circbuf/src/spsc.rs
@@ -24,7 +24,7 @@
 /// ```
 pub mod bounded {
     use crate::sp_inner;
-    pub use TryRecv;
+    pub use crate::TryRecv;
 
     /// The sender of a bounded SPSC queue.
     #[derive(Debug)]
@@ -122,7 +122,7 @@ pub mod bounded {
 /// ```
 pub mod unbounded {
     use crate::sp_inner;
-    pub use TryRecv;
+    pub use crate::TryRecv;
 
     /// The sender of an unbounded SPSC queue.
     #[derive(Debug)]

--- a/crossbeam-circbuf/src/try_recv.rs
+++ b/crossbeam-circbuf/src/try_recv.rs
@@ -1,0 +1,21 @@
+/// The return type for `try_recv` methods.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TryRecv<T> {
+    /// Received a value.
+    Data(T),
+    /// Not received a value because the buffer is empty.
+    Empty,
+    /// Lost the race to a concurrent operation. Try again.
+    Retry,
+}
+
+impl<T> TryRecv<T> {
+    /// Applies a function to the content of `TryRecv::Data`.
+    pub fn map<U, F: FnOnce(T) -> U>(self, f: F) -> TryRecv<U> {
+        match self {
+            TryRecv::Data(v) => TryRecv::Data(f(v)),
+            TryRecv::Empty => TryRecv::Empty,
+            TryRecv::Retry => TryRecv::Retry,
+        }
+    }
+}

--- a/crossbeam-circbuf/tests/mpmc_bounded.rs
+++ b/crossbeam-circbuf/tests/mpmc_bounded.rs
@@ -1,0 +1,249 @@
+extern crate crossbeam_circbuf as circbuf;
+extern crate crossbeam_utils as utils;
+extern crate rand;
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use circbuf::mpmc::bounded::Queue;
+use rand::{thread_rng, Rng};
+
+#[test]
+fn smoke() {
+    let q = Queue::new(1);
+
+    q.send(7).unwrap();
+    assert_eq!(q.recv(), Some(7));
+
+    q.send(8).unwrap();
+    assert_eq!(q.recv(), Some(8));
+    assert_eq!(q.recv(), None);
+}
+
+#[test]
+fn cap() {
+    for i in 1..10 {
+        let q = Queue::<i32>::new(i);
+        assert_eq!(q.cap(), i);
+    }
+}
+
+#[test]
+fn len_empty_full() {
+    let q = Queue::new(2);
+
+    assert_eq!(q.len(), 0);
+    assert_eq!(q.is_empty(), true);
+    assert_eq!(q.is_full(), false);
+
+    q.send(()).unwrap();
+
+    assert_eq!(q.len(), 1);
+    assert_eq!(q.is_empty(), false);
+    assert_eq!(q.is_full(), false);
+
+    q.send(()).unwrap();
+
+    assert_eq!(q.len(), 2);
+    assert_eq!(q.is_empty(), false);
+    assert_eq!(q.is_full(), true);
+
+    println!("before: {:?}", q);
+    q.recv().unwrap();
+    println!("before: {:?}", q);
+
+    assert_eq!(q.len(), 1);
+    assert_eq!(q.is_empty(), false);
+    assert_eq!(q.is_full(), false);
+}
+
+#[test]
+fn len() {
+    const COUNT: usize = 25_000;
+    const CAP: usize = 1000;
+
+    let q = Queue::new(CAP);
+    assert_eq!(q.len(), 0);
+
+    for _ in 0..CAP / 10 {
+        for i in 0..50 {
+            q.send(i).unwrap();
+            assert_eq!(q.len(), i + 1);
+        }
+
+        for i in 0..50 {
+            q.recv().unwrap();
+            assert_eq!(q.len(), 50 - i - 1);
+        }
+    }
+    assert_eq!(q.len(), 0);
+
+    for i in 0..CAP {
+        q.send(i).unwrap();
+        assert_eq!(q.len(), i + 1);
+    }
+
+    for _ in 0..CAP {
+        q.recv().unwrap();
+    }
+    assert_eq!(q.len(), 0);
+
+    utils::thread::scope(|scope| {
+        scope.spawn(|_| {
+            for i in 0..COUNT {
+                loop {
+                    if let Some(x) = q.recv() {
+                        assert_eq!(x, i);
+                        break;
+                    }
+                }
+                let len = q.len();
+                assert!(len <= CAP);
+            }
+        });
+
+        scope.spawn(|_| {
+            for i in 0..COUNT {
+                while q.send(i).is_err() {}
+                let len = q.len();
+                assert!(len <= CAP);
+            }
+        });
+    })
+    .unwrap();
+    assert_eq!(q.len(), 0);
+}
+
+#[test]
+fn spsc() {
+    const COUNT: usize = 100_000;
+
+    let q = Queue::new(3);
+
+    utils::thread::scope(|scope| {
+        scope.spawn(|_| {
+            for i in 0..COUNT {
+                loop {
+                    if let Some(x) = q.recv() {
+                        assert_eq!(x, i);
+                        break;
+                    }
+                }
+            }
+            assert_eq!(q.recv(), None);
+        });
+
+        scope.spawn(|_| {
+            for i in 0..COUNT {
+                while q.send(i).is_err() {}
+            }
+        });
+    })
+    .unwrap();
+}
+
+#[test]
+fn mpmc() {
+    const COUNT: usize = 25_000;
+    const THREADS: usize = 4;
+
+    let q = Queue::<usize>::new(3);
+    let v = (0..COUNT).map(|_| AtomicUsize::new(0)).collect::<Vec<_>>();
+
+    utils::thread::scope(|scope| {
+        for _ in 0..THREADS {
+            scope.spawn(|_| {
+                for _ in 0..COUNT {
+                    let n = loop {
+                        if let Some(x) = q.recv() {
+                            break x;
+                        }
+                    };
+                    v[n].fetch_add(1, Ordering::SeqCst);
+                }
+            });
+        }
+        for _ in 0..THREADS {
+            scope.spawn(|_| {
+                for i in 0..COUNT {
+                    while q.send(i).is_err() {}
+                }
+            });
+        }
+    })
+    .unwrap();
+
+    for c in v {
+        assert_eq!(c.load(Ordering::SeqCst), THREADS);
+    }
+}
+
+#[test]
+fn drops() {
+    const RUNS: usize = 100;
+
+    static DROPS: AtomicUsize = AtomicUsize::new(0);
+
+    #[derive(Debug, PartialEq)]
+    struct DropCounter;
+
+    impl Drop for DropCounter {
+        fn drop(&mut self) {
+            DROPS.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    let mut rng = thread_rng();
+
+    for _ in 0..RUNS {
+        let steps = rng.gen_range(0, 10_000);
+        let additional = rng.gen_range(0, 50);
+
+        DROPS.store(0, Ordering::SeqCst);
+        let q = Queue::new(50);
+
+        utils::thread::scope(|scope| {
+            scope.spawn(|_| {
+                for _ in 0..steps {
+                    while q.recv().is_none() {}
+                }
+            });
+
+            scope.spawn(|_| {
+                for _ in 0..steps {
+                    while q.send(DropCounter).is_err() {
+                        DROPS.fetch_sub(1, Ordering::SeqCst);
+                    }
+                }
+            });
+        })
+        .unwrap();
+
+        for _ in 0..additional {
+            q.send(DropCounter).unwrap();
+        }
+
+        assert_eq!(DROPS.load(Ordering::SeqCst), steps);
+        drop(q);
+        assert_eq!(DROPS.load(Ordering::SeqCst), steps + additional);
+    }
+}
+
+#[test]
+fn linearizable() {
+    const COUNT: usize = 25_000;
+    const THREADS: usize = 4;
+
+    let q = Queue::new(THREADS);
+
+    utils::thread::scope(|scope| {
+        for _ in 0..THREADS {
+            scope.spawn(|_| {
+                for _ in 0..COUNT {
+                    while q.send(0).is_err() {}
+                    q.recv().unwrap();
+                }
+            });
+        }
+    })
+    .unwrap();
+}

--- a/crossbeam-epoch/src/guard.rs
+++ b/crossbeam-epoch/src/guard.rs
@@ -3,7 +3,7 @@ use core::mem;
 
 use scopeguard::defer;
 
-use crate::atomic::Shared;
+use crate::atomic::{Pointable, Shared};
 use crate::collector::Collector;
 use crate::deferred::Deferred;
 use crate::internal::Local;
@@ -270,7 +270,7 @@ impl Guard {
     /// ```
     ///
     /// [`unprotected`]: fn.unprotected.html
-    pub unsafe fn defer_destroy<T>(&self, ptr: Shared<'_, T>) {
+    pub unsafe fn defer_destroy<T: ?Sized + Pointable>(&self, ptr: Shared<'_, T>) {
         self.defer_unchecked(move || ptr.into_owned());
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,12 @@ cfg_if! {
         #[doc(inline)]
         pub use crate::_deque::crossbeam_deque as deque;
 
+        mod _circbuf {
+            pub use crossbeam_circbuf;
+        }
+        #[doc(inline)]
+        pub use crate::_circbuf::crossbeam_circbuf as circbuf;
+
         mod _channel {
             pub use crossbeam_channel;
         }


### PR DESCRIPTION
I'm proposing to introduce `crossbeam-circbuf`, which implements bounded/unbounded SPSC/SPMC queues based on circular buffer.  Bounded queues are implemented with fixed-sized circular buffer.  Unbounded queues are implemented with dynamically growable/shrinkable circular buffer.

Currently I'm not sure how performant this crate is.  A few benchmark will be helpful in evaluating the performance.  I'm thinking of re-purposing the benchmark used in `crossbeam-channel`.

The implementation is sub-optimal in that it has an unnecessary indirection when accessing the underlying buffer.  In order to remove the indireciton we need to [support DST](#209), which is not yet implemented in Crossbeam, though.

We discussed to introduce `crossbeam-circbuf` in [another PR](https://github.com/crossbeam-rs/crossbeam/pull/189), and there we also discussed tentative crate organizations.  Speaking of organizations, I think `crossbeam-deque` and `crossbeam-arrayqueue` can also be incorporated in this crate for the following reasons:

- All of them share [the same buffer struct](https://github.com/jeehoonkang/crossbeam/blob/circbuf/crossbeam-circbuf/src/buffer.rs).

- `crossbeam-arrayqueue` is actually bounded MPMC queue based on circular buffer.

- `crossbeam-deque` is actually a slight variant of unbounded SPMC queue based on circular buffer.