### PR TITLE
Documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This crate provides a set of tools for concurrent programming:
     * `MsQueue<T>` and `SegQueue<T>` are simple concurrent queues.
     * `TreiberStack<T>` is a lock-free stack.
 
-* Synchronization
+* Thread synchronization
     * `channel` module contains multi-producer multi-consumer channels for message passing.
     * `ShardedLock<T>` is like `RwLock<T>`, but sharded for faster concurrent reads.
     * `WaitGroup` enables threads to synchronize the beginning or end of some computation.

--- a/crossbeam-utils/src/sync/mod.rs
+++ b/crossbeam-utils/src/sync/mod.rs
@@ -1,4 +1,4 @@
-//! Synchronization tools.
+//! Thread synchronization primitives.
 
 mod parker;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,33 +1,43 @@
-//! Crossbeam supports concurrent programming, especially focusing on memory
-//! management, synchronization, and non-blocking data structures.
+//! Tools for concurrent programming.
 //!
-//! Crossbeam consists of several submodules:
+//! * Atomics
+//!     * [`ArcCell<T>`] is a shared mutable [`Arc<T>`] pointer.
+//!     * [`AtomicCell<T>`] is equivalent to [`Cell<T>`], except it is also thread-safe.
+//!     * [`AtomicConsume`] allows reading from primitive atomic types with "consume" ordering.
 //!
-//!  - `atomic` for **enhancing `std::sync` API**. `AtomicConsume` provides
-//!    C/C++11-style "consume" atomic operations (re-exported from
-//!    [`crossbeam-utils`]). `ArcCell` provides atomic storage and retrieval of
-//!    `Arc`.
+//! * Data structures
+//!     * [`deque`] module contains work-stealing deques for building task schedulers.
+//!     * [`MsQueue<T>`] and [`SegQueue<T>`] are simple concurrent queues.
+//!     * [`TreiberStack<T>`] is a lock-free stack.
 //!
-//!  - `utils` and `thread` for **utilities**, re-exported from [`crossbeam-utils`].
-//!    The "scoped" thread API in `thread` makes it possible to spawn threads that
-//!    share stack data with their parents. The `utils::CachePadded` struct inserts
-//!    padding to align data with the size of a cacheline. This crate also seeks to
-//!    expand the standard library's few synchronization primitives (locks,
-//!    barriers, etc) to include advanced/niche primitives, as well as userspace
-//!    alternatives.
+//! * Thread synchronization
+//!     * [`channel`] module contains multi-producer multi-consumer channels for message passing.
+//!     * [`ShardedLock<T>`] is like [`RwLock<T>`], but sharded for faster concurrent reads.
+//!     * [`WaitGroup`] enables threads to synchronize the beginning or end of some computation.
 //!
-//!  - `epoch` for **memory management**, re-exported from [`crossbeam-epoch`].
-//!    Because non-blocking data structures avoid global synchronization, it is not
-//!    easy to tell when internal data can be safely freed. The crate provides
-//!    generic, easy to use, and high-performance APIs for managing memory in these
-//!    cases. We plan to support other memory management schemes, e.g. hazard
-//!    pointers (HP) and quiescent state-based reclamation (QSBR).
+//! * Memory management
+//!     * [`epoch`] module contains epoch-based garbage collection.
 //!
-//!  - **Concurrent data structures** which are non-blocking and much superior to
-//!    wrapping sequential ones with a `Mutex`. Crossbeam currently provides
-//!    channels (re-exported from [`crossbeam-channel`]), deques
-//!    (re-exported from [`crossbeam-deque`]), queues, and stacks. Ultimately the
-//!    goal is to also include bags, sets and maps.
+//! * Utilities
+//!     * [`CachePadded<T>`] pads and aligns a value to the length of a cache line.
+//!     * [`scope()`] can spawn threads that borrow local variables from the stack.
+//!
+//! [`ArcCell<T>`]: atomic/struct.ArcCell.html
+//! [`Arc<T>`]: https://doc.rust-lang.org/std/sync/struct.Arc.html
+//! [`AtomicCell<T>`]: atomic/struct.AtomicCell.html
+//! [`Cell<T>`]: https://doc.rust-lang.org/std/cell/struct.Cell.html
+//! [`AtomicConsume`]: atomic/trait.AtomicConsume.html
+//! [`deque`]: deque/index.html
+//! [`MsQueue<T>`]: queue/struct.MsQueue.html
+//! [`SegQueue<T>`]: queue/struct.SegQueue.html
+//! [`TreiberStack<T>`]: stack/struct.TreiberStack.html
+//! [`channel`]: channel/index.html
+//! [`ShardedLock<T>`]: sync/struct.ShardedLock.html
+//! [`RwLock<T>`]: https://doc.rust-lang.org/std/sync/struct.RwLock.html
+//! [`WaitGroup`]: sync/struct.WaitGroup.html
+//! [`epoch`]: epoch/index.html
+//! [`CachePadded<T>`]: utils/struct.CachePadded.html
+//! [`scope()`]: fn.scope.html
 
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]
@@ -62,17 +72,14 @@ mod arc_cell;
 
 extern crate crossbeam_utils;
 
-/// Additional utilities for atomics.
+/// Atomic types.
 pub mod atomic {
     pub use arc_cell::ArcCell;
     pub use crossbeam_utils::atomic::AtomicCell;
     pub use crossbeam_utils::atomic::AtomicConsume;
 }
 
-/// Utilities for concurrent programming.
-///
-/// See [the `crossbeam-utils` crate](https://github.com/crossbeam-rs/crossbeam-utils) for more
-/// information.
+/// Miscellaneous utilities.
 pub mod utils {
     pub use crossbeam_utils::CachePadded;
 }
@@ -123,7 +130,7 @@ cfg_if! {
             pub use treiber_stack::TreiberStack;
         }
 
-        /// Utilities for thread synchronization.
+        /// Thread synchronization primitives.
         pub mod sync {
             pub use crossbeam_utils::sync::Parker;
             pub use sharded_lock::{ShardedLock, ShardedLockReadGuard, ShardedLockWriteGuard};


### PR DESCRIPTION
The root `crossbeam` module had outdated documentation and broken links. This PR moves the contents of the readme into the root module and expands some docs for `crossbeam-utils`.