### PR TITLE
Use `target_has_atomic` in `impl_arithmethic`

### DIFF
--- a/crossbeam-utils/src/atomic/atomic_cell.rs
+++ b/crossbeam-utils/src/atomic/atomic_cell.rs
@@ -464,7 +464,7 @@ macro_rules! impl_arithmetic {
             }
         }
     };
-    ($t:ty, $size:literal, $atomic:ty, $example:tt) => {
+    ($t:ty, $size:tt, $atomic:ty, $example:tt) => {
         #[cfg(target_has_atomic = $size)]
         impl_arithmetic!($t, $atomic, $example);
     };

--- a/crossbeam-utils/src/atomic/atomic_cell.rs
+++ b/crossbeam-utils/src/atomic/atomic_cell.rs
@@ -464,18 +464,22 @@ macro_rules! impl_arithmetic {
             }
         }
     };
+    ($t:ty, $size:literal, $atomic:ty, $example:tt) => {
+        #[cfg(target_has_atomic = $size)]
+        impl_arithmetic!($t, $atomic, $example);
+    };
 }
 
 cfg_if! {
     if #[cfg(feature = "nightly")] {
-        impl_arithmetic!(u8, atomic::AtomicU8, "let a = AtomicCell::new(7u8);");
-        impl_arithmetic!(i8, atomic::AtomicI8, "let a = AtomicCell::new(7i8);");
-        impl_arithmetic!(u16, atomic::AtomicU16, "let a = AtomicCell::new(7u16);");
-        impl_arithmetic!(i16, atomic::AtomicI16, "let a = AtomicCell::new(7i16);");
-        impl_arithmetic!(u32, atomic::AtomicU32, "let a = AtomicCell::new(7u32);");
-        impl_arithmetic!(i32, atomic::AtomicI32, "let a = AtomicCell::new(7i32);");
-        impl_arithmetic!(u64, atomic::AtomicU64, "let a = AtomicCell::new(7u64);");
-        impl_arithmetic!(i64, atomic::AtomicI64, "let a = AtomicCell::new(7i64);");
+        impl_arithmetic!(u8, "8", atomic::AtomicU8, "let a = AtomicCell::new(7u8);");
+        impl_arithmetic!(i8, "8", atomic::AtomicI8, "let a = AtomicCell::new(7i8);");
+        impl_arithmetic!(u16, "16", atomic::AtomicU16, "let a = AtomicCell::new(7u16);");
+        impl_arithmetic!(i16, "16", atomic::AtomicI16, "let a = AtomicCell::new(7i16);");
+        impl_arithmetic!(u32, "32", atomic::AtomicU32, "let a = AtomicCell::new(7u32);");
+        impl_arithmetic!(i32, "32", atomic::AtomicI32, "let a = AtomicCell::new(7i32);");
+        impl_arithmetic!(u64, "64", atomic::AtomicU64, "let a = AtomicCell::new(7u64);");
+        impl_arithmetic!(i64, "64", atomic::AtomicI64, "let a = AtomicCell::new(7i64);");
     } else {
         impl_arithmetic!(u8, "let a = AtomicCell::new(7u8);");
         impl_arithmetic!(i8, "let a = AtomicCell::new(7i8);");


### PR DESCRIPTION
The lack of larger atomics on thumbv7m-none-eabi (and I'm guessing
similar embedded platforms as well) was causing build errors.