### PR TITLE
long-form superscript notation in readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ This crate provides a set of tools for concurrent programming:
 
 #### Atomics
 
-* [`AtomicCell`], a thread-safe mutable memory location.<sup>(\*)</sup>
-* [`AtomicConsume`], for reading from primitive atomic types with "consume" ordering.<sup>(\*)</sup>
+* [`AtomicCell`], a thread-safe mutable memory location.<sup>(no_std)</sup>
+* [`AtomicConsume`], for reading from primitive atomic types with "consume" ordering.<sup>(no_std)</sup>
 
 #### Data structures
 
@@ -26,7 +26,7 @@ This crate provides a set of tools for concurrent programming:
 
 #### Memory management
 
-* [`epoch`], an epoch-based garbage collector.<sup>(\*\*)</sup>
+* [`epoch`], an epoch-based garbage collector.<sup>(alloc)</sup>
 
 #### Thread synchronization
 
@@ -37,12 +37,12 @@ This crate provides a set of tools for concurrent programming:
 
 #### Utilities
 
-* [`Backoff`], for exponential backoff in spin loops.<sup>(\*)</sup>
-* [`CachePadded`], for padding and aligning a value to the length of a cache line.<sup>(\*)</sup>
+* [`Backoff`], for exponential backoff in spin loops.<sup>(no_std)</sup>
+* [`CachePadded`], for padding and aligning a value to the length of a cache line.<sup>(no_std)</sup>
 * [`scope`], for spawning threads that borrow local variables from the stack.
 
-*Features marked with <sup>(\*)</sup> can be used in `no_std` environments.*<br/>
-*Features marked with <sup>(\*\*)</sup> can be used in `no_std` + `alloc` environments.*
+*Features marked with <sup>(no_std)</sup> can be used in `no_std` environments.*<br/>
+*Features marked with <sup>(alloc)</sup> can be used in `no_std` environments that implement `alloc`.*
 
 [`AtomicCell`]: https://docs.rs/crossbeam/*/crossbeam/atomic/struct.AtomicCell.html
 [`AtomicConsume`]: https://docs.rs/crossbeam/*/crossbeam/atomic/trait.AtomicConsume.html

--- a/crossbeam-epoch/README.md
+++ b/crossbeam-epoch/README.md
@@ -18,7 +18,8 @@ may be still using pointers to it at the same time, so it cannot be destroyed
 immediately. Epoch-based GC is an efficient mechanism for deferring destruction of
 shared objects until no pointers to them can exist.
 
-Everything in this crate except the global GC can be used in `no_std` + `alloc` environments.
+Everything in this crate except the global GC can be used in `no_std` environments that implement
+`alloc`.
 
 ## Usage
 

--- a/crossbeam-skiplist/README.md
+++ b/crossbeam-skiplist/README.md
@@ -13,7 +13,7 @@ https://www.rust-lang.org)
 
 **Note:** This crate is still a work in progress.
 
-This crate can be used in `no_std` + `alloc` environments.
+This crate can be used in `no_std` environments that implement `alloc`.
 
 <!--
 ## Usage

--- a/crossbeam-utils/README.md
+++ b/crossbeam-utils/README.md
@@ -15,8 +15,8 @@ This crate provides miscellaneous tools for concurrent programming:
 
 #### Atomics
 
-* [`AtomicCell`], a thread-safe mutable memory location.<sup>(\*)</sup>
-* [`AtomicConsume`], for reading from primitive atomic types with "consume" ordering.<sup>(\*)</sup>
+* [`AtomicCell`], a thread-safe mutable memory location.<sup>(alloc)</sup>
+* [`AtomicConsume`], for reading from primitive atomic types with "consume" ordering.<sup>(alloc)</sup>
 
 #### Thread synchronization
 
@@ -26,11 +26,11 @@ This crate provides miscellaneous tools for concurrent programming:
 
 #### Utilities
 
-* [`Backoff`], for exponential backoff in spin loops.<sup>(\*)</sup>
-* [`CachePadded`], for padding and aligning a value to the length of a cache line.<sup>(\*)</sup>
+* [`Backoff`], for exponential backoff in spin loops.<sup>(alloc)</sup>
+* [`CachePadded`], for padding and aligning a value to the length of a cache line.<sup>(alloc)</sup>
 * [`scope`], for spawning threads that borrow local variables from the stack.
 
-*Features marked with <sup>(\*)</sup> can be used in `no_std` environments.*
+*Features marked with <sup>(no_std)</sup> can be used in `no_std` environments.*<br/>
 
 [`AtomicCell`]: https://docs.rs/crossbeam-utils/*/crossbeam_utils/atomic/struct.AtomicCell.html
 [`AtomicConsume`]: https://docs.rs/crossbeam-utils/*/crossbeam_utils/atomic/trait.AtomicConsume.html


### PR DESCRIPTION
[rendered](https://github.com/yoshuawuyts/crossbeam/blob/e62a39f32e9582b9ff9f0114572eeb173710112c/README.md)

This patch changes the asterisk / double asterisk notation in the READMEs to a long-form variant.

I was reading the README, and it took me a bit to figure out what the asterisks mean. I couldn't figure it out on first glance, so I scrolled down to the bottom of the page, which didn't yield results. Only after careful searching did I find what it meant.

This patch would solve most of the confusion I ran into by just placing the meaning right next to the text, similar to dietary restrictions in a restaurant menu. I feel this would've saved me a bit of searching, and might for others too.

Hope this is helpful; sorry if it's trivial or not really useful. Thanks for your time! :sparkles: