### PR TITLE
Join all threads created in tests

### DIFF
--- a/crossbeam-channel/tests/mpsc.rs
+++ b/crossbeam-channel/tests/mpsc.rs
@@ -8,6 +8,7 @@
 //! - Replace `box` syntax with `Box::new`.
 //! - Replace all uses of `Select` with `select!`.
 //! - Change the imports.
+//! - Join all spawned threads.
 //!
 //! Source:
 //!   - https://github.com/rust-lang/rust/tree/master/src/libstd/sync/mpsc


### PR DESCRIPTION
A lot of tests created threads but never waited (joined) on them. As a
result if one of those threads panicked they test still passed and the
test runner exits with a success exit code.

Updates #321.