### PR TITLE
channel: remove parking_lot dependency

### DIFF
--- a/crossbeam-channel/Cargo.toml
+++ b/crossbeam-channel/Cargo.toml
@@ -16,7 +16,6 @@ keywords = ["channel", "mpmc", "select", "golang", "message"]
 categories = ["algorithms", "concurrency", "data-structures"]
 
 [dependencies]
-parking_lot = "0.7"
 smallvec = "0.6.2"
 
 [dependencies.crossbeam-utils]

--- a/crossbeam-channel/src/flavors/zero.rs
+++ b/crossbeam-channel/src/flavors/zero.rs
@@ -7,12 +7,10 @@ use std::marker::PhantomData;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
 
-use parking_lot::Mutex;
-
 use context::Context;
 use err::{RecvTimeoutError, SendTimeoutError, TryRecvError, TrySendError};
 use select::{Operation, SelectHandle, Selected, Token};
-use utils::Backoff;
+use utils::{Backoff, Mutex};
 use waker::Waker;
 
 /// A pointer to a packet.

--- a/crossbeam-channel/src/lib.rs
+++ b/crossbeam-channel/src/lib.rs
@@ -348,7 +348,6 @@
 #![warn(missing_debug_implementations)]
 
 extern crate crossbeam_utils;
-extern crate parking_lot;
 extern crate smallvec;
 
 mod channel;

--- a/crossbeam-channel/src/utils.rs
+++ b/crossbeam-channel/src/utils.rs
@@ -130,7 +130,7 @@ impl<T> Mutex<T> {
 }
 
 /// A guard holding a mutex locked.
-pub struct MutexGuard<'a, T> {
+pub struct MutexGuard<'a, T: 'a> {
     parent: &'a Mutex<T>,
 }
 

--- a/crossbeam-channel/src/utils.rs
+++ b/crossbeam-channel/src/utils.rs
@@ -1,8 +1,9 @@
 //! Miscellaneous utilities.
 
-use std::cell::Cell;
+use std::cell::{Cell, UnsafeCell};
 use std::num::Wrapping;
-use std::sync::atomic;
+use std::ops::{Deref, DerefMut};
+use std::sync::atomic::{self, AtomicBool, Ordering};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -97,6 +98,62 @@ pub fn sleep_until(deadline: Option<Instant>) {
                 }
                 thread::sleep(d - now);
             }
+        }
+    }
+}
+
+/// A simple spinlock-based mutex.
+pub struct Mutex<T> {
+    flag: AtomicBool,
+    value: UnsafeCell<T>,
+}
+
+impl<T> Mutex<T> {
+    /// Returns a new mutex initialized with `value`.
+    pub fn new(value: T) -> Mutex<T> {
+        Mutex {
+            flag: AtomicBool::new(false),
+            value: UnsafeCell::new(value),
+        }
+    }
+
+    /// Locks the mutex.
+    pub fn lock(&self) -> MutexGuard<'_, T> {
+        let mut backoff = Backoff::new();
+        while self.flag.swap(true, Ordering::Acquire) {
+            backoff.snooze();
+        }
+        MutexGuard {
+            parent: self,
+        }
+    }
+}
+
+/// A guard holding a mutex locked.
+pub struct MutexGuard<'a, T> {
+    parent: &'a Mutex<T>,
+}
+
+impl<'a, T> Drop for MutexGuard<'a, T> {
+    fn drop(&mut self) {
+        self.parent.flag.store(false, Ordering::Release);
+    }
+}
+
+impl<'a, T> Deref for MutexGuard<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        unsafe {
+            &*self.parent.value.get()
+        }
+    }
+}
+
+impl<'a, T> DerefMut for MutexGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        unsafe {
+            &mut *self.parent.value.get()
         }
     }
 }

--- a/crossbeam-channel/src/waker.rs
+++ b/crossbeam-channel/src/waker.rs
@@ -3,10 +3,9 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::{self, ThreadId};
 
-use parking_lot::Mutex;
-
 use context::Context;
 use select::{Operation, Selected};
