### PR TITLE
crossbeam-channel: Remove dependency on smallvec

### DIFF
--- a/crossbeam-channel/Cargo.toml
+++ b/crossbeam-channel/Cargo.toml
@@ -15,9 +15,6 @@ description = "Multi-producer multi-consumer channels for message passing"
 keywords = ["channel", "mpmc", "select", "golang", "message"]
 categories = ["algorithms", "concurrency", "data-structures"]
 
-[dependencies]
-smallvec = "0.6.9"
-
 [dependencies.crossbeam-utils]
 version = "0.6.5"
 path = "../crossbeam-utils"

--- a/crossbeam-channel/src/lib.rs
+++ b/crossbeam-channel/src/lib.rs
@@ -348,7 +348,6 @@
 #![warn(missing_debug_implementations)]
 
 extern crate crossbeam_utils;
-extern crate smallvec;
 
 mod channel;
 mod context;

--- a/crossbeam-channel/src/select.rs
+++ b/crossbeam-channel/src/select.rs
@@ -6,7 +6,6 @@ use std::mem;
 use std::time::{Duration, Instant};
 
 use crossbeam_utils::Backoff;
-use smallvec::SmallVec;
 
 use channel::{self, Receiver, Sender};
 use context::Context;
@@ -523,7 +522,7 @@ fn run_ready(handles: &mut [(&SelectHandle, usize, *const u8)], timeout: Timeout
 /// [`ready_timeout`]: struct.Select.html#method.ready_timeout
 pub struct Select<'a> {
     /// A list of senders and receivers participating in selection.
-    handles: SmallVec<[(&'a SelectHandle, usize, *const u8); 4]>,
+    handles: Vec<(&'a SelectHandle, usize, *const u8)>,
 }
 
 unsafe impl<'a> Send for Select<'a> {}
@@ -544,7 +543,7 @@ impl<'a> Select<'a> {
     /// ```
     pub fn new() -> Select<'a> {
         Select {
-            handles: SmallVec::new(),
+            handles: Vec::with_capacity(4),
         }
     }
 


### PR DESCRIPTION
This doesn't seem to affect benchmarks.