### PR TITLE
utils: add Backoff for exponential backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This crate provides a set of tools for concurrent programming:
     * `epoch` module contains epoch-based garbage collection.
 
 * Utilities
+    * `Backoff` performs exponential backoff in spin loops.
     * `CachePadded<T>` pads and aligns a value to the length of a cache line.
     * `scope()` can spawn threads that borrow local variables from the stack. 
 
@@ -79,6 +80,7 @@ Features available in `no_std` environments:
 
 * `AtomicCell<T>`
 * `AtomicConsume`
+* `Backoff`
 * `CachePadded<T>`
 * `epoch` (nightly Rust only)
 

--- a/crossbeam-channel/src/flavors/zero.rs
+++ b/crossbeam-channel/src/flavors/zero.rs
@@ -7,10 +7,12 @@ use std::marker::PhantomData;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
 
+use crossbeam_utils::Backoff;
+
 use context::Context;
 use err::{RecvTimeoutError, SendTimeoutError, TryRecvError, TrySendError};
 use select::{Operation, SelectHandle, Selected, Token};
-use utils::{Backoff, Mutex};
+use utils::Mutex;
 use waker::Waker;
 
 /// A pointer to a packet.
@@ -58,7 +60,7 @@ impl<T> Packet<T> {
 
     /// Waits until the packet becomes ready for reading or writing.
     fn wait_ready(&self) {
-        let mut backoff = Backoff::new();
+        let backoff = Backoff::new();
         while !self.ready.load(Ordering::Acquire) {
             backoff.snooze();
         }

--- a/crossbeam-utils/README.md
+++ b/crossbeam-utils/README.md
@@ -15,6 +15,7 @@ This crate provides miscellaneous utilities for concurrent programming:
 
 * `AtomicCell<T>` is equivalent to `Cell<T>`, except it is also thread-safe.
 * `AtomicConsume` allows reading from primitive atomic types with "consume" ordering.
+* `Backoff` performs exponential backoff in spin loops.
 * `CachePadded<T>` pads and aligns a value to the length of a cache line.
 * `scope()` can spawn threads that borrow local variables from the stack. 
 
@@ -41,6 +42,7 @@ Features available in `no_std` environments:
 
 * `AtomicCell<T>`
 * `AtomicConsume`
+* `Backoff`
 * `CachePadded<T>`
 
 ## License

--- a/crossbeam-utils/benches/atomic_cell.rs
+++ b/crossbeam-utils/benches/atomic_cell.rs
@@ -51,18 +51,20 @@ fn concurrent_load_u8(b: &mut test::Bencher) {
 
     thread::scope(|scope| {
         for _ in 0..THREADS {
-            scope.spawn(|| loop {
-                start.wait();
+            scope.spawn(|_| {
+                loop {
+                    start.wait();
 
-                let mut sum = 0;
-                for _ in 0..STEPS {
-                    sum += a.load();
-                }
-                test::black_box(sum);
+                    let mut sum = 0;
+                    for _ in 0..STEPS {
+                        sum += a.load();
+                    }
+                    test::black_box(sum);
 
-                end.wait();
-                if exit.load() {
-                    break;
+                    end.wait();
+                    if exit.load() {
+                        break;
+                    }
                 }
             });
         }
@@ -124,18 +126,20 @@ fn concurrent_load_usize(b: &mut test::Bencher) {
 
     thread::scope(|scope| {
         for _ in 0..THREADS {
-            scope.spawn(|| loop {
-                start.wait();
+            scope.spawn(|_| {
+                loop {
+                    start.wait();
 
-                let mut sum = 0;
-                for _ in 0..STEPS {
-                    sum += a.load();
-                }
-                test::black_box(sum);
+                    let mut sum = 0;
+                    for _ in 0..STEPS {
+                        sum += a.load();
+                    }
+                    test::black_box(sum);
 
-                end.wait();
-                if exit.load() {
-                    break;
+                    end.wait();
+                    if exit.load() {
+                        break;
+                    }
                 }
             });
         }

--- a/crossbeam-utils/src/backoff.rs
+++ b/crossbeam-utils/src/backoff.rs
@@ -5,11 +5,11 @@ use core::sync::atomic;
 const SPIN_LIMIT: u32 = 6;
 const YIELD_LIMIT: u32 = 10;
 
-/// A counter for exponential backoff in spin loops.
+/// Performs exponential backoff in spin loops.
 ///
 /// Backing off in spin loops reduces contention and improves overall performance.
 ///
-/// This primitive can execute "YIELD" and "PAUSE" instructions, yield the current thread to the OS
+/// This primitive can execute *YIELD* and *PAUSE* instructions, yield the current thread to the OS
 /// scheduler, and tell when is a good time to block the thread using a different synchronization
 /// mechanism. Each step of the back off procedure takes roughly twice as long as the previous
 /// step.
@@ -118,7 +118,7 @@ impl Backoff {
     /// This method should be used when we need to retry an operation because another thread made
     /// progress.
     ///
-    /// The processor may yield using the "YIELD" or "PAUSE" instruction.
+    /// The processor may yield using the *YIELD* or *PAUSE* instruction.
     ///
     /// # Examples
     ///
@@ -159,7 +159,7 @@ impl Backoff {
     ///
     /// This method should be used when we need to wait for another thread to make progress.
     ///
-    /// The processor may yield using the "YIELD" or "PAUSE" instruction and the current thread
+    /// The processor may yield using the *YIELD* or *PAUSE* instruction and the current thread
     /// may yield by giving up a timeslice to the OS scheduler.
     ///
     /// In `#[no_std]` environments, this method is equivalent to [`spin`].

--- a/crossbeam-utils/src/backoff.rs
+++ b/crossbeam-utils/src/backoff.rs
@@ -1,0 +1,246 @@
+use core::cell::Cell;
+use core::fmt;
+use core::sync::atomic;
+
+const SPIN_LIMIT: u32 = 6;
+const YIELD_LIMIT: u32 = 10;
+
+/// A counter for exponential backoff in spin loops.
+///
+/// Exponential backoff reduces contention and improves performance in spin loops.
+///
+/// # Examples
+///
+/// TODO a classic sketch with spin, snooze, block
+///
+/// ```
+/// use crossbeam_utils::Backoff;
+/// use std::sync::atomic::{AtomicBool, AtomicUsize};
+/// use std::sync::atomic::Ordering::SeqCst;
+///
+/// fn fetch_mul(a: &AtomicUsize, b: usize) -> usize {
+///     let backoff = Backoff::new();
+///     loop {
+///         let val = a.load(SeqCst);
+///         if a.compare_and_swap(val, val.wrapping_mul(b), SeqCst) == val {
+///             return val;
+///         }
+///         backoff.spin();
+///     }
+/// }
+///
+/// fn spin_wait(ready: &AtomicBool) {
+///     let backoff = Backoff::new();
+///     while !ready.load(SeqCst) {
+///         backoff.snooze();
+///     }
+/// }
+///
+/// fn blocking_wait(ready: &AtomicBool) {
+///     let backoff = Backoff::new();
+///     while !ready.load(SeqCst) {
+///         if backoff.is_complete() {
+///             thread::park();
+///         } else {
+///             backoff.snooze();
+///         }
+///     }
+/// }
+/// ```
+pub struct Backoff {
+    step: Cell<u32>,
+}
+
+impl Backoff {
+    /// Creates a new `Backoff`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_utils::Backoff;
+    ///
+    /// let backoff = Backoff::new();
+    /// ```
+    #[inline]
+    pub fn new() -> Self {
+        Backoff {
+            step: Cell::new(0),
+        }
+    }
+
+    /// Resets the `Backoff`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_utils::Backoff;
+    ///
+    /// let backoff = Backoff::new();
+    /// backoff.reset();
+    /// ```
+    #[inline]
+    pub fn reset(&self) {
+        self.step.set(0);
+    }
+
+    /// Backs off in a lock-free loop.
+    ///
+    /// This method should be used when we need to retry an operation because another thread made
+    /// progress.
+    ///
+    /// The processor may yield using the "YIELD" or "PAUSE" instruction.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_utils::Backoff;
+    /// use std::sync::atomic::AtomicUsize;
+    /// use std::sync::atomic::Ordering::SeqCst;
+    ///
+    /// fn fetch_mul(a: &AtomicUsize, b: usize) -> usize {
+    ///     let backoff = Backoff::new();
+    ///     loop {
+    ///         let val = a.load(SeqCst);
+    ///         if a.compare_and_swap(val, val.wrapping_mul(b), SeqCst) == val {
+    ///             return val;
+    ///         }
+    ///         backoff.spin();
+    ///     }
+    /// }
+    ///
+    /// let a = AtomicUsize::new(7);
+    /// assert_eq!(fetch_mul(&a, 8), 7);
+    /// assert_eq!(a.load(SeqCst), 56);
+    /// ```
+    #[inline]
+    pub fn spin(&self) {
+        for _ in 0..1 << self.step.get().min(SPIN_LIMIT) {
+            atomic::spin_loop_hint();
+        }
+
+        if self.step.get() <= SPIN_LIMIT {
+            self.step.set(self.step.get() + 1);
+        }
+    }
+
+    /// Backs off in a blocking loop.
+    ///
+    /// This method should be used when we need to wait for another thread to make progress.
+    ///
+    /// The processor may yield using the "YIELD" or "PAUSE" instruction and the current thread
+    /// may yield by giving up a timeslice to the OS scheduler.
+    ///
+    /// In `#[no_std]` environments, this method is equivalent to [`spin`].
+    ///
+    /// If possible, use [`is_complete`] to check when it is advised to stop using backoff and
+    /// block the current thread using a different synchronization mechanism instead.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_utils::Backoff;
+    /// use std::sync::Arc;
+    /// use std::sync::atomic::AtomicBool;
+    /// use std::sync::atomic::Ordering::SeqCst;
+    /// use std::thread;
+    /// use std::time::Duration;
+    ///
+    /// fn wait(ready: &AtomicBool) {
+    ///     let backoff = Backoff::new();
+    ///     while !ready.load(SeqCst) {
+    ///         backoff.snooze();
+    ///     }
+    /// }
+    ///
+    /// let ready = Arc::new(AtomicBool::new(false));
+    /// let ready2 = ready.clone();
+    ///
+    /// thread::spawn(move || {
+    ///     thread::sleep(Duration::from_millis(100));
+    ///     ready2.store(true, SeqCst);
+    /// });
+    ///
+    /// assert_eq!(ready.load(SeqCst), false);
+    /// wait(&ready);
+    /// assert_eq!(ready.load(SeqCst), true);
+    /// ```
+    #[inline]
+    pub fn snooze(&self) {
+        if self.step.get() <= SPIN_LIMIT {
+            for _ in 0..1 << self.step.get() {
+                atomic::spin_loop_hint();
+            }
+        } else {
+            #[cfg(not(feature = "std"))]
+            for _ in 0..1 << self.step.get() {
+                atomic::spin_loop_hint();
+            }
+
+            #[cfg(feature = "std")]
+            ::std::thread::yield_now();
+        }
+
+        if self.step.get() <= YIELD_LIMIT {
+            self.step.set(self.step.get() + 1);
+        }
+    }
+
+    /// Returns `true` if backoff is complete and blocking the thread is advised.
+    ///
+    /// TODO
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_utils::Backoff;
+    /// use std::sync::Arc;
+    /// use std::sync::atomic::AtomicBool;
+    /// use std::sync::atomic::Ordering::SeqCst;
+    /// use std::thread;
+    /// use std::time::Duration;
+    ///
+    /// fn wait(ready: &AtomicBool) {
+    ///     let backoff = Backoff::new();
+    ///     while !ready.load(SeqCst) {
+    ///         if backoff.is_complete() {
+    ///             thread::park();
+    ///         } else {
+    ///             backoff.snooze();
+    ///         }
+    ///     }
+    /// }
+    ///
+    /// let ready = Arc::new(AtomicBool::new(false));
+    /// let ready2 = ready.clone();
+    /// let waiter = thread::current();
+    ///
+    /// thread::spawn(move || {
+    ///     thread::sleep(Duration::from_millis(100));
+    ///     ready2.store(true, SeqCst);
+    ///     waiter.unpark();
+    /// });
+    ///
+    /// assert_eq!(ready.load(SeqCst), false);
+    /// wait(&ready);
+    /// assert_eq!(ready.load(SeqCst), true);
+    /// ```
+    #[inline]
+    pub fn is_complete(&self) -> bool {
+        self.step.get() > YIELD_LIMIT
+    }
+}
+
+impl fmt::Debug for Backoff {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Backoff")
+            .field("step", &self.step)
+            .field("is_complete", &self.is_complete())
+            .finish()
+    }
+}
+
+impl Default for Backoff {
+    fn default() -> Backoff {
+        Backoff::new()
+    }
+}

--- a/crossbeam-utils/src/lib.rs
+++ b/crossbeam-utils/src/lib.rs
@@ -28,6 +28,9 @@ pub mod atomic;
 mod cache_padded;
 pub use cache_padded::CachePadded;
 
+mod backoff;
+pub use backoff::Backoff;
+
 cfg_if! {
     if #[cfg(feature = "std")] {
         pub mod sync;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@
 //!     * [`epoch`] module contains epoch-based garbage collection.
 //!
 //! * Utilities
+//!     * [`Backoff`] performs exponential backoff in spin loops.
 //!     * [`CachePadded<T>`] pads and aligns a value to the length of a cache line.
 //!     * [`scope()`] can spawn threads that borrow local variables from the stack.
 //!
@@ -36,6 +37,7 @@
 //! [`RwLock<T>`]: https://doc.rust-lang.org/std/sync/struct.RwLock.html
 //! [`WaitGroup`]: sync/struct.WaitGroup.html
 //! [`epoch`]: epoch/index.html
+//! [`Backoff`]: utils/struct.CachePadded.html
 //! [`CachePadded<T>`]: utils/struct.CachePadded.html
 //! [`scope()`]: fn.scope.html
 
@@ -81,6 +83,7 @@ pub mod atomic {
 
 /// Miscellaneous utilities.
 pub mod utils {
+    pub use crossbeam_utils::Backoff;
     pub use crossbeam_utils::CachePadded;
 }
 


### PR DESCRIPTION
This is one of those simple tools like `CachePadded` that comes up so often it is useful to have it in the library, despite being easy to implement. `Backoff` calls `spin_loop_hint()` and `yield_now()` with good default settings that work well across a wide spectrum of workloads.

Currently, `crossbeam-channel`, `crossbeam-deque`, and `SegQueue` have their own `Backoff`s so this PR just removes duplication.

There's even a place in Tokio where this might be useful as we previously struggled with tuning backoff manually and got it wrong: https://github.com/tokio-rs/tokio/pull/534