+use utils::Mutex;
 
 /// Represents a thread blocked on a specific channel operation.
 pub struct Entry {


### PR DESCRIPTION
`parking_lot` is a big dependency, which is discouraging library writers from using `crossbeam-channel`. I am therefore removing it.

Mutexes are replaced with a simple spinlock that yields threads on contention. That should be ok since all critical sections are small anyway. Benchmarks look good (see below).

Previous dependency tree:

```
crossbeam-channel v0.3.6 (/home/stjepan/work/crossbeam/crossbeam-channel)
├── crossbeam-utils v0.6.3 (/home/stjepan/work/crossbeam/crossbeam-utils)
│   └── cfg-if v0.1.6
├── parking_lot v0.7.1
│   ├── lock_api v0.1.5
│   │   ├── owning_ref v0.4.0
│   │   │   └── stable_deref_trait v1.1.1
│   │   └── scopeguard v0.3.3
│   └── parking_lot_core v0.4.0
│       ├── libc v0.2.47
│       ├── rand v0.6.4
│       │   ├── libc v0.2.47 (*)
│       │   ├── rand_chacha v0.1.1
│       │   │   └── rand_core v0.3.0
│       │   │   [build-dependencies]
│       │   │   └── autocfg v0.1.2
│       │   ├── rand_core v0.3.0 (*)
│       │   ├── rand_hc v0.1.0
│       │   │   └── rand_core v0.3.0 (*)
│       │   ├── rand_isaac v0.1.1
│       │   │   └── rand_core v0.3.0 (*)
│       │   ├── rand_os v0.1.1
│       │   │   ├── libc v0.2.47 (*)
│       │   │   └── rand_core v0.3.0 (*)
│       │   ├── rand_pcg v0.1.1
│       │   │   └── rand_core v0.3.0 (*)
│       │   │   [build-dependencies]
│       │   │   └── rustc_version v0.2.3
│       │   │       └── semver v0.9.0
│       │   │           └── semver-parser v0.7.0
│       │   └── rand_xorshift v0.1.1
│       │       └── rand_core v0.3.0 (*)
│       │   [build-dependencies]
│       │   └── autocfg v0.1.2 (*)
│       └── smallvec v0.6.7
│           └── unreachable v1.0.0
│               └── void v1.0.2
│       [build-dependencies]
│       └── rustc_version v0.2.3 (*)
└── smallvec v0.6.7 (*)
```

New dependency tree:

```
crossbeam-channel v0.3.6 (/home/stjepan/work/crossbeam/crossbeam-channel)
├── crossbeam-utils v0.6.3 (/home/stjepan/work/crossbeam/crossbeam-utils)
│   └── cfg-if v0.1.6
└── smallvec v0.6.7
    └── unreachable v1.0.0
        └── void v1.0.2
```

Benchmarks (before vs after):

```
bounded0_mpmc          1.962  1.953 sec
bounded0_mpsc          2.420  2.026 sec
bounded0_select_both   5.859  5.993 sec
bounded0_select_rx     2.126  1.902 sec
bounded0_spsc          2.403  1.913 sec
bounded1_mpmc          0.526  0.708 sec
bounded1_mpsc          0.555  0.469 sec
bounded1_select_both   0.912  1.128 sec
bounded1_select_rx     1.027  1.003 sec
bounded1_spsc          0.973  0.985 sec
bounded_mpmc           0.248  0.261 sec
bounded_mpsc           0.255  0.278 sec
bounded_select_both    0.570  0.530 sec
bounded_select_rx      0.563  0.548 sec
bounded_seq            0.258  0.253 sec
bounded_spsc           0.151  0.156 sec
unbounded_mpmc         0.274  0.291 sec
unbounded_mpsc         0.298  0.307 sec
unbounded_select_both  0.523  0.477 sec
unbounded_select_rx    0.545  0.564 sec
unbounded_seq          0.352  0.353 sec
unbounded_spsc         0.215  0.213 sec
```

cc @BurntSushi There we go :)