### PR TITLE
deque: add MPMC queue and new batched steal methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,14 @@ matrix:
   include:
 
   # Test crates on their minimum Rust versions.
-  - rust: 1.26.0
-    name: "crossbeam on 1.26.0"
+  - rust: 1.28.0
+    name: "crossbeam on 1.28.0"
     script: ./ci/crossbeam.sh
   - rust: 1.26.0
     name: "crossbeam-channel on 1.26.0"
     script: ./ci/crossbeam-channel.sh
-  - rust: 1.26.0
-    name: "crossbeam-deque on 1.26.0"
+  - rust: 1.28.0
+    name: "crossbeam-deque on 1.28.0"
     script: ./ci/crossbeam-deque.sh
   - rust: 1.26.0
     name: "crossbeam-epoch on 1.26.0"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ https://github.com/crossbeam-rs/crossbeam)
 https://crates.io/crates/crossbeam)
 [![Documentation](https://docs.rs/crossbeam/badge.svg)](
 https://docs.rs/crossbeam)
-[![Rust 1.26+](https://img.shields.io/badge/rust-1.26+-lightgray.svg)](
+[![Rust 1.28+](https://img.shields.io/badge/rust-1.28+-lightgray.svg)](
 https://www.rust-lang.org)
 
 This crate provides a set of tools for concurrent programming:
@@ -73,7 +73,7 @@ extern crate crossbeam;
 
 ## Compatibility
 
-The minimum supported Rust version is 1.26.
+The minimum supported Rust version is 1.28.
 
 Features available in `no_std` environments:
 

--- a/crossbeam-channel/src/select.rs
+++ b/crossbeam-channel/src/select.rs
@@ -460,7 +460,8 @@ fn run_ready(
 /// * Wait for an operation to become ready with [`try_ready`], [`ready`], or [`ready_timeout`]. If
 ///   successful, we may attempt to execute the operation, but are not obliged to. In fact, it's
 ///   possible for another thread to make the operation not ready just before we try executing it,
-///   so it's wise to use a retry loop.
+///   so it's wise to use a retry loop. However, note that these methods might return with success
+///   spuriously, so it's a good idea to always double check if the operation is really ready.
 ///
 /// # Examples
 ///
@@ -777,8 +778,8 @@ impl<'a> Select<'a> {
     /// An operation is considered to be ready if it doesn't have to block. Note that it is ready
     /// even when it will simply return an error because the channel is disconnected.
     ///
-    /// Note that this method might return with success spuriously, so it's a good idea to double
-    /// check if the operation is really ready.
+    /// Note that this method might return with success spuriously, so it's a good idea to always
+    /// double check if the operation is really ready.
     ///
     /// # Examples
     ///
@@ -819,8 +820,8 @@ impl<'a> Select<'a> {
     /// An operation is considered to be ready if it doesn't have to block. Note that it is ready
     /// even when it will simply return an error because the channel is disconnected.
     ///
-    /// Note that this method might return with success spuriously, so it's a good idea to double
-    /// check if the operation is really ready.
+    /// Note that this method might return with success spuriously, so it's a good idea to always
+    /// double check if the operation is really ready.
     ///
     /// # Panics
     ///

--- a/crossbeam-channel/tests/ready.rs
+++ b/crossbeam-channel/tests/ready.rs
@@ -793,20 +793,28 @@ fn fairness2() {
             sel.recv(&r1);
             sel.recv(&r2);
             sel.recv(&r3);
-            match sel.ready() {
-                0 => {
-                    r1.try_recv().unwrap();
-                    hits[0].set(hits[0].get() + 1);
+            loop {
+                match sel.ready() {
+                    0 => {
+                        if r1.try_recv().is_ok() {
+                            hits[0].set(hits[0].get() + 1);
+                            break;
+                        }
+                    }
+                    1 => {
+                        if r2.try_recv().is_ok() {
+                            hits[1].set(hits[1].get() + 1);
+                            break;
+                        }
+                    }
+                    2 => {
+                        if r3.try_recv().is_ok() {
+                            hits[2].set(hits[2].get() + 1);
+                            break;
+                        }
+                    }
+                    _ => unreachable!(),
                 }
-                1 => {
-                    r2.try_recv().unwrap();
-                    hits[1].set(hits[1].get() + 1);
-                }
-                2 => {
-                    r3.try_recv().unwrap();
-                    hits[2].set(hits[2].get() + 1);
-                }
-                _ => unreachable!(),
             }
         }
         assert!(hits.iter().all(|x| x.get() >= COUNT / hits.len() / 10));

--- a/crossbeam-deque/README.md
+++ b/crossbeam-deque/README.md
@@ -8,7 +8,7 @@ https://github.com/crossbeam-rs/crossbeam-deque)
 https://crates.io/crates/crossbeam-deque)
 [![Documentation](https://docs.rs/crossbeam-deque/badge.svg)](
 https://docs.rs/crossbeam-deque)
-[![Rust 1.26+](https://img.shields.io/badge/rust-1.26+-lightgray.svg)](
+[![Rust 1.28+](https://img.shields.io/badge/rust-1.28+-lightgray.svg)](
 https://www.rust-lang.org)
 
 This crate provides work-stealing deques, which are primarily intended for
@@ -31,7 +31,7 @@ extern crate crossbeam_deque;
 
 ## Compatibility
 
-The minimum supported Rust version is 1.26.
+The minimum supported Rust version is 1.28.
 
 This crate does not work in `no_std` environments.
 

--- a/crossbeam-deque/src/lib.rs
+++ b/crossbeam-deque/src/lib.rs
@@ -88,11 +88,30 @@ const MAX_BATCH: usize = 128;
 /// deallocated as soon as possible.
 const FLUSH_THRESHOLD_BYTES: usize = 1 << 10;
 
+/// TODO
 #[must_use]
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum Racy<T> {
+    /// TODO
     Done(T),
+
+    /// TODO
     Retry,
+}
+
+impl<T> Racy<T> {
+    /// TODO
+    pub fn spin<F>(mut f: F) -> T
+    where
+        F: FnMut() -> Racy<T>,
+    {
+        loop {
+            match f() {
+                Racy::Done(v) => return v,
+                Racy::Retry => {}
+            }
+        }
+    }
 }
 
 /// A buffer that holds elements in a deque.
@@ -317,6 +336,7 @@ impl<T> Worker<T> {
         }
     }
 
+    /// TODO
     pub fn stealer(&self) -> Stealer<T> {
         Stealer {
             inner: self.inner.clone(),

--- a/crossbeam-deque/tests/fifo.rs
+++ b/crossbeam-deque/tests/fifo.rs
@@ -1,14 +1,15 @@
 extern crate crossbeam_deque as deque;
+extern crate crossbeam_utils as utils;
 extern crate rand;
 
 use std::sync::atomic::Ordering::SeqCst;
 use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::sync::{Arc, Mutex};
-use std::thread;
 
 use deque::Steal::{Empty, Success};
 use deque::Worker;
 use rand::Rng;
+use utils::thread::scope;
 
 #[test]
 fn smoke() {
@@ -73,26 +74,30 @@ fn is_empty() {
 }
 
 #[test]
-fn steal_push() {
+fn spsc() {
     const STEPS: usize = 50_000;
 
     let w = Worker::new_fifo();
     let s = w.stealer();
-    let t = thread::spawn(move || {
-        for i in 0..STEPS {
-            loop {
-                if let Success(v) = s.steal() {
-                    assert_eq!(i, v);
-                    break;
+
+    scope(|scope| {
+        scope.spawn(|_| {
+            for i in 0..STEPS {
+                loop {
+                    if let Success(v) = s.steal() {
+                        assert_eq!(i, v);
+                        break;
+                    }
                 }
             }
-        }
-    });
 
-    for i in 0..STEPS {
-        w.push(i);
-    }
-    t.join().unwrap();
+            assert_eq!(s.steal(), Empty);
+        });
+
+        for i in 0..STEPS {
+            w.push(i);
+        }
+    }).unwrap();
 }
 
 #[test]
@@ -107,12 +112,12 @@ fn stampede() {
     }
     let remaining = Arc::new(AtomicUsize::new(COUNT));
 
-    let threads = (0..THREADS)
-        .map(|_| {
+    scope(|scope| {
+        for _ in 0..THREADS {
             let s = w.stealer();
             let remaining = remaining.clone();
 
-            thread::spawn(move || {
+            scope.spawn(move |_| {
                 let mut last = 0;
                 while remaining.load(SeqCst) > 0 {
                     if let Success(x) = s.steal() {
@@ -121,21 +126,18 @@ fn stampede() {
                         remaining.fetch_sub(1, SeqCst);
                     }
                 }
-            })
-        }).collect::<Vec<_>>();
-
-    let mut last = 0;
-    while remaining.load(SeqCst) > 0 {
-        if let Some(x) = w.pop() {
-            assert!(last < *x);
-            last = *x;
-            remaining.fetch_sub(1, SeqCst);
+            });
         }
-    }
 
-    for t in threads {
-        t.join().unwrap();
-    }
+        let mut last = 0;
+        while remaining.load(SeqCst) > 0 {
+            if let Some(x) = w.pop() {
+                assert!(last < *x);
+                last = *x;
+                remaining.fetch_sub(1, SeqCst);
+            }
+        }
+    }).unwrap();
 }
 
 #[test]
@@ -147,13 +149,13 @@ fn stress() {
     let done = Arc::new(AtomicBool::new(false));
     let hits = Arc::new(AtomicUsize::new(0));
 
-    let threads = (0..THREADS)
-        .map(|_| {
+    scope(|scope| {
+        for _ in 0..THREADS {
             let s = w.stealer();
             let done = done.clone();
             let hits = hits.clone();
 
-            thread::spawn(move || {
+            scope.spawn(move |_| {
                 let w2 = Worker::new_fifo();
 
                 while !done.load(SeqCst) {
@@ -171,32 +173,29 @@ fn stress() {
                         hits.fetch_add(1, SeqCst);
                     }
                 }
-            })
-        }).collect::<Vec<_>>();
+            });
+        }
 
-    let mut rng = rand::thread_rng();
-    let mut expected = 0;
-    while expected < COUNT {
-        if rng.gen_range(0, 3) == 0 {
+        let mut rng = rand::thread_rng();
+        let mut expected = 0;
+        while expected < COUNT {
+            if rng.gen_range(0, 3) == 0 {
+                while let Some(_) = w.pop() {
+                    hits.fetch_add(1, SeqCst);
+                }
+            } else {
+                w.push(expected);
+                expected += 1;
+            }
+        }
+
+        while hits.load(SeqCst) < COUNT {
             while let Some(_) = w.pop() {
                 hits.fetch_add(1, SeqCst);
             }
-        } else {
-            w.push(expected);
-            expected += 1;
         }
-    }
-
-    while hits.load(SeqCst) < COUNT {
-        while let Some(_) = w.pop() {
-            hits.fetch_add(1, SeqCst);
-        }
-    }
-    done.store(true, SeqCst);
-
-    for t in threads {
-        t.join().unwrap();
-    }
+        done.store(true, SeqCst);
+    }).unwrap();
 }
 
 #[test]
@@ -206,61 +205,55 @@ fn no_starvation() {
 
     let w = Worker::new_fifo();
     let done = Arc::new(AtomicBool::new(false));
+    let mut all_hits = Vec::new();
 
-    let (threads, hits): (Vec<_>, Vec<_>) = (0..THREADS)
-        .map(|_| {
+    scope(|scope| {
+        for _ in 0..THREADS {
             let s = w.stealer();
             let done = done.clone();
             let hits = Arc::new(AtomicUsize::new(0));
+            all_hits.push(hits.clone());
 
-            let t = {
-                let hits = hits.clone();
-                thread::spawn(move || {
-                    let w2 = Worker::new_fifo();
+            scope.spawn(move |_| {
+                let w2 = Worker::new_fifo();
 
-                    while !done.load(SeqCst) {
-                        if let Success(_) = s.steal() {
-                            hits.fetch_add(1, SeqCst);
-                        }
-
-                        let _ = s.steal_batch(&w2);
-
-                        if let Success(_) = s.steal_batch_and_pop(&w2) {
-                            hits.fetch_add(1, SeqCst);
-                        }
-
-                        while let Some(_) = w2.pop() {
-                            hits.fetch_add(1, SeqCst);
-                        }
+                while !done.load(SeqCst) {
+                    if let Success(_) = s.steal() {
+                        hits.fetch_add(1, SeqCst);
                     }
-                })
-            };
 
-            (t, hits)
-        }).unzip();
+                    let _ = s.steal_batch(&w2);
 
-    let mut rng = rand::thread_rng();
-    let mut my_hits = 0;
-    loop {
-        for i in 0..rng.gen_range(0, COUNT) {
-            if rng.gen_range(0, 3) == 0 && my_hits == 0 {
-                while let Some(_) = w.pop() {
-                    my_hits += 1;
+                    if let Success(_) = s.steal_batch_and_pop(&w2) {
+                        hits.fetch_add(1, SeqCst);
+                    }
+
+                    while let Some(_) = w2.pop() {
+                        hits.fetch_add(1, SeqCst);
+                    }
                 }
-            } else {
-                w.push(i);
+            });
+        }
+
+        let mut rng = rand::thread_rng();
+        let mut my_hits = 0;
+        loop {
+            for i in 0..rng.gen_range(0, COUNT) {
+                if rng.gen_range(0, 3) == 0 && my_hits == 0 {
+                    while let Some(_) = w.pop() {
+                        my_hits += 1;
+                    }
+                } else {
+                    w.push(i);
+                }
+            }
+
+            if my_hits > 0 && all_hits.iter().all(|h| h.load(SeqCst) > 0) {
+                break;
             }
         }
-
-        if my_hits > 0 && hits.iter().all(|h| h.load(SeqCst) > 0) {
-            break;
-        }
-    }
-    done.store(true, SeqCst);
-
-    for t in threads {
-        t.join().unwrap();
-    }
+        done.store(true, SeqCst);
+    }).unwrap();
 }
 
 #[test]
@@ -285,12 +278,12 @@ fn destructors() {
         w.push(Elem(i, dropped.clone()));
     }
 
-    let threads = (0..THREADS)
-        .map(|_| {
+    scope(|scope| {
+        for _ in 0..THREADS {
             let remaining = remaining.clone();
             let s = w.stealer();
 
-            thread::spawn(move || {
+            scope.spawn(move |_| {
                 let w2 = Worker::new_fifo();
                 let mut cnt = 0;
 
@@ -312,18 +305,15 @@ fn destructors() {
                         remaining.fetch_sub(1, SeqCst);
                     }
                 }
-            })
-        }).collect::<Vec<_>>();
-
-    for _ in 0..STEPS {
-        if let Some(_) = w.pop() {
-            remaining.fetch_sub(1, SeqCst);
+            });
         }
-    }
 
-    for t in threads {
-        t.join().unwrap();
-    }
+        for _ in 0..STEPS {
+            if let Some(_) = w.pop() {
+                remaining.fetch_sub(1, SeqCst);
+            }
+        }
+    }).unwrap();
 
     let rem = remaining.load(SeqCst);
     assert!(rem > 0);

--- a/crossbeam-deque/tests/fifo.rs
+++ b/crossbeam-deque/tests/fifo.rs
@@ -7,12 +7,14 @@ use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-use deque::Racy::{Done, Retry};
+use deque::Racy::{self, Done};
+use deque::Worker;
 use rand::Rng;
 
 #[test]
 fn smoke() {
-    let (w, s) = deque::fifo::<i32>();
+    let w = Worker::new_fifo();
+    let s = w.stealer();
     assert_eq!(w.pop(), Done(None));
     assert_eq!(s.steal_one(), Done(None));
 
@@ -49,7 +51,8 @@ fn smoke() {
 fn steal_push() {
     const STEPS: usize = 50_000;
 
-    let (w, s) = deque::fifo();
+    let w = Worker::new_fifo();
+    let s = w.stealer();
     let t = thread::spawn(move || {
         for i in 0..STEPS {
             loop {
@@ -72,7 +75,8 @@ fn stampede() {
     const THREADS: usize = 8;
     const COUNT: usize = 50_000;
 
-    let (w, s) = deque::fifo();
+    let w = Worker::new_fifo();
+    let s = w.stealer();
 
     for i in 0..COUNT {
         w.push(Box::new(i + 1));
@@ -98,17 +102,10 @@ fn stampede() {
 
     let mut last = 0;
     while remaining.load(SeqCst) > 0 {
-        loop {
-            match w.pop() {
-                Done(Some(x)) => {
-                    assert!(last < *x);
-                    last = *x;
-                    remaining.fetch_sub(1, SeqCst);
-                    break;
-                }
-                Done(None) => break,
-                Retry => {}
-            }
+        if let Some(x) = Racy::spin(|| w.pop()) {
+            assert!(last < *x);
+            last = *x;
+            remaining.fetch_sub(1, SeqCst);
         }
     }
 
@@ -121,7 +118,8 @@ fn run_stress() {
     const THREADS: usize = 8;
     const COUNT: usize = 50_000;
 
-    let (w, s) = deque::fifo();
+    let w = Worker::new_fifo();
+    let s = w.stealer();
     let done = Arc::new(AtomicBool::new(false));
     let hits = Arc::new(AtomicUsize::new(0));
 
@@ -132,7 +130,7 @@ fn run_stress() {
             let hits = hits.clone();
 
             thread::spawn(move || {
-                let (w2, _) = deque::fifo();
+                let w2 = Worker::new_fifo();
 
                 while !done.load(SeqCst) {
                     if let Done(Some(_)) = s.steal_one() {
@@ -142,14 +140,8 @@ fn run_stress() {
                     if let Done(Some(_)) = s.steal_one_and_batch(&w2) {
                         hits.fetch_add(1, SeqCst);
 
-                        loop {
-                            match w2.pop() {
-                                Done(Some(_)) => {
-                                    hits.fetch_add(1, SeqCst);
-                                }
-                                Done(None) => break,
-                                Retry => {}
-                            }
+                        while let Some(_) = Racy::spin(|| w2.pop()) {
+                            hits.fetch_add(1, SeqCst);
                         }
                     }
                 }
@@ -160,14 +152,8 @@ fn run_stress() {
     let mut expected = 0;
     while expected < COUNT {
         if rng.gen_range(0, 3) == 0 {
-            loop {
-                match w.pop() {
-                    Done(Some(_)) => {
-                        hits.fetch_add(1, SeqCst);
-                    }
-                    Done(None) => break,
-                    Retry => {}
-                }
+            while let Some(_) = Racy::spin(|| w.pop()) {
+                hits.fetch_add(1, SeqCst);
             }
         } else {
             w.push(expected);
@@ -176,14 +162,8 @@ fn run_stress() {
     }
 
     while hits.load(SeqCst) < COUNT {
-        loop {
-            match w.pop() {
-                Done(Some(_)) => {
-                    hits.fetch_add(1, SeqCst);
-                }
-                Done(None) => break,
-                Retry => {}
-            }
+        while let Some(_) = Racy::spin(|| w.pop()) {
+            hits.fetch_add(1, SeqCst);
         }
     }
     done.store(true, SeqCst);
@@ -209,7 +189,8 @@ fn no_starvation() {
     const THREADS: usize = 8;
     const COUNT: usize = 50_000;
 
-    let (w, s) = deque::fifo();
+    let w = Worker::new_fifo();
+    let s = w.stealer();
     let done = Arc::new(AtomicBool::new(false));
 
     let (threads, hits): (Vec<_>, Vec<_>) = (0..THREADS)
@@ -221,7 +202,7 @@ fn no_starvation() {
             let t = {
                 let hits = hits.clone();
                 thread::spawn(move || {
-                    let (w2, _) = deque::fifo();
+                    let w2 = Worker::new_fifo();
 
                     while !done.load(SeqCst) {
                         if let Done(Some(_)) = s.steal_one() {
@@ -231,14 +212,8 @@ fn no_starvation() {
                         if let Done(Some(_)) = s.steal_one_and_batch(&w2) {
                             hits.fetch_add(1, SeqCst);
 
-                            loop {
-                                match w2.pop() {
-                                    Done(Some(_)) => {
-                                        hits.fetch_add(1, SeqCst);
-                                    }
-                                    Done(None) => break,
-                                    Retry => {}
-                                }
+                            while let Some(_) = Racy::spin(|| w2.pop()) {
+                                hits.fetch_add(1, SeqCst);
                             }
                         }
                     }
@@ -253,12 +228,8 @@ fn no_starvation() {
     loop {
         for i in 0..rng.gen_range(0, COUNT) {
             if rng.gen_range(0, 3) == 0 && my_hits == 0 {
-                loop {
-                    match w.pop() {
-                        Done(Some(_)) => my_hits += 1,
-                        Done(None) => break,
-                        Retry => {}
-                    }
+                while let Some(_) = Racy::spin(|| w.pop()) {
+                    my_hits += 1;
                 }
             } else {
                 w.push(i);
@@ -290,7 +261,8 @@ fn destructors() {
         }
     }
 
-    let (w, s) = deque::fifo();
+    let w = Worker::new_fifo();
+    let s = w.stealer();
 
     let dropped = Arc::new(Mutex::new(Vec::new()));
     let remaining = Arc::new(AtomicUsize::new(COUNT));
@@ -304,7 +276,7 @@ fn destructors() {
             let s = s.clone();
 
             thread::spawn(move || {
-                let (w2, _) = deque::fifo();
+                let w2 = Worker::new_fifo();
                 let mut cnt = 0;
 
                 while cnt < STEPS {
@@ -317,15 +289,9 @@ fn destructors() {
                         cnt += 1;
                         remaining.fetch_sub(1, SeqCst);
 
-                        loop {
-                            match w2.pop() {
-                                Done(Some(_)) => {
-                                    cnt += 1;
-                                    remaining.fetch_sub(1, SeqCst);
-                                }
-                                Done(None) => break,
-                                Retry => {}
-                            }
+                        while let Some(_) = Racy::spin(|| w2.pop()) {
+                            cnt += 1;
+                            remaining.fetch_sub(1, SeqCst);
                         }
                     }
                 }
@@ -333,15 +299,8 @@ fn destructors() {
         }).collect::<Vec<_>>();
 
     for _ in 0..STEPS {
-        loop {
-            match w.pop() {
-                Done(Some(_)) => {
-                    remaining.fetch_sub(1, SeqCst);
-                    break;
-                }
-                Done(None) => break,
-                Retry => {}
-            }
+        if let Some(_) = Racy::spin(|| w.pop()) {
+            remaining.fetch_sub(1, SeqCst);
         }
     }
 

--- a/crossbeam-deque/tests/fifo.rs
+++ b/crossbeam-deque/tests/fifo.rs
@@ -7,7 +7,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-use deque::Racy::{self, Done};
+use deque::Steal::{Empty, Success};
 use deque::Worker;
 use rand::Rng;
 
@@ -15,36 +15,36 @@ use rand::Rng;
 fn smoke() {
     let w = Worker::new_fifo();
     let s = w.stealer();
-    assert_eq!(w.pop(), Done(None));
-    assert_eq!(s.steal_one(), Done(None));
+    assert_eq!(w.pop(), None);
+    assert_eq!(s.steal(), Empty);
 
     w.push(1);
-    assert_eq!(w.pop(), Done(Some(1)));
-    assert_eq!(w.pop(), Done(None));
-    assert_eq!(s.steal_one(), Done(None));
+    assert_eq!(w.pop(), Some(1));
+    assert_eq!(w.pop(), None);
+    assert_eq!(s.steal(), Empty);
 
     w.push(2);
-    assert_eq!(s.steal_one(), Done(Some(2)));
-    assert_eq!(s.steal_one(), Done(None));
-    assert_eq!(w.pop(), Done(None));
+    assert_eq!(s.steal(), Success(2));
+    assert_eq!(s.steal(), Empty);
+    assert_eq!(w.pop(), None);
 
     w.push(3);
     w.push(4);
     w.push(5);
-    assert_eq!(s.steal_one(), Done(Some(3)));
-    assert_eq!(s.steal_one(), Done(Some(4)));
-    assert_eq!(s.steal_one(), Done(Some(5)));
-    assert_eq!(s.steal_one(), Done(None));
+    assert_eq!(s.steal(), Success(3));
+    assert_eq!(s.steal(), Success(4));
+    assert_eq!(s.steal(), Success(5));
+    assert_eq!(s.steal(), Empty);
 
     w.push(6);
     w.push(7);
     w.push(8);
     w.push(9);
-    assert_eq!(w.pop(), Done(Some(6)));
-    assert_eq!(s.steal_one(), Done(Some(7)));
-    assert_eq!(w.pop(), Done(Some(8)));
-    assert_eq!(w.pop(), Done(Some(9)));
-    assert_eq!(w.pop(), Done(None));
+    assert_eq!(w.pop(), Some(6));
+    assert_eq!(s.steal(), Success(7));
+    assert_eq!(w.pop(), Some(8));
+    assert_eq!(w.pop(), Some(9));
+    assert_eq!(w.pop(), None);
 }
 
 #[test]
@@ -56,7 +56,7 @@ fn steal_push() {
     let t = thread::spawn(move || {
         for i in 0..STEPS {
             loop {
-                if let Done(Some(v)) = s.steal_one() {
+                if let Success(v) = s.steal() {
                     assert_eq!(i, v);
                     break;
                 }
@@ -76,7 +76,6 @@ fn stampede() {
     const COUNT: usize = 50_000;
 
     let w = Worker::new_fifo();
-    let s = w.stealer();
 
     for i in 0..COUNT {
         w.push(Box::new(i + 1));
@@ -85,13 +84,13 @@ fn stampede() {
 
     let threads = (0..THREADS)
         .map(|_| {
-            let s = s.clone();
+            let s = w.stealer();
             let remaining = remaining.clone();
 
             thread::spawn(move || {
                 let mut last = 0;
                 while remaining.load(SeqCst) > 0 {
-                    if let Done(Some(x)) = s.steal_one() {
+                    if let Success(x) = s.steal() {
                         assert!(last < *x);
                         last = *x;
                         remaining.fetch_sub(1, SeqCst);
@@ -102,7 +101,7 @@ fn stampede() {
 
     let mut last = 0;
     while remaining.load(SeqCst) > 0 {
-        if let Some(x) = Racy::spin(|| w.pop()) {
+        if let Some(x) = w.pop() {
             assert!(last < *x);
             last = *x;
             remaining.fetch_sub(1, SeqCst);
@@ -119,13 +118,12 @@ fn run_stress() {
     const COUNT: usize = 50_000;
 
     let w = Worker::new_fifo();
-    let s = w.stealer();
     let done = Arc::new(AtomicBool::new(false));
     let hits = Arc::new(AtomicUsize::new(0));
 
     let threads = (0..THREADS)
         .map(|_| {
-            let s = s.clone();
+            let s = w.stealer();
             let done = done.clone();
             let hits = hits.clone();
 
@@ -133,14 +131,14 @@ fn run_stress() {
                 let w2 = Worker::new_fifo();
 
                 while !done.load(SeqCst) {
-                    if let Done(Some(_)) = s.steal_one() {
+                    if let Success(_) = s.steal() {
                         hits.fetch_add(1, SeqCst);
                     }
 
-                    if let Done(Some(_)) = s.steal_one_and_batch(&w2) {
+                    if let Success(_) = s.steal_batch_and_pop(&w2) {
                         hits.fetch_add(1, SeqCst);
 
-                        while let Some(_) = Racy::spin(|| w2.pop()) {
+                        while let Some(_) = w2.pop() {
                             hits.fetch_add(1, SeqCst);
                         }
                     }
@@ -152,7 +150,7 @@ fn run_stress() {
     let mut expected = 0;
     while expected < COUNT {
         if rng.gen_range(0, 3) == 0 {
-            while let Some(_) = Racy::spin(|| w.pop()) {
+            while let Some(_) = w.pop() {
                 hits.fetch_add(1, SeqCst);
             }
         } else {
@@ -162,7 +160,7 @@ fn run_stress() {
     }
 
     while hits.load(SeqCst) < COUNT {
-        while let Some(_) = Racy::spin(|| w.pop()) {
+        while let Some(_) = w.pop() {
             hits.fetch_add(1, SeqCst);
         }
     }
@@ -190,12 +188,11 @@ fn no_starvation() {
     const COUNT: usize = 50_000;
 
     let w = Worker::new_fifo();
-    let s = w.stealer();
     let done = Arc::new(AtomicBool::new(false));
 
     let (threads, hits): (Vec<_>, Vec<_>) = (0..THREADS)
         .map(|_| {
-            let s = s.clone();
+            let s = w.stealer();
             let done = done.clone();
             let hits = Arc::new(AtomicUsize::new(0));
 
@@ -205,14 +202,14 @@ fn no_starvation() {
                     let w2 = Worker::new_fifo();
 
                     while !done.load(SeqCst) {
-                        if let Done(Some(_)) = s.steal_one() {
+                        if let Success(_) = s.steal() {
                             hits.fetch_add(1, SeqCst);
                         }
 
-                        if let Done(Some(_)) = s.steal_one_and_batch(&w2) {
+                        if let Success(_) = s.steal_batch_and_pop(&w2) {
                             hits.fetch_add(1, SeqCst);
 
-                            while let Some(_) = Racy::spin(|| w2.pop()) {
+                            while let Some(_) = w2.pop() {
                                 hits.fetch_add(1, SeqCst);
                             }
                         }
@@ -228,7 +225,7 @@ fn no_starvation() {
     loop {
         for i in 0..rng.gen_range(0, COUNT) {
             if rng.gen_range(0, 3) == 0 && my_hits == 0 {
-                while let Some(_) = Racy::spin(|| w.pop()) {
+                while let Some(_) = w.pop() {
                     my_hits += 1;
                 }
             } else {
@@ -262,10 +259,9 @@ fn destructors() {
     }
 
     let w = Worker::new_fifo();
-    let s = w.stealer();
-
     let dropped = Arc::new(Mutex::new(Vec::new()));
     let remaining = Arc::new(AtomicUsize::new(COUNT));
+
     for i in 0..COUNT {
         w.push(Elem(i, dropped.clone()));
     }
@@ -273,23 +269,23 @@ fn destructors() {
     let threads = (0..THREADS)
         .map(|_| {
             let remaining = remaining.clone();
-            let s = s.clone();
+            let s = w.stealer();
 
             thread::spawn(move || {
                 let w2 = Worker::new_fifo();
                 let mut cnt = 0;
 
                 while cnt < STEPS {
-                    if let Done(Some(_)) = s.steal_one() {
+                    if let Success(_) = s.steal() {
                         cnt += 1;
                         remaining.fetch_sub(1, SeqCst);
                     }
 
-                    if let Done(Some(_)) = s.steal_one_and_batch(&w2) {
+                    if let Success(_) = s.steal_batch_and_pop(&w2) {
                         cnt += 1;
                         remaining.fetch_sub(1, SeqCst);
 
-                        while let Some(_) = Racy::spin(|| w2.pop()) {
+                        while let Some(_) = w2.pop() {
                             cnt += 1;
                             remaining.fetch_sub(1, SeqCst);
                         }
@@ -299,7 +295,7 @@ fn destructors() {
         }).collect::<Vec<_>>();
 
     for _ in 0..STEPS {
-        if let Some(_) = Racy::spin(|| w.pop()) {
+        if let Some(_) = w.pop() {
             remaining.fetch_sub(1, SeqCst);
         }
     }
@@ -317,7 +313,7 @@ fn destructors() {
         v.clear();
     }
 
-    drop((w, s));
+    drop(w);
 
     {
         let mut v = dropped.lock().unwrap();

--- a/crossbeam-deque/tests/injector.rs
+++ b/crossbeam-deque/tests/injector.rs
@@ -1,1 +1,347 @@
 extern crate crossbeam_deque as deque;
+extern crate crossbeam_utils as utils;
+extern crate rand;
+
+use std::sync::atomic::Ordering::SeqCst;
+use std::sync::atomic::{AtomicBool, AtomicUsize};
+use std::sync::{Arc, Mutex};
+
+use deque::{Injector, Worker};
+use deque::Steal::{Empty, Success};
+use rand::Rng;
+use utils::thread::scope;
+
+#[test]
+fn smoke() {
+    let q = Injector::new();
+    assert_eq!(q.steal(), Empty);
+
+    q.push(1);
+    q.push(2);
+    assert_eq!(q.steal(), Success(1));
+    assert_eq!(q.steal(), Success(2));
+    assert_eq!(q.steal(), Empty);
+
+    q.push(3);
+    assert_eq!(q.steal(), Success(3));
+    assert_eq!(q.steal(), Empty);
+}
+
+#[test]
+fn is_empty() {
+    let q = Injector::new();
+    assert!(q.is_empty());
+
+    q.push(1);
+    assert!(!q.is_empty());
+    q.push(2);
+    assert!(!q.is_empty());
+
+    let _ = q.steal();
+    assert!(!q.is_empty());
+    let _ = q.steal();
+    assert!(q.is_empty());
+
+    q.push(3);
+    assert!(!q.is_empty());
+    let _ = q.steal();
+    assert!(q.is_empty());
+}
+
+#[test]
+fn spsc() {
+    const COUNT: usize = 100_000;
+
+    let q = Injector::new();
+
+    scope(|scope| {
+        scope.spawn(|_| {
+            for i in 0..COUNT {
+                loop {
+                    if let Success(v) = q.steal() {
+                        assert_eq!(i, v);
+                        break;
+                    }
+                }
+            }
+
+            assert_eq!(q.steal(), Empty);
+        });
+
+        for i in 0..COUNT {
+            q.push(i);
+        }
+    }).unwrap();
+}
+
+#[test]
+fn mpmc() {
+    const COUNT: usize = 25_000;
+    const THREADS: usize = 4;
+
+    let q = Injector::new();
+    let v = (0..COUNT).map(|_| AtomicUsize::new(0)).collect::<Vec<_>>();
+
+    scope(|scope| {
+        for _ in 0..THREADS {
+            scope.spawn(|_| {
+                for i in 0..COUNT {
+                    q.push(i);
+                }
+            });
+        }
+
+        for _ in 0..THREADS {
+            scope.spawn(|_| {
+                for _ in 0..COUNT {
+                    loop {
+                        if let Success(n) = q.steal() {
+                            v[n].fetch_add(1, SeqCst);
+                            break;
+                        }
+                    }
+                }
+            });
+        }
+    }).unwrap();
+
+    for c in v {
+        assert_eq!(c.load(SeqCst), THREADS);
+    }
+}
+
+#[test]
+fn stampede() {
+    const THREADS: usize = 8;
+    const COUNT: usize = 50_000;
+
+    let q = Injector::new();
+
+    for i in 0..COUNT {
+        q.push(Box::new(i + 1));
+    }
+    let remaining = Arc::new(AtomicUsize::new(COUNT));
+
+    scope(|scope| {
+        for _ in 0..THREADS {
+            let remaining = remaining.clone();
+            let q = &q;
+
+            scope.spawn(move |_| {
+                let mut last = 0;
+                while remaining.load(SeqCst) > 0 {
+                    if let Success(x) = q.steal() {
+                        assert!(last < *x);
+                        last = *x;
+                        remaining.fetch_sub(1, SeqCst);
+                    }
+                }
+            });
+        }
+
+        let mut last = 0;
+        while remaining.load(SeqCst) > 0 {
+            if let Success(x) = q.steal() {
+                assert!(last < *x);
+                last = *x;
+                remaining.fetch_sub(1, SeqCst);
+            }
+        }
+    }).unwrap();
+}
+
+#[test]
+fn stress() {
+    const THREADS: usize = 8;
+    const COUNT: usize = 50_000;
+
+    let q = Injector::new();
+    let done = Arc::new(AtomicBool::new(false));
+    let hits = Arc::new(AtomicUsize::new(0));
+
+    scope(|scope| {
+        for _ in 0..THREADS {
+            let done = done.clone();
+            let hits = hits.clone();
+            let q = &q;
+
+            scope.spawn(move |_| {
+                let w2 = Worker::new_fifo();
+
+                while !done.load(SeqCst) {
+                    if let Success(_) = q.steal() {
+                        hits.fetch_add(1, SeqCst);
+                    }
+
+                    let _ = q.steal_batch(&w2);
+
+                    if let Success(_) = q.steal_batch_and_pop(&w2) {
+                        hits.fetch_add(1, SeqCst);
+                    }
+
+                    while let Some(_) = w2.pop() {
+                        hits.fetch_add(1, SeqCst);
+                    }
+                }
+            });
+        }
+
+        let mut rng = rand::thread_rng();
+        let mut expected = 0;
+        while expected < COUNT {
+            if rng.gen_range(0, 3) == 0 {
+                while let Success(_) = q.steal() {
+                    hits.fetch_add(1, SeqCst);
+                }
+            } else {
+                q.push(expected);
+                expected += 1;
+            }
+        }
+
+        while hits.load(SeqCst) < COUNT {
+            while let Success(_) = q.steal() {
+                hits.fetch_add(1, SeqCst);
+            }
+        }
+        done.store(true, SeqCst);
+    }).unwrap();
+}
+
+#[test]
+fn no_starvation() {
+    const THREADS: usize = 8;
+    const COUNT: usize = 50_000;
+
+    let q = Injector::new();
+    let done = Arc::new(AtomicBool::new(false));
+    let mut all_hits = Vec::new();
+
+    scope(|scope| {
+        for _ in 0..THREADS {
+            let done = done.clone();
+            let hits = Arc::new(AtomicUsize::new(0));
+            all_hits.push(hits.clone());
+            let q = &q;
+
+            scope.spawn(move |_| {
+                let w2 = Worker::new_fifo();
+
+                while !done.load(SeqCst) {
+                    if let Success(_) = q.steal() {
+                        hits.fetch_add(1, SeqCst);
+                    }
+
+                    let _ = q.steal_batch(&w2);
+
+                    if let Success(_) = q.steal_batch_and_pop(&w2) {
+                        hits.fetch_add(1, SeqCst);
+                    }
+
+                    while let Some(_) = w2.pop() {
+                        hits.fetch_add(1, SeqCst);
+                    }
+                }
+            });
+        }
+
+        let mut rng = rand::thread_rng();
+        let mut my_hits = 0;
+        loop {
+            for i in 0..rng.gen_range(0, COUNT) {
+                if rng.gen_range(0, 3) == 0 && my_hits == 0 {
+                    while let Success(_) = q.steal() {
+                        my_hits += 1;
+                    }
+                } else {
+                    q.push(i);
+                }
+            }
+
+            if my_hits > 0 && all_hits.iter().all(|h| h.load(SeqCst) > 0) {
+                break;
+            }
+        }
+        done.store(true, SeqCst);
+    }).unwrap();
+}
+
+#[test]
+fn destructors() {
+    const THREADS: usize = 8;
+    const COUNT: usize = 50_000;
+    const STEPS: usize = 1000;
+
+    struct Elem(usize, Arc<Mutex<Vec<usize>>>);
+
+    impl Drop for Elem {
+        fn drop(&mut self) {
+            self.1.lock().unwrap().push(self.0);
+        }
+    }
+
+    let q = Injector::new();
+    let dropped = Arc::new(Mutex::new(Vec::new()));
+    let remaining = Arc::new(AtomicUsize::new(COUNT));
+
+    for i in 0..COUNT {
+        q.push(Elem(i, dropped.clone()));
+    }
+
+    scope(|scope| {
+        for _ in 0..THREADS {
+            let remaining = remaining.clone();
+            let q = &q;
+
+            scope.spawn(move |_| {
+                let w2 = Worker::new_fifo();
+                let mut cnt = 0;
+
+                while cnt < STEPS {
+                    if let Success(_) = q.steal() {
+                        cnt += 1;
+                        remaining.fetch_sub(1, SeqCst);
+                    }
+
+                    let _ = q.steal_batch(&w2);
+
+                    if let Success(_) = q.steal_batch_and_pop(&w2) {
+                        cnt += 1;
+                        remaining.fetch_sub(1, SeqCst);
+                    }
+
+                    while let Some(_) = w2.pop() {
+                        cnt += 1;
+                        remaining.fetch_sub(1, SeqCst);
+                    }
+                }
+            });
+        }
+
+        for _ in 0..STEPS {
+            if let Success(_) = q.steal() {
+                remaining.fetch_sub(1, SeqCst);
+            }
+        }
+    }).unwrap();
+
+    let rem = remaining.load(SeqCst);
+    assert!(rem > 0);
+
+    {
+        let mut v = dropped.lock().unwrap();
+        assert_eq!(v.len(), COUNT - rem);
+        v.clear();
+    }
+
+    drop(q);
+
+    {
+        let mut v = dropped.lock().unwrap();
+        assert_eq!(v.len(), rem);
+        v.sort();
+        for pair in v.windows(2) {
+            assert_eq!(pair[0] + 1, pair[1]);
+        }
+    }
+}

--- a/crossbeam-deque/tests/injector.rs
+++ b/crossbeam-deque/tests/injector.rs
@@ -1,0 +1,1 @@
+extern crate crossbeam_deque as deque;

--- a/crossbeam-deque/tests/lifo.rs
+++ b/crossbeam-deque/tests/lifo.rs
@@ -1,14 +1,15 @@
 extern crate crossbeam_deque as deque;
+extern crate crossbeam_utils as utils;
 extern crate rand;
 
 use std::sync::atomic::Ordering::SeqCst;
 use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::sync::{Arc, Mutex};
-use std::thread;
 
 use deque::Steal::{Empty, Success};
 use deque::Worker;
 use rand::Rng;
+use utils::thread::scope;
 
 #[test]
 fn smoke() {
@@ -73,26 +74,30 @@ fn is_empty() {
 }
 
 #[test]
-fn steal_push() {
+fn spsc() {
     const STEPS: usize = 50_000;
 
     let w = Worker::new_lifo();
     let s = w.stealer();
-    let t = thread::spawn(move || {
-        for i in 0..STEPS {
-            loop {
-                if let Success(v) = s.steal() {
-                    assert_eq!(i, v);
-                    break;
+
+    scope(|scope| {
+        scope.spawn(|_| {
+            for i in 0..STEPS {
+                loop {
+                    if let Success(v) = s.steal() {
+                        assert_eq!(i, v);
+                        break;
+                    }
                 }
             }
-        }
-    });
 
-    for i in 0..STEPS {
-        w.push(i);
-    }
-    t.join().unwrap();
+            assert_eq!(s.steal(), Empty);
+        });
+
+        for i in 0..STEPS {
+            w.push(i);
+        }
+    }).unwrap();
 }
 
 #[test]
@@ -107,12 +112,12 @@ fn stampede() {
     }
     let remaining = Arc::new(AtomicUsize::new(COUNT));
 
-    let threads = (0..THREADS)
-        .map(|_| {
+    scope(|scope| {
+        for _ in 0..THREADS {
             let s = w.stealer();
             let remaining = remaining.clone();
 
-            thread::spawn(move || {
+            scope.spawn(move |_| {
                 let mut last = 0;
                 while remaining.load(SeqCst) > 0 {
                     if let Success(x) = s.steal() {
@@ -121,21 +126,18 @@ fn stampede() {
                         remaining.fetch_sub(1, SeqCst);
                     }
                 }
-            })
-        }).collect::<Vec<_>>();
-
-    let mut last = COUNT + 1;
-    while remaining.load(SeqCst) > 0 {
-        if let Some(x) = w.pop() {
-            assert!(last > *x);
-            last = *x;
-            remaining.fetch_sub(1, SeqCst);
+            });
         }
-    }
 
-    for t in threads {
-        t.join().unwrap();
-    }
+        let mut last = COUNT + 1;
+        while remaining.load(SeqCst) > 0 {
+            if let Some(x) = w.pop() {
+                assert!(last > *x);
+                last = *x;
+                remaining.fetch_sub(1, SeqCst);
+            }
+        }
+    }).unwrap();
 }
 
 #[test]
@@ -147,13 +149,13 @@ fn stress() {
     let done = Arc::new(AtomicBool::new(false));
     let hits = Arc::new(AtomicUsize::new(0));
 
-    let threads = (0..THREADS)
-        .map(|_| {
+    scope(|scope| {
+        for _ in 0..THREADS {
             let s = w.stealer();
             let done = done.clone();
             let hits = hits.clone();
 
-            thread::spawn(move || {
+            scope.spawn(move |_| {
                 let w2 = Worker::new_lifo();
 
                 while !done.load(SeqCst) {
@@ -171,32 +173,29 @@ fn stress() {
                         hits.fetch_add(1, SeqCst);
                     }
                 }
-            })
-        }).collect::<Vec<_>>();
+            });
+        }
 
-    let mut rng = rand::thread_rng();
-    let mut expected = 0;
-    while expected < COUNT {
-        if rng.gen_range(0, 3) == 0 {
+        let mut rng = rand::thread_rng();
+        let mut expected = 0;
+        while expected < COUNT {
+            if rng.gen_range(0, 3) == 0 {
+                while let Some(_) = w.pop() {
+                    hits.fetch_add(1, SeqCst);
+                }
+            } else {
+                w.push(expected);
+                expected += 1;
+            }
+        }
+
+        while hits.load(SeqCst) < COUNT {
             while let Some(_) = w.pop() {
                 hits.fetch_add(1, SeqCst);
             }
-        } else {
-            w.push(expected);
-            expected += 1;
         }
-    }
-
-    while hits.load(SeqCst) < COUNT {
-        while let Some(_) = w.pop() {
-            hits.fetch_add(1, SeqCst);
-        }
-    }
-    done.store(true, SeqCst);
-
-    for t in threads {
-        t.join().unwrap();
-    }
+        done.store(true, SeqCst);
+    }).unwrap();
 }
 
 #[test]
@@ -206,61 +205,55 @@ fn no_starvation() {
 
     let w = Worker::new_lifo();
     let done = Arc::new(AtomicBool::new(false));
+    let mut all_hits = Vec::new();
 
-    let (threads, hits): (Vec<_>, Vec<_>) = (0..THREADS)
-        .map(|_| {
+    scope(|scope| {
+        for _ in 0..THREADS {
             let s = w.stealer();
             let done = done.clone();
             let hits = Arc::new(AtomicUsize::new(0));
+            all_hits.push(hits.clone());
 
-            let t = {
-                let hits = hits.clone();
-                thread::spawn(move || {
-                    let w2 = Worker::new_lifo();
+            scope.spawn(move |_| {
+                let w2 = Worker::new_lifo();
 
-                    while !done.load(SeqCst) {
-                        if let Success(_) = s.steal() {
-                            hits.fetch_add(1, SeqCst);
-                        }
-
-                        let _ = s.steal_batch(&w2);
-
-                        if let Success(_) = s.steal_batch_and_pop(&w2) {
-                            hits.fetch_add(1, SeqCst);
-                        }
-
-                        while let Some(_) = w2.pop() {
-                            hits.fetch_add(1, SeqCst);
-                        }
+                while !done.load(SeqCst) {
+                    if let Success(_) = s.steal() {
+                        hits.fetch_add(1, SeqCst);
                     }
-                })
-            };
 
-            (t, hits)
-        }).unzip();
+                    let _ = s.steal_batch(&w2);
 
-    let mut rng = rand::thread_rng();
-    let mut my_hits = 0;
-    loop {
-        for i in 0..rng.gen_range(0, COUNT) {
-            if rng.gen_range(0, 3) == 0 && my_hits == 0 {
-                while let Some(_) = w.pop() {
-                    my_hits += 1;
+                    if let Success(_) = s.steal_batch_and_pop(&w2) {
+                        hits.fetch_add(1, SeqCst);
+                    }
+
+                    while let Some(_) = w2.pop() {
+                        hits.fetch_add(1, SeqCst);
+                    }
                 }
-            } else {
-                w.push(i);
+            });
+        }
+
+        let mut rng = rand::thread_rng();
+        let mut my_hits = 0;
+        loop {
+            for i in 0..rng.gen_range(0, COUNT) {
+                if rng.gen_range(0, 3) == 0 && my_hits == 0 {
+                    while let Some(_) = w.pop() {
+                        my_hits += 1;
+                    }
+                } else {
+                    w.push(i);
+                }
+            }
+
+            if my_hits > 0 && all_hits.iter().all(|h| h.load(SeqCst) > 0) {
+                break;
             }
         }
-
-        if my_hits > 0 && hits.iter().all(|h| h.load(SeqCst) > 0) {
-            break;
-        }
-    }
-    done.store(true, SeqCst);
-
-    for t in threads {
-        t.join().unwrap();
-    }
+        done.store(true, SeqCst);
+    }).unwrap();
 }
 
 #[test]
@@ -285,12 +278,12 @@ fn destructors() {
         w.push(Elem(i, dropped.clone()));
     }
 
-    let threads = (0..THREADS)
-        .map(|_| {
+    scope(|scope| {
+        for _ in 0..THREADS {
             let remaining = remaining.clone();
             let s = w.stealer();
 
-            thread::spawn(move || {
+            scope.spawn(move |_| {
                 let w2 = Worker::new_lifo();
                 let mut cnt = 0;
 
@@ -312,18 +305,15 @@ fn destructors() {
                         remaining.fetch_sub(1, SeqCst);
                     }
                 }
-            })
-        }).collect::<Vec<_>>();
-
-    for _ in 0..STEPS {
-        if let Some(_) = w.pop() {
-            remaining.fetch_sub(1, SeqCst);
+            });
         }
-    }
 
-    for t in threads {
-        t.join().unwrap();
-    }
+        for _ in 0..STEPS {
+            if let Some(_) = w.pop() {
+                remaining.fetch_sub(1, SeqCst);
+            }
+        }
+    }).unwrap();
 
     let rem = remaining.load(SeqCst);
     assert!(rem > 0);

--- a/crossbeam-deque/tests/lifo.rs
+++ b/crossbeam-deque/tests/lifo.rs
@@ -1,5 +1,4 @@
 extern crate crossbeam_deque as deque;
-extern crate crossbeam_epoch as epoch;
 extern crate rand;
 
 use std::sync::atomic::Ordering::SeqCst;
@@ -45,6 +44,32 @@ fn smoke() {
     assert_eq!(w.pop(), Some(8));
     assert_eq!(w.pop(), Some(7));
     assert_eq!(w.pop(), None);
+}
+
+#[test]
+fn is_empty() {
+    let w = Worker::new_lifo();
+    let s = w.stealer();
+
+    assert!(w.is_empty());
+    w.push(1);
+    assert!(!w.is_empty());
+    w.push(2);
+    assert!(!w.is_empty());
+    let _ = w.pop();
+    assert!(!w.is_empty());
+    let _ = w.pop();
+    assert!(w.is_empty());
+
+    assert!(s.is_empty());
+    w.push(1);
+    assert!(!s.is_empty());
+    w.push(2);
+    assert!(!s.is_empty());
+    let _ = s.steal();
+    assert!(!s.is_empty());
+    let _ = s.steal();
+    assert!(s.is_empty());
 }
 
 #[test]
@@ -113,7 +138,8 @@ fn stampede() {
     }
 }
 
-fn run_stress() {
+#[test]
+fn stress() {
     const THREADS: usize = 8;
     const COUNT: usize = 50_000;
 
@@ -135,12 +161,14 @@ fn run_stress() {
                         hits.fetch_add(1, SeqCst);
                     }
 
+                    let _ = s.steal_batch(&w2);
+
                     if let Success(_) = s.steal_batch_and_pop(&w2) {
                         hits.fetch_add(1, SeqCst);
+                    }
 
-                        while let Some(_) = w2.pop() {
-                            hits.fetch_add(1, SeqCst);
-                        }
+                    while let Some(_) = w2.pop() {
+                        hits.fetch_add(1, SeqCst);
                     }
                 }
             })
@@ -172,17 +200,6 @@ fn run_stress() {
 }
 
 #[test]
-fn stress() {
-    run_stress();
-}
-
-#[test]
-fn stress_pinned() {
-    let _guard = epoch::pin();
-    run_stress();
-}
-
-#[test]
 fn no_starvation() {
     const THREADS: usize = 8;
     const COUNT: usize = 50_000;
@@ -206,12 +223,14 @@ fn no_starvation() {
                             hits.fetch_add(1, SeqCst);
                         }
 
+                        let _ = s.steal_batch(&w2);
+
                         if let Success(_) = s.steal_batch_and_pop(&w2) {
                             hits.fetch_add(1, SeqCst);
+                        }
 
-                            while let Some(_) = w2.pop() {
-                                hits.fetch_add(1, SeqCst);
-                            }
+                        while let Some(_) = w2.pop() {
+                            hits.fetch_add(1, SeqCst);
                         }
                     }
                 })
@@ -281,14 +300,16 @@ fn destructors() {
                         remaining.fetch_sub(1, SeqCst);
                     }
 
+                    let _ = s.steal_batch(&w2);
+
                     if let Success(_) = s.steal_batch_and_pop(&w2) {
                         cnt += 1;
                         remaining.fetch_sub(1, SeqCst);
+                    }
 
-                        while let Some(_) = w2.pop() {
-                            cnt += 1;
-                            remaining.fetch_sub(1, SeqCst);
-                        }
+                    while let Some(_) = w2.pop() {
+                        cnt += 1;
+                        remaining.fetch_sub(1, SeqCst);
                     }
                 }
             })

--- a/crossbeam-deque/tests/lifo.rs
+++ b/crossbeam-deque/tests/lifo.rs
@@ -7,42 +7,42 @@ use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-use deque::{Pop, Steal};
+use deque::Racy::{Done, Retry};
 use rand::Rng;
 
 #[test]
 fn smoke() {
     let (w, s) = deque::lifo::<i32>();
-    assert_eq!(w.pop(), Pop::Empty);
-    assert_eq!(s.steal(), Steal::Empty);
+    assert_eq!(w.pop(), Done(None));
+    assert_eq!(s.steal_one(), Done(None));
 
     w.push(1);
-    assert_eq!(w.pop(), Pop::Data(1));
-    assert_eq!(w.pop(), Pop::Empty);
-    assert_eq!(s.steal(), Steal::Empty);
+    assert_eq!(w.pop(), Done(Some(1)));
+    assert_eq!(w.pop(), Done(None));
+    assert_eq!(s.steal_one(), Done(None));
 
     w.push(2);
-    assert_eq!(s.steal(), Steal::Data(2));
-    assert_eq!(s.steal(), Steal::Empty);
-    assert_eq!(w.pop(), Pop::Empty);
+    assert_eq!(s.steal_one(), Done(Some(2)));
+    assert_eq!(s.steal_one(), Done(None));
+    assert_eq!(w.pop(), Done(None));
 
     w.push(3);
     w.push(4);
     w.push(5);
-    assert_eq!(s.steal(), Steal::Data(3));
-    assert_eq!(s.steal(), Steal::Data(4));
-    assert_eq!(s.steal(), Steal::Data(5));
-    assert_eq!(s.steal(), Steal::Empty);
+    assert_eq!(s.steal_one(), Done(Some(3)));
+    assert_eq!(s.steal_one(), Done(Some(4)));
+    assert_eq!(s.steal_one(), Done(Some(5)));
+    assert_eq!(s.steal_one(), Done(None));
 
     w.push(6);
     w.push(7);
     w.push(8);
     w.push(9);
-    assert_eq!(w.pop(), Pop::Data(9));
-    assert_eq!(s.steal(), Steal::Data(6));
-    assert_eq!(w.pop(), Pop::Data(8));
-    assert_eq!(w.pop(), Pop::Data(7));
-    assert_eq!(w.pop(), Pop::Empty);
+    assert_eq!(w.pop(), Done(Some(9)));
+    assert_eq!(s.steal_one(), Done(Some(6)));
+    assert_eq!(w.pop(), Done(Some(8)));
+    assert_eq!(w.pop(), Done(Some(7)));
+    assert_eq!(w.pop(), Done(None));
 }
 
 #[test]
@@ -53,7 +53,7 @@ fn steal_push() {
     let t = thread::spawn(move || {
         for i in 0..STEPS {
             loop {
-                if let Steal::Data(v) = s.steal() {
+                if let Done(Some(v)) = s.steal_one() {
                     assert_eq!(i, v);
                     break;
                 }
@@ -87,7 +87,7 @@ fn stampede() {
             thread::spawn(move || {
                 let mut last = 0;
                 while remaining.load(SeqCst) > 0 {
-                    if let Steal::Data(x) = s.steal() {
+                    if let Done(Some(x)) = s.steal_one() {
                         assert!(last < *x);
                         last = *x;
                         remaining.fetch_sub(1, SeqCst);
@@ -100,14 +100,14 @@ fn stampede() {
     while remaining.load(SeqCst) > 0 {
         loop {
             match w.pop() {
-                Pop::Data(x) => {
+                Done(Some(x)) => {
                     assert!(last > *x);
                     last = *x;
                     remaining.fetch_sub(1, SeqCst);
                     break;
                 }
-                Pop::Empty => break,
-                Pop::Retry => {}
+                Done(None) => break,
+                Retry => {}
             }
         }
     }
@@ -135,20 +135,20 @@ fn run_stress() {
                 let (w2, _) = deque::lifo();
 
                 while !done.load(SeqCst) {
-                    if let Steal::Data(_) = s.steal() {
+                    if let Done(Some(_)) = s.steal_one() {
                         hits.fetch_add(1, SeqCst);
                     }
 
-                    if let Steal::Data(_) = s.steal_many(&w2) {
+                    if let Done(Some(_)) = s.steal_one_and_batch(&w2) {
                         hits.fetch_add(1, SeqCst);
 
                         loop {
                             match w2.pop() {
-                                Pop::Data(_) => {
+                                Done(Some(_)) => {
                                     hits.fetch_add(1, SeqCst);
                                 }
-                                Pop::Empty => break,
-                                Pop::Retry => {}
+                                Done(None) => break,
+                                Retry => {}
                             }
                         }
                     }
@@ -162,11 +162,11 @@ fn run_stress() {
         if rng.gen_range(0, 3) == 0 {
             loop {
                 match w.pop() {
-                    Pop::Data(_) => {
+                    Done(Some(_)) => {
                         hits.fetch_add(1, SeqCst);
                     }
-                    Pop::Empty => break,
-                    Pop::Retry => {}
+                    Done(None) => break,
+                    Retry => {}
                 }
             }
         } else {
@@ -178,11 +178,11 @@ fn run_stress() {
     while hits.load(SeqCst) < COUNT {
         loop {
             match w.pop() {
-                Pop::Data(_) => {
+                Done(Some(_)) => {
                     hits.fetch_add(1, SeqCst);
                 }
-                Pop::Empty => break,
-                Pop::Retry => {}
+                Done(None) => break,
+                Retry => {}
             }
         }
     }
@@ -224,20 +224,20 @@ fn no_starvation() {
                     let (w2, _) = deque::lifo();
 
                     while !done.load(SeqCst) {
-                        if let Steal::Data(_) = s.steal() {
+                        if let Done(Some(_)) = s.steal_one() {
                             hits.fetch_add(1, SeqCst);
                         }
 
-                        if let Steal::Data(_) = s.steal_many(&w2) {
+                        if let Done(Some(_)) = s.steal_one_and_batch(&w2) {
                             hits.fetch_add(1, SeqCst);
 
                             loop {
                                 match w2.pop() {
-                                    Pop::Data(_) => {
+                                    Done(Some(_)) => {
                                         hits.fetch_add(1, SeqCst);
                                     }
-                                    Pop::Empty => break,
-                                    Pop::Retry => {}
+                                    Done(None) => break,
+                                    Retry => {}
                                 }
                             }
                         }
@@ -255,9 +255,9 @@ fn no_starvation() {
             if rng.gen_range(0, 3) == 0 && my_hits == 0 {
                 loop {
                     match w.pop() {
-                        Pop::Data(_) => my_hits += 1,
-                        Pop::Empty => break,
-                        Pop::Retry => {}
+                        Done(Some(_)) => my_hits += 1,
+                        Done(None) => break,
+                        Retry => {}
                     }
                 }
             } else {
@@ -308,23 +308,23 @@ fn destructors() {
                 let mut cnt = 0;
 
                 while cnt < STEPS {
-                    if let Steal::Data(_) = s.steal() {
+                    if let Done(Some(_)) = s.steal_one() {
                         cnt += 1;
                         remaining.fetch_sub(1, SeqCst);
                     }
 
-                    if let Steal::Data(_) = s.steal_many(&w2) {
+                    if let Done(Some(_)) = s.steal_one_and_batch(&w2) {
                         cnt += 1;
                         remaining.fetch_sub(1, SeqCst);
 
                         loop {
                             match w2.pop() {
-                                Pop::Data(_) => {
+                                Done(Some(_)) => {
                                     cnt += 1;
                                     remaining.fetch_sub(1, SeqCst);
                                 }
-                                Pop::Empty => break,
-                                Pop::Retry => {}
+                                Done(None) => break,
+                                Retry => {}
                             }
                         }
                     }
@@ -335,12 +335,12 @@ fn destructors() {
     for _ in 0..STEPS {
         loop {
             match w.pop() {
-                Pop::Data(_) => {
+                Done(Some(_)) => {
                     remaining.fetch_sub(1, SeqCst);
                     break;
                 }
-                Pop::Empty => break,
-                Pop::Retry => {}
+                Done(None) => break,
+                Retry => {}
             }
         }
     }

--- a/crossbeam-deque/tests/steal.rs
+++ b/crossbeam-deque/tests/steal.rs
@@ -1,0 +1,214 @@
+extern crate crossbeam_deque as deque;
+
+use deque::Steal::Success;
+use deque::{Injector, Worker};
+
+#[test]
+fn steal_fifo() {
+    let w = Worker::new_fifo();
+    for i in 1..=3 {
+        w.push(i);
+    }
+
+    let s = w.stealer();
+    assert_eq!(s.steal(), Success(1));
+    assert_eq!(s.steal(), Success(2));
+    assert_eq!(s.steal(), Success(3));
+}
+
+#[test]
+fn steal_lifo() {
+    let w = Worker::new_lifo();
+    for i in 1..=3 {
+        w.push(i);
+    }
+
+    let s = w.stealer();
+    assert_eq!(s.steal(), Success(1));
+    assert_eq!(s.steal(), Success(2));
+    assert_eq!(s.steal(), Success(3));
+}
+
+#[test]
+fn steal_injector() {
+    let q = Injector::new();
+    for i in 1..=3 {
+        q.push(i);
+    }
+
+    assert_eq!(q.steal(), Success(1));
+    assert_eq!(q.steal(), Success(2));
+    assert_eq!(q.steal(), Success(3));
+}
+
+#[test]
+fn steal_batch_fifo_fifo() {
+    let w = Worker::new_fifo();
+    for i in 1..=4 {
+        w.push(i);
+    }
+
+    let s = w.stealer();
+    let w2 = Worker::new_fifo();
+
+    assert_eq!(s.steal_batch(&w2), Success(()));
+    assert_eq!(w2.pop(), Some(1));
+    assert_eq!(w2.pop(), Some(2));
+}
+
+#[test]
+fn steal_batch_lifo_lifo() {
+    let w = Worker::new_lifo();
+    for i in 1..=4 {
+        w.push(i);
+    }
+
+    let s = w.stealer();
+    let w2 = Worker::new_lifo();
+
+    assert_eq!(s.steal_batch(&w2), Success(()));
+    assert_eq!(w2.pop(), Some(2));
+    assert_eq!(w2.pop(), Some(1));
+}
+
+#[test]
+fn steal_batch_fifo_lifo() {
+    let w = Worker::new_fifo();
+    for i in 1..=4 {
+        w.push(i);
+    }
+
+    let s = w.stealer();
+    let w2 = Worker::new_lifo();
+
+    assert_eq!(s.steal_batch(&w2), Success(()));
+    assert_eq!(w2.pop(), Some(1));
+    assert_eq!(w2.pop(), Some(2));
+}
+
+#[test]
+fn steal_batch_lifo_fifo() {
+    let w = Worker::new_lifo();
+    for i in 1..=4 {
+        w.push(i);
+    }
+
+    let s = w.stealer();
+    let w2 = Worker::new_fifo();
+
+    assert_eq!(s.steal_batch(&w2), Success(()));
+    assert_eq!(w2.pop(), Some(2));
+    assert_eq!(w2.pop(), Some(1));
+}
+
+#[test]
+fn steal_batch_injector_fifo() {
+    let q = Injector::new();
+    for i in 1..=4 {
+        q.push(i);
+    }
+
+    let w2 = Worker::new_fifo();
+    assert_eq!(q.steal_batch(&w2), Success(()));
+    assert_eq!(w2.pop(), Some(1));
+    assert_eq!(w2.pop(), Some(2));
+}
+
+#[test]
+fn steal_batch_injector_lifo() {
+    let q = Injector::new();
+    for i in 1..=4 {
+        q.push(i);
+    }
+
+    let w2 = Worker::new_lifo();
+    assert_eq!(q.steal_batch(&w2), Success(()));
+    assert_eq!(w2.pop(), Some(1));
+    assert_eq!(w2.pop(), Some(2));
+}
+
+#[test]
+fn steal_batch_and_pop_fifo_fifo() {
+    let w = Worker::new_fifo();
+    for i in 1..=6 {
+        w.push(i);
+    }
+
+    let s = w.stealer();
+    let w2 = Worker::new_fifo();
+
+    assert_eq!(s.steal_batch_and_pop(&w2), Success(1));
+    assert_eq!(w2.pop(), Some(2));
+    assert_eq!(w2.pop(), Some(3));
+}
+
+#[test]
+fn steal_batch_and_pop_lifo_lifo() {
+    let w = Worker::new_lifo();
+    for i in 1..=6 {
+        w.push(i);
+    }
+
+    let s = w.stealer();
+    let w2 = Worker::new_lifo();
+
+    assert_eq!(s.steal_batch_and_pop(&w2), Success(3));
+    assert_eq!(w2.pop(), Some(2));
+    assert_eq!(w2.pop(), Some(1));
+}
+
+#[test]
+fn steal_batch_and_pop_fifo_lifo() {
+    let w = Worker::new_fifo();
+    for i in 1..=6 {
+        w.push(i);
+    }
+
+    let s = w.stealer();
+    let w2 = Worker::new_lifo();
+
+    assert_eq!(s.steal_batch_and_pop(&w2), Success(1));
+    assert_eq!(w2.pop(), Some(2));
+    assert_eq!(w2.pop(), Some(3));
+}
+
+#[test]
+fn steal_batch_and_pop_lifo_fifo() {
+    let w = Worker::new_lifo();
+    for i in 1..=6 {
+        w.push(i);
+    }
+
+    let s = w.stealer();
+    let w2 = Worker::new_fifo();
+
+    assert_eq!(s.steal_batch_and_pop(&w2), Success(3));
+    assert_eq!(w2.pop(), Some(2));
+    assert_eq!(w2.pop(), Some(1));
+}
+
+#[test]
+fn steal_batch_and_pop_injector_fifo() {
+    let q = Injector::new();
+    for i in 1..=6 {
+        q.push(i);
+    }
+
+    let w2 = Worker::new_fifo();
+    assert_eq!(q.steal_batch_and_pop(&w2), Success(1));
+    assert_eq!(w2.pop(), Some(2));
+    assert_eq!(w2.pop(), Some(3));
+}
+
+#[test]
+fn steal_batch_and_pop_injector_lifo() {
+    let q = Injector::new();
+    for i in 1..=6 {
+        q.push(i);
+    }
+
+    let w2 = Worker::new_lifo();
+    assert_eq!(q.steal_batch_and_pop(&w2), Success(1));
+    assert_eq!(w2.pop(), Some(2));
+    assert_eq!(w2.pop(), Some(3));
+}

--- a/tests/subcrates.rs
+++ b/tests/subcrates.rs
@@ -15,10 +15,9 @@ fn channel() {
 
 #[test]
 fn deque() {
-    let (w, s) = crossbeam::deque::fifo();
+    let w = crossbeam::deque::Worker::new_fifo();
     w.push(1);
     let _ = w.pop();
-    let _ = s.steal();
 }
 
 #[test]


### PR DESCRIPTION
This PR introduces a big set of changes:

* `Injector<T>` is introduced, which is a MPMC FIFO queue. Every task scheduler (Rayon, Tokio, Go, TBB, Cilk, you name it) has an "injector" queue, through which tasks are spawned onto the thread pool. This is a special queue supports it batched steal operations.

* `fifo()` and `lifo()` constructors are changed to `Worker::new_fifo()` and `Worker::new_lifo()`. Stealers are created using `Worker::stealer()`.

* `steal_many()` is renamed to `steal_batch_and_pop()`.

* There's a new batched steal method named `steal_batch()`. It moves only a batch of tasks into another `Worker` - it doesn't return an additional task.

* `Steal::Data` is renamed to `Steal::Success` because `steal_batch()` returns `Steal<()>`, which means the success case doesn't have data.

* `Steal` has `FromIterator` and `or_else`, which are useful combinators for implementing stealing strategies. There are a few other useful methods on it.

* `Steal<T>` is now `#[must_use]`.

As a simple demonstration, this is how one might efficiently implement a strategy for finding the next task to run. The strategy in this example is:

1. Try popping one task from the local worker queue.
2. Try stealing a batch of tasks from the global injector queue.
3. Try stealing one task from another thread using the stealer list.

```rust
fn find_task<T>(
    local: &Worker<T>,
    global: &Injector<T>,
    stealers: &[Stealer<T>],
) -> Option<T> {
    // Pop a task from the local queue, if not empty.
    local.pop().or_else(|| {
        // Otherwise, we need to look for a task elsewhere.
        iter::repeat_with(|| {
            // Try stealing a batch of tasks from the global queue.
            global.steal_batch_and_pop(local)
                // Or try stealing a task from one of the other threads.
                .or_else(|| stealers.iter().map(|s| s.steal()).collect())
        })
        // Loop while no task was stolen and any steal operation needs to be retried.
        .find(|s| !s.is_retry())
        // Extract the stolen task, if there is one.
        .and_then(|s| s.success())
    })
}
```

The new `crossbeam-deque` interface looks like this:

```rust
struct Injector<T>;
struct Worker<T>;
struct Stealer<T>;

#[must_use]
enum Steal<T> {
    Empty,
    Success(T),
    Retry,
}

impl<T> Injector<T> {
    fn new() -> Injector<T>;

    fn is_empty(&self) -> bool;
    fn push(&self, task: T);

    fn steal(&self) -> Steal<T>;
    fn steal_batch(&self, dest: &Worker<T>) -> Steal<()>;
    fn steal_batch_and_pop(&self, dest: &Worker<T>) -> Steal<T>;
}

impl<T> Worker<T> {
    fn new_fifo() -> Worker<T>;
    fn new_lifo() -> Worker<T>;

    fn stealer(&self) -> Stealer<T>;
    fn is_empty(&self) -> bool;

    fn push(&self, task: T);
    fn pop(&self) -> Option<T>;
}

impl<T> Stealer<T> {
    fn is_empty(&self) -> bool;

    fn steal(&self) -> Steal<T>;
    fn steal_batch(&self, dest: &Worker<T>) -> Steal<()>;
    fn steal_batch_and_pop(&self, dest: &Worker<T>) -> Steal<T>;
}

impl<T> Steal<T> {
    fn is_empty(&self) -> bool;
    fn is_success(&self) -> bool;
    fn is_retry(&self) -> bool;

    fn success(self) -> Option<T>;
    fn or_else<F: FnOnce() -> Steal<T>>(self, f: F);
}

impl<T> FromIterator<Steal<T>> for Steal<T>;
```

Finally, a benchmark with Tokio updated to this branch and changed to use batched stealing from `Injector`:

```
 name                    before ns/iter  after ns/iter  diff ns/iter  diff %  speedup
 threadpool::spawn_many  3,055,261       2,767,283          -287,978  -9.43%   x 1.10
 threadpool::yield_many  10,258,470      10,092,862         -165,608  -1.61%   x 1.02
```
