### PR TITLE
Skip use_while_exiting test on macOS

### DIFF
--- a/crossbeam-channel/tests/thread_locals.rs
+++ b/crossbeam-channel/tests/thread_locals.rs
@@ -15,6 +15,7 @@ fn ms(ms: u64) -> Duration {
 }
 
 #[test]
+#[cfg_attr(target_os = "macos", ignore = "TLS is destroyed too early on macOS")]
 fn use_while_exiting() {
     struct Foo;
 


### PR DESCRIPTION
Updates #321.

As per @stjepang suggestion in https://github.com/crossbeam-rs/crossbeam/issues/321#issuecomment-461024423.