### PR TITLE
Remove ATOMIC_USIZE_INIT

### DIFF
--- a/crossbeam-epoch/src/atomic.rs
+++ b/crossbeam-epoch/src/atomic.rs
@@ -6,8 +6,7 @@ use core::marker::PhantomData;
 use core::mem;
 use core::ops::{Deref, DerefMut};
 use core::ptr;
-use core::sync::atomic::Ordering;
-use core::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT};
+use core::sync::atomic::{AtomicUsize, Ordering};
 
 use crossbeam_utils::atomic::AtomicConsume;
 use guard::Guard;
@@ -154,7 +153,7 @@ impl<T> Atomic<T> {
     #[cfg(not(feature = "nightly"))]
     pub fn null() -> Atomic<T> {
         Self {
-            data: ATOMIC_USIZE_INIT,
+            data: AtomicUsize::new(0),
             _marker: PhantomData,
         }
     }
@@ -171,7 +170,7 @@ impl<T> Atomic<T> {
     #[cfg(feature = "nightly")]
     pub const fn null() -> Atomic<T> {
         Self {
-            data: ATOMIC_USIZE_INIT,
+            data: AtomicUsize::new(0),
             _marker: PhantomData,
         }
     }

--- a/crossbeam-epoch/src/collector.rs
+++ b/crossbeam-epoch/src/collector.rs
@@ -106,8 +106,7 @@ impl fmt::Debug for LocalHandle {
 #[cfg(test)]
 mod tests {
     use std::mem;
-    use std::sync::atomic::Ordering;
-    use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT};
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use crossbeam_utils::thread;
 
@@ -196,7 +195,7 @@ mod tests {
     #[test]
     fn incremental() {
         const COUNT: usize = 100_000;
-        static DESTROYS: AtomicUsize = ATOMIC_USIZE_INIT;
+        static DESTROYS: AtomicUsize = AtomicUsize::new(0);
 
         let collector = Collector::new();
         let handle = collector.register();
@@ -229,7 +228,7 @@ mod tests {
     #[test]
     fn buffering() {
         const COUNT: usize = 10;
-        static DESTROYS: AtomicUsize = ATOMIC_USIZE_INIT;
+        static DESTROYS: AtomicUsize = AtomicUsize::new(0);
 
         let collector = Collector::new();
         let handle = collector.register();
@@ -262,7 +261,7 @@ mod tests {
     #[test]
     fn count_drops() {
         const COUNT: usize = 100_000;
-        static DROPS: AtomicUsize = ATOMIC_USIZE_INIT;
+        static DROPS: AtomicUsize = AtomicUsize::new(0);
 
         struct Elem(i32);
 
@@ -295,7 +294,7 @@ mod tests {
     #[test]
     fn count_destroy() {
         const COUNT: usize = 100_000;
-        static DESTROYS: AtomicUsize = ATOMIC_USIZE_INIT;
+        static DESTROYS: AtomicUsize = AtomicUsize::new(0);
 
         let collector = Collector::new();
         let handle = collector.register();
@@ -323,7 +322,7 @@ mod tests {
     #[test]
     fn drop_array() {
         const COUNT: usize = 700;
-        static DROPS: AtomicUsize = ATOMIC_USIZE_INIT;
+        static DROPS: AtomicUsize = AtomicUsize::new(0);
 
         struct Elem(i32);
 
@@ -361,7 +360,7 @@ mod tests {
     #[test]
     fn destroy_array() {
         const COUNT: usize = 100_000;
-        static DESTROYS: AtomicUsize = ATOMIC_USIZE_INIT;
+        static DESTROYS: AtomicUsize = AtomicUsize::new(0);
 
         let collector = Collector::new();
         let handle = collector.register();
@@ -396,7 +395,7 @@ mod tests {
     fn stress() {
         const THREADS: usize = 8;
         const COUNT: usize = 100_000;
-        static DROPS: AtomicUsize = ATOMIC_USIZE_INIT;
+        static DROPS: AtomicUsize = AtomicUsize::new(0);
 
         struct Elem(i32);
 

--- a/crossbeam-epoch/src/internal.rs
+++ b/crossbeam-epoch/src/internal.rs
@@ -509,14 +509,13 @@ impl IsElement<Local> for Local {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::Ordering;
-    use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT};
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use super::*;
 
     #[test]
     fn check_defer() {
-        static FLAG: AtomicUsize = ATOMIC_USIZE_INIT;
+        static FLAG: AtomicUsize = AtomicUsize::new(0);
         fn set() {
             FLAG.store(42, Ordering::Relaxed);
         }
@@ -529,7 +528,7 @@ mod tests {
 
     #[test]
     fn check_bag() {
-        static FLAG: AtomicUsize = ATOMIC_USIZE_INIT;
+        static FLAG: AtomicUsize = AtomicUsize::new(0);
         fn incr() {
             FLAG.fetch_add(1, Ordering::Relaxed);
         }

--- a/crossbeam-skiplist/tests/base.rs
+++ b/crossbeam-skiplist/tests/base.rs
@@ -2,7 +2,7 @@ extern crate crossbeam_epoch as epoch;
 extern crate crossbeam_skiplist as skiplist;
 
 use std::ops::Bound;
-use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use skiplist::SkipList;
 
@@ -770,8 +770,8 @@ fn clear() {
 
 #[test]
 fn drops() {
-    static KEYS: AtomicUsize = ATOMIC_USIZE_INIT;
-    static VALUES: AtomicUsize = ATOMIC_USIZE_INIT;
+    static KEYS: AtomicUsize = AtomicUsize::new(0);
+    static VALUES: AtomicUsize = AtomicUsize::new(0);
 
     let collector = epoch::Collector::new();
     let handle = collector.register();


### PR DESCRIPTION
Removes some compilation warnings because `ATOMIC_USIZE_INIT` is deprecated.