### PR TITLE
Release `RefEntry` when dropping `Entry`

### DIFF
--- a/crossbeam-skiplist/src/base.rs
+++ b/crossbeam-skiplist/src/base.rs
@@ -230,7 +230,7 @@ impl<K, V> Node<K, V> {
     /// Decrements the reference count of a node, pinning the thread and destoying the node
     /// if the count become zero.
     #[inline]
-    unsafe fn decremnt_with_pin<F>(&self, pin: F)
+    unsafe fn decrement_with_pin<F>(&self, pin: F)
     where
         F: FnOnce() -> Guard,
     {
@@ -1431,7 +1431,7 @@ impl<'a, K: 'a, V: 'a> RefEntry<'a, K, V> {
     where
         F: FnOnce() -> Guard,
     {
-        unsafe { self.node.decremnt_with_pin(pin) }
+        unsafe { self.node.decrement_with_pin(pin) }
     }
 
     /// Tries to create a new `RefEntry` by incrementing the reference count of

--- a/crossbeam-skiplist/src/base.rs
+++ b/crossbeam-skiplist/src/base.rs
@@ -1401,6 +1401,12 @@ impl<'a, K: 'a, V: 'a> RefEntry<'a, K, V> {
         self.parent
     }
 
+    /// Releases the reference on the entry.
+    pub fn release(self, guard: &Guard) {
+        self.parent.check_guard(guard);
+        unsafe { self.node.decrement(guard) }
+    }
+
     /// Tries to create a new `RefEntry` by incrementing the reference count of
     /// a node.
     unsafe fn try_acquire(
@@ -1529,12 +1535,6 @@ where
                 }
             }
         }
-    }
-
-    /// Releases the reference on the entry.
-    pub fn release(self, guard: &Guard) {
-        self.parent.check_guard(guard);
-        unsafe { self.node.decrement(guard) }
     }
 }
 

--- a/crossbeam-skiplist/src/base.rs
+++ b/crossbeam-skiplist/src/base.rs
@@ -1647,7 +1647,13 @@ where
     pub fn next(&mut self, guard: &Guard) -> Option<RefEntry<'a, K, V>> {
         self.parent.check_guard(guard);
         self.head = match self.head {
-            Some(ref e) => e.next(guard),
+            Some(ref e) => {
+                let next_head = e.next(guard);
+                unsafe {
+                    e.node.decrement(guard);
+                }
+                next_head
+            }
             None => try_pin_loop(|| self.parent.front(guard)),
         };
         let mut finished = false;
@@ -1667,7 +1673,13 @@ where
     pub fn next_back(&mut self, guard: &Guard) -> Option<RefEntry<'a, K, V>> {
         self.parent.check_guard(guard);
         self.tail = match self.tail {
-            Some(ref e) => e.prev(guard),
+            Some(ref e) => {
+                let next_tail = e.prev(guard);
+                unsafe {
+                    e.node.decrement(guard);
+                }
+                next_tail
+            }
             None => try_pin_loop(|| self.parent.back(guard)),
         };
         let mut finished = false;

--- a/crossbeam-skiplist/src/lib.rs
+++ b/crossbeam-skiplist/src/lib.rs
@@ -4,6 +4,7 @@
 #![warn(missing_debug_implementations)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "nightly", feature(alloc))]
+#![feature(manually_drop_take)]
 
 #[macro_use]
 extern crate cfg_if;

--- a/crossbeam-skiplist/src/lib.rs
+++ b/crossbeam-skiplist/src/lib.rs
@@ -4,7 +4,6 @@
 #![warn(missing_debug_implementations)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "nightly", feature(alloc))]
-#![feature(manually_drop_take)]
 
 #[macro_use]
 extern crate cfg_if;

--- a/crossbeam-skiplist/src/map.rs
+++ b/crossbeam-skiplist/src/map.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use std::iter::FromIterator;
 use std::mem::ManuallyDrop;
 use std::ops::{Bound, RangeBounds};
+use std::ptr;
 
 use base::{self, try_pin_loop};
 use epoch;
@@ -254,7 +255,7 @@ impl<'a, K, V> Drop for Entry<'a, K, V>
     fn drop(&mut self) {
         let guard = &epoch::pin();
         unsafe {
-            ManuallyDrop::take(&mut self.inner).release(guard);
+            ManuallyDrop::into_inner(ptr::read(&mut self.inner)).release(guard);
         }
     }
 }

--- a/crossbeam-skiplist/src/map.rs
+++ b/crossbeam-skiplist/src/map.rs
@@ -253,9 +253,9 @@ impl<'a, K, V> Entry<'a, K, V> {
 impl<'a, K, V> Drop for Entry<'a, K, V>
 {
     fn drop(&mut self) {
-        let guard = &epoch::pin();
         unsafe {
-            ManuallyDrop::into_inner(ptr::read(&mut self.inner)).release(guard);
+            ManuallyDrop::into_inner(ptr::read(&mut self.inner))
+                .release_with_pin(|| epoch::pin());
         }
     }
 }


### PR DESCRIPTION
This PR fixes #273. ~in the case where you are using `clear`. The memory leak still persists when you use `Entry::remove()`~. EDIT: both cases are fixed with https://github.com/crossbeam-rs/crossbeam/commit/a6de0ca23b5364d2acc876f6e3d74cb8ab4d7b4a.

I find that when creating a new `Entry`, a reference counter to the node gets incremented, but the counter won't get decremented when `Entry` gets dropped. This could be why garbage were not collected, though I am not entirely sure if it is right. Looking forward to see reviews from the crossbeam maintainers.

Thank you for creating great piece of code and documentation. It was very fun to read both of them.