### PR TITLE
Move queues into crossbeam-queue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ matrix:
   - rust: 1.26.0
     name: "crossbeam-epoch on 1.26.0"
     script: ./ci/crossbeam-epoch.sh
+  - rust: 1.26.0
+    name: "crossbeam-queue on 1.26.0"
+    script: ./ci/crossbeam-queue.sh
   - rust: 1.28.0
     name: "crossbeam-skiplist on 1.28.0"
     script: ./ci/crossbeam-skiplist.sh
@@ -56,6 +59,9 @@ matrix:
           - llvm-3.8-dev
           - clang-3.8
           - clang-3.8-dev
+  - rust: nightly
+    name: "crossbeam-queue on nightly"
+    script: ./ci/crossbeam-queue.sh
   - rust: nightly
     name: "crossbeam-skiplist on nightly"
     script: ./ci/crossbeam-skiplist.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,10 @@ path = "./crossbeam-deque"
 version = "0.7.0"
 path = "./crossbeam-epoch"
 
+[dependencies.crossbeam-queue]
+version = "0.0.0"
+path = "./crossbeam-queue"
+
 [dependencies.crossbeam-utils]
 version = "0.6.3"
 path = "./crossbeam-utils"
@@ -53,14 +57,7 @@ members = [
   "crossbeam-channel/benchmarks",
   "crossbeam-deque",
   "crossbeam-epoch",
+  "crossbeam-queue",
   "crossbeam-skiplist",
   "crossbeam-utils",
 ]
-
-# [patch.crates-io]
-# crossbeam = { path = "." }
-# crossbeam-channel = { path = "./crossbeam-channel" }
-# crossbeam-deque = { path = "./crossbeam-deque" }
-# crossbeam-epoch = { path = "./crossbeam-epoch" }
-# crossbeam-skiplist = { path = "./crossbeam-skiplist" }
-# crossbeam-utils = { path = "./crossbeam-utils" }

--- a/ci/crossbeam-queue.sh
+++ b/ci/crossbeam-queue.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+cd "$(dirname "$0")"/../crossbeam-queue
+set -ex
+
+export RUSTFLAGS="-D warnings"
+
+cargo check --bins --examples --tests
+cargo test

--- a/crossbeam-channel/benchmarks/segqueue.rs
+++ b/crossbeam-channel/benchmarks/segqueue.rs
@@ -16,7 +16,7 @@ fn seq() {
     }
 
     for _ in 0..MESSAGES {
-        q.try_pop().unwrap();
+        q.pop().unwrap();
     }
 }
 
