### PR TITLE
Enable testing on macOS (OS X) on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,11 @@ matrix:
   - rust: 1.26.0
     name: "crossbeam-utils on 1.26.0"
     script: ./ci/crossbeam-utils.sh
+  # Run all test with the highest minimum Rust version on macOS.
+  - rust: 1.28.0
+    os: osx
+    name: "all of crossbeam on 1.28.0 on macOS"
+    script: ./ci/all.sh
 
   # Test crates on nightly Rust.
   - rust: nightly
@@ -68,6 +73,11 @@ matrix:
   - rust: nightly
     name: "crossbeam-utils on nightly"
     script: ./ci/crossbeam-utils.sh
+  # Run all test on macOS.
+  - rust: nightly
+    os: osx
+    name: "all of crossbeam on nightly on macOS"
+    script: ./ci/all.sh
 
   # Check for duplicate dependencies.
   - rust: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
   - rust: 1.28.0
     os: osx
     name: "all of crossbeam on 1.28.0 on macOS"
-    script: ./ci/all.sh
+    script: ./ci/all.sh --test-threads=1
 
   # Test crates on nightly Rust.
   - rust: nightly
@@ -77,7 +77,7 @@ matrix:
   - rust: nightly
     os: osx
     name: "all of crossbeam on nightly on macOS"
-    script: ./ci/all.sh
+    script: ./ci/all.sh --test-threads=1
 
   # Check for duplicate dependencies.
   - rust: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,6 @@ rand = "0.6"
 members = [
   ".",
   "crossbeam-channel",
-  "crossbeam-channel/benchmarks",
   "crossbeam-deque",
   "crossbeam-epoch",
   "crossbeam-queue",

--- a/ci/all.sh
+++ b/ci/all.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+cd "$(dirname "$0")"/..
+set -ex
+
+export RUSTFLAGS="-D warnings"
+
+cargo check --all --no-default-features
+cargo check --all --bins --examples --tests
+cargo test --all
+
+if [[ "$TRAVIS_RUST_VERSION" == "nightly" ]]; then
+    cargo check --all --no-default-features --features nightly
+    cargo test --all --features nightly
+fi

--- a/ci/all.sh
+++ b/ci/all.sh
@@ -7,9 +7,9 @@ export RUSTFLAGS="-D warnings"
 
 cargo check --all --no-default-features
 cargo check --all --bins --examples --tests
-cargo test --all
+cargo test --all -- $@
 
 if [[ "$TRAVIS_RUST_VERSION" == "nightly" ]]; then
     cargo check --all --no-default-features --features nightly
-    cargo test --all --features nightly
+    cargo test --all --features nightly -- $@
 fi

--- a/crossbeam-channel/tests/select.rs
+++ b/crossbeam-channel/tests/select.rs
@@ -327,7 +327,7 @@ fn default_only() {
     assert!(oper.is_err());
     let now = Instant::now();
     assert!(now - start >= ms(450));
-    assert!(now - start <= ms(550));
+    assert!(now - start <= ms(650));
 }
 
 #[test]


### PR DESCRIPTION
Note that macOS on Travis is not the fastest thing in the world and as crossbeam already has a huge number of tests still will greatly increase the time it takes for the check to complete.

Updates #321.