### PR TITLE
Deprecate AtomicCell::get_mut

### DIFF
--- a/crossbeam-utils/src/atomic/atomic_cell.rs
+++ b/crossbeam-utils/src/atomic/atomic_cell.rs
@@ -57,6 +57,8 @@ impl<T> AtomicCell<T> {
     ///
     /// assert_eq!(a.load(), 8);
     /// ```
+    #[doc(hidden)]
+    #[deprecated(note = "this method is unsound and will be removed in the next release")]
     pub fn get_mut(&mut self) -> &mut T {
         unsafe { &mut *self.value.get() }
     }


### PR DESCRIPTION
This is an essential step in solving #315 - there is no way to make `AtomicCell::get_mut()` sound, unfortunately. Let's deprecate it and remove in the next release.