@@ -32,7 +32,7 @@ fn spsc() {
 
         for _ in 0..MESSAGES {
             loop {
-                if q.try_pop().is_none() {
+                if q.pop().is_err() {
                     thread::yield_now();
                 } else {
                     break;
@@ -56,7 +56,7 @@ fn mpsc() {
 
         for _ in 0..MESSAGES {
             loop {
-                if q.try_pop().is_none() {
+                if q.pop().is_err() {
                     thread::yield_now();
                 } else {
                     break;
@@ -82,7 +82,7 @@ fn mpmc() {
             scope.spawn(|_| {
                 for _ in 0..MESSAGES / THREADS {
                     loop {
-                        if q.try_pop().is_none() {
+                        if q.pop().is_err() {
                             thread::yield_now();
                         } else {
                             break;

--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -205,7 +205,7 @@ pub fn after(duration: Duration) -> Receiver<Instant> {
 ///     s.send(1).unwrap();
 /// });
 ///
-/// // This duration can be a `Some` or a `None`.
+/// // Suppose this duration can be a `Some` or a `None`.
 /// let duration = Some(Duration::from_millis(100));
 ///
 /// // Create a channel that times out after the specified duration.

--- a/crossbeam-queue/Cargo.toml
+++ b/crossbeam-queue/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "crossbeam-queue"
+# When publishing a new version:
+# - Update CHANGELOG.md
+# - Update README.md
+# - Create "crossbeam-queue-X.Y.Z" git tag
+version = "0.0.0"
+authors = ["The Crossbeam Project Developers"]
+license = "MIT/Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/crossbeam-rs/crossbeam"
+homepage = "https://github.com/crossbeam-rs/crossbeam"
+documentation = "https://docs.rs/crossbeam-queue"
+description = "Concurrent queues"
+keywords = ["queue", "mpmc", "lock-free", "producer", "consumer"]
+categories = ["concurrency", "data-structures"]
+
+[dependencies]
+
+[dependencies.crossbeam-utils]
+version = "0.6"
+path = "../crossbeam-utils"
+
+[dev-dependencies]
+rand = "0.6"

--- a/crossbeam-queue/Cargo.toml
+++ b/crossbeam-queue/Cargo.toml
@@ -9,13 +9,11 @@ authors = ["The Crossbeam Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/crossbeam-rs/crossbeam"
-homepage = "https://github.com/crossbeam-rs/crossbeam"
+homepage = "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-utils"
 documentation = "https://docs.rs/crossbeam-queue"
 description = "Concurrent queues"
 keywords = ["queue", "mpmc", "lock-free", "producer", "consumer"]
 categories = ["concurrency", "data-structures"]
-
-[dependencies]
 
 [dependencies.crossbeam-utils]
 version = "0.6"

--- a/crossbeam-queue/LICENSE-APACHE
+++ b/crossbeam-queue/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/crossbeam-queue/LICENSE-MIT
+++ b/crossbeam-queue/LICENSE-MIT
@@ -1,0 +1,23 @@
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/crossbeam-queue/LICENSE-THIRD-PARTY
+++ b/crossbeam-queue/LICENSE-THIRD-PARTY
@@ -1,0 +1,31 @@
+===============================================================================
+
+Bounded MPMC queue
+http://www.1024cores.net/home/code-license
+
+Copyright (c) 2010-2011 Dmitry Vyukov.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY DMITRY VYUKOV "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+EVENT SHALL DMITRY VYUKOV OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The views and conclusions contained in the software and documentation are those
+of the authors and should not be interpreted as representing official policies,
+either expressed or implied, of Dmitry Vyukov.

--- a/crossbeam-queue/README.md
+++ b/crossbeam-queue/README.md
@@ -1,0 +1,63 @@
+# Crossbeam Utils
+
+[![Build Status](https://travis-ci.org/crossbeam-rs/crossbeam.svg?branch=master)](
+https://travis-ci.org/crossbeam-rs/crossbeam)
+[![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](
+https://github.com/crossbeam-rs/crossbeam-utils/tree/master/src)
+[![Cargo](https://img.shields.io/crates/v/crossbeam-utils.svg)](
+https://crates.io/crates/crossbeam-utils)
+[![Documentation](https://docs.rs/crossbeam-utils/badge.svg)](
+https://docs.rs/crossbeam-utils)
+[![Rust 1.26+](https://img.shields.io/badge/rust-1.26+-lightgray.svg)](
+https://www.rust-lang.org)
+
+This crate provides miscellaneous utilities for concurrent programming:
+
+* `AtomicCell<T>` is equivalent to `Cell<T>`, except it is also thread-safe.
+* `AtomicConsume` allows reading from primitive atomic types with "consume" ordering.
+* `Backoff` performs exponential backoff in spin loops.
+* `CachePadded<T>` pads and aligns a value to the length of a cache line.
+* `scope()` can spawn threads that borrow local variables from the stack. 
+* `ShardedLock<T>` is like `RwLock<T>`, but sharded for faster concurrent reads.
+* `WaitGroup` enables threads to synchronize the beginning or end of some computation.
+
+## Usage
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+crossbeam-utils = "0.6"
+```
+
+Next, add this to your crate:
+
+```rust
+extern crate crossbeam_utils;
+```
+
+## Compatibility
+
+The minimum supported Rust version is 1.26.
+
+Features available in `no_std` environments:
+
+* `AtomicCell<T>`
+* `AtomicConsume`
+* `Backoff`
+* `CachePadded<T>`
+
+## License
+
+Licensed under either of
+
+ * Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.

--- a/crossbeam-queue/README.md
+++ b/crossbeam-queue/README.md
@@ -11,10 +11,14 @@ https://docs.rs/crossbeam-queue)
 [![Rust 1.26+](https://img.shields.io/badge/rust-1.26+-lightgray.svg)](
 https://www.rust-lang.org)
 
-This crate provides concurrent queues:
+This crate provides concurrent queues that can be shared among threads:
 
-* TODO
-* TODO
+* [`ArrayQueue`], a bounded MPMC queue that allocates a fixed-capacity buffer on construction.
+* [`SegQueue`], an unbounded MPMC queue that allocates segments on demand. Segments are small
+  buffers that can hold a handful of elements.
+
+[`ArrayQueue`]: https://docs.rs/crossbeam-queue/*/crossbeam_queue/struct.ArrayQueue.html
+[`SegQueue`]: https://docs.rs/crossbeam-queue/*/crossbeam_queue/struct.SegQueue.html
 
 ## Usage
 
@@ -44,13 +48,13 @@ Licensed under either of
 
 at your option.
 
-### Contribution
+#### Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
 
-### Third party software
+#### Third party software
 
 This product includes copies and modifications of software developed by third parties:
 

--- a/crossbeam-queue/README.md
+++ b/crossbeam-queue/README.md
@@ -1,25 +1,20 @@
-# Crossbeam Utils
+# Crossbeam Queue
 
 [![Build Status](https://travis-ci.org/crossbeam-rs/crossbeam.svg?branch=master)](
 https://travis-ci.org/crossbeam-rs/crossbeam)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](
-https://github.com/crossbeam-rs/crossbeam-utils/tree/master/src)
-[![Cargo](https://img.shields.io/crates/v/crossbeam-utils.svg)](
-https://crates.io/crates/crossbeam-utils)
-[![Documentation](https://docs.rs/crossbeam-utils/badge.svg)](
-https://docs.rs/crossbeam-utils)
+https://github.com/crossbeam-rs/crossbeam-queue/tree/master/src)
+[![Cargo](https://img.shields.io/crates/v/crossbeam-queue.svg)](
+https://crates.io/crates/crossbeam-queue)
+[![Documentation](https://docs.rs/crossbeam-queue/badge.svg)](
+https://docs.rs/crossbeam-queue)
 [![Rust 1.26+](https://img.shields.io/badge/rust-1.26+-lightgray.svg)](
 https://www.rust-lang.org)
 
-This crate provides miscellaneous utilities for concurrent programming:
+This crate provides concurrent queues:
 
-* `AtomicCell<T>` is equivalent to `Cell<T>`, except it is also thread-safe.
-* `AtomicConsume` allows reading from primitive atomic types with "consume" ordering.
-* `Backoff` performs exponential backoff in spin loops.
-* `CachePadded<T>` pads and aligns a value to the length of a cache line.
-* `scope()` can spawn threads that borrow local variables from the stack. 
-* `ShardedLock<T>` is like `RwLock<T>`, but sharded for faster concurrent reads.
-* `WaitGroup` enables threads to synchronize the beginning or end of some computation.
+* TODO
+* TODO
 
 ## Usage
 
@@ -27,25 +22,18 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-crossbeam-utils = "0.6"
+crossbeam-queue = "0.1"
 ```
 
 Next, add this to your crate:
 
 ```rust
-extern crate crossbeam_utils;
+extern crate crossbeam_queue;
 ```
 
 ## Compatibility
 
 The minimum supported Rust version is 1.26.
-
-Features available in `no_std` environments:
-
-* `AtomicCell<T>`
-* `AtomicConsume`
-* `Backoff`
-* `CachePadded<T>`
 
 ## License
 
@@ -61,3 +49,15 @@ at your option.
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
+
+### Third party software
+
+This product includes copies and modifications of software developed by third parties:
+
+* [src/array_queue.rs](src/array_queue.rs) is based on
+  [Bounded MPMC queue](http://www.1024cores.net/home/lock-free-algorithms/queues/bounded-mpmc-queue)
+  by Dmitry Vyukov, licensed under the Simplified BSD License and the Apache License, Version 2.0.
+
+See the source code files for more details.
+
+Copies of third party licenses can be found in [LICENSE-THIRD-PARTY](LICENSE-THIRD-PARTY).

--- a/crossbeam-queue/src/array_queue.rs
+++ b/crossbeam-queue/src/array_queue.rs
@@ -18,8 +18,9 @@ use std::mem;
 use std::ptr;
 use std::sync::atomic::{self, AtomicUsize, Ordering};
 
-use queue::{PopError, PushError};
-use utils::{Backoff, CachePadded};
+use crossbeam_utils::{Backoff, CachePadded};
+
+use err::{PopError, PushError};
 
 /// A slot in a queue.
 struct Slot<T> {
@@ -34,6 +35,8 @@ struct Slot<T> {
 }
 
 /// A bounded multi-producer multi-consumer queue.
+///
+/// This queue uses a fixed-capacity buffer to store pushed values.
 pub struct ArrayQueue<T> {
     /// The head of the queue.
     ///

--- a/crossbeam-queue/src/array_queue.rs
+++ b/crossbeam-queue/src/array_queue.rs
@@ -74,7 +74,7 @@ impl<T> ArrayQueue<T> {
     ///
     /// Panics if the capacity is zero.
     pub fn new(cap: usize) -> ArrayQueue<T> {
-        assert!(cap > 0, "capacity must be positive");
+        assert!(cap > 0, "capacity must be non-zero");
 
         // Head is initialized to `{ lap: 0, index: 0 }`.
         // Tail is initialized to `{ lap: 0, index: 0 }`.

--- a/crossbeam-queue/src/array_queue.rs
+++ b/crossbeam-queue/src/array_queue.rs
@@ -1,10 +1,7 @@
-//! Bounded multi-producer multi-consumer queue.
-//!
 //! The implementation is based on Dmitry Vyukov's bounded MPMC queue.
 //!
 //! Source:
 //!   - http://www.1024cores.net/home/lock-free-algorithms/queues/bounded-mpmc-queue
-//!   - https://docs.google.com/document/d/1yIAYmbvL3JxOKOjuCyon7JhW4cSv1wy5hC0ApeGMV9s/pub
 //!
 //! Copyright & License:
 //!   - Copyright (c) 2010-2011 Dmitry Vyukov

--- a/crossbeam-queue/src/err.rs
+++ b/crossbeam-queue/src/err.rs
@@ -1,12 +1,6 @@
 use std::error;
 use std::fmt;
 
-mod array_queue;
-mod seg_queue;
-
-pub use self::array_queue::ArrayQueue;
-pub use self::seg_queue::SegQueue;
-
 /// Error which occurs when popping from an empty queue.
 #[derive(Clone, Copy, Eq, PartialEq)]
 pub struct PopError;

--- a/crossbeam-queue/src/lib.rs
+++ b/crossbeam-queue/src/lib.rs
@@ -1,6 +1,13 @@
 //! Concurrent queues.
 //!
-//! TODO
+//! This crate provides concurrent queues that can be shared among threads:
+//!
+//! * [`ArrayQueue`], a bounded MPMC queue that allocates a fixed-capacity buffer on construction.
+//! * [`SegQueue`], an unbounded MPMC queue that allocates segments on demand. Segments are small
+//!   buffers that can hold a handful of elements.
+//!
+//! [`ArrayQueue`]: struct.ArrayQueue.html
+//! [`SegQueue`]: struct.SegQueue.html
 
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]

--- a/crossbeam-queue/src/lib.rs
+++ b/crossbeam-queue/src/lib.rs
@@ -1,0 +1,16 @@
+//! Concurrent queues.
+//!
+//! TODO
+
+#![warn(missing_docs)]
+#![warn(missing_debug_implementations)]
+
+extern crate crossbeam_utils;
+
+mod array_queue;
+mod err;
+mod seg_queue;
+
+pub use self::array_queue::ArrayQueue;
+pub use self::seg_queue::SegQueue;
+pub use self::err::{PopError, PushError};

--- a/crossbeam-queue/tests/array_queue.rs
+++ b/crossbeam-queue/tests/array_queue.rs
@@ -1,10 +1,11 @@
-extern crate crossbeam;
+extern crate crossbeam_queue;
+extern crate crossbeam_utils;
 extern crate rand;
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use crossbeam::queue::ArrayQueue;
-use crossbeam::scope;
+use crossbeam_queue::ArrayQueue;
+use crossbeam_utils::thread::scope;
 use rand::{thread_rng, Rng};
 
 #[test]

--- a/crossbeam-queue/tests/array_queue.rs
+++ b/crossbeam-queue/tests/array_queue.rs
@@ -29,6 +29,12 @@ fn capacity() {
 }
 
 #[test]
+#[should_panic(expected = "capacity must be non-zero")]
+fn zero_capacity() {
+    let _ = ArrayQueue::<i32>::new(0);
+}
+
+#[test]
 fn len_empty_full() {
     let q = ArrayQueue::new(2);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,8 +100,11 @@ cfg_if! {
         #[doc(hidden)]
         pub use _channel::*;
 
-        /// Concurrent queues.
-        pub mod queue;
+        mod _queue {
+            pub extern crate crossbeam_queue;
+        }
+        #[doc(inline)]
+        pub use _queue::crossbeam_queue as queue;
 
         pub use crossbeam_utils::sync;
         pub use crossbeam_utils::thread;

--- a/tests/subcrates.rs
+++ b/tests/subcrates.rs
@@ -26,6 +26,13 @@ fn epoch() {
 }
 
 #[test]
+fn queue() {
+    let a = crossbeam::queue::ArrayQueue::new(10);
+    let _ = a.push(1);
+    let _ = a.pop();
+}
+
+#[test]
 fn utils() {
     crossbeam::utils::CachePadded::new(7);
 


### PR DESCRIPTION
This PR moves `ArrayQueue` and `SegQueue` into a new crate `crossbeam-queue`.

We need queues in a crate that doesn't pull all other Crossbeam crates as a dependency. In particular, Tokio wants to use MPMC queues but cares a lot about keeping its dependency tree as small as possible. See #292 for more information.

Since we already have the `crossbeam::queue` module, and this simply extracts it into `crossbeam-queue`, and there's a real need for moving queues out of `crossbeam`, I believe the introduction of a new crate should be uncontroversial.

I'll leave this PR open for a few days and merge if there are no objections. If anyone feels this might be a wrong decision, please speak up!

Closes #292 