### PR TITLE
Fix CI errors

### DIFF
--- a/crossbeam-channel/src/flavors/tick.rs
+++ b/crossbeam-channel/src/flavors/tick.rs
@@ -60,7 +60,7 @@ impl Channel {
         loop {
             // Compute the time to sleep until the next message or the deadline.
             let offset = {
-                let mut delivery_time = self.delivery_time.load();
+                let delivery_time = self.delivery_time.load();
                 let now = Instant::now();
 
                 // Check if we can receive the next message.

--- a/crossbeam-channel/tests/array.rs
+++ b/crossbeam-channel/tests/array.rs
@@ -634,7 +634,7 @@ fn channel_through_channel() {
 
             for _ in 0..COUNT {
                 let (new_s, new_r) = bounded(1);
-                let mut new_r: T = Box::new(Some(new_r));
+                let new_r: T = Box::new(Some(new_r));
 
                 s.send(new_r).unwrap();
                 s = new_s;

--- a/crossbeam-channel/tests/list.rs
+++ b/crossbeam-channel/tests/list.rs
@@ -513,7 +513,7 @@ fn channel_through_channel() {
 
             for _ in 0..COUNT {
                 let (new_s, new_r) = unbounded();
-                let mut new_r: T = Box::new(Some(new_r));
+                let new_r: T = Box::new(Some(new_r));
 
                 s.send(new_r).unwrap();
                 s = new_s;

--- a/crossbeam-channel/tests/ready.rs
+++ b/crossbeam-channel/tests/ready.rs
@@ -609,7 +609,7 @@ fn stress_timeout_two_threads() {
                     thread::sleep(ms(500));
                 }
 
-                let mut done = false;
+                let done = false;
                 while !done {
                     let mut sel = Select::new();
                     sel.send(&s);
@@ -684,7 +684,7 @@ fn channel_through_channel() {
 
                 for _ in 0..COUNT {
                     let (new_s, new_r) = bounded(cap);
-                    let mut new_r: T = Box::new(Some(new_r));
+                    let new_r: T = Box::new(Some(new_r));
 
                     {
                         let mut sel = Select::new();

--- a/crossbeam-channel/tests/select.rs
+++ b/crossbeam-channel/tests/select.rs
@@ -812,7 +812,7 @@ fn stress_timeout_two_threads() {
                     thread::sleep(ms(500));
                 }
 
-                let mut done = false;
+                let done = false;
                 while !done {
                     let mut sel = Select::new();
                     let oper1 = sel.send(&s);
@@ -958,7 +958,7 @@ fn channel_through_channel() {
 
                 for _ in 0..COUNT {
                     let (new_s, new_r) = bounded(cap);
-                    let mut new_r: T = Box::new(Some(new_r));
+                    let new_r: T = Box::new(Some(new_r));
 
                     {
                         let mut sel = Select::new();

--- a/crossbeam-channel/tests/select_macro.rs
+++ b/crossbeam-channel/tests/select_macro.rs
@@ -698,7 +698,7 @@ fn channel_through_channel() {
 
                 for _ in 0..COUNT {
                     let (new_s, new_r) = bounded(cap);
-                    let mut new_r: T = Box::new(Some(new_r));
+                    let new_r: T = Box::new(Some(new_r));
 
                     select! {
                         send(s, new_r) -> _ => {}
@@ -713,7 +713,7 @@ fn channel_through_channel() {
 
                 for _ in 0..COUNT {
                     r = select! {
-                        recv(r) -> mut msg => {
+                        recv(r) -> msg => {
                             msg.unwrap()
                                 .downcast_mut::<Option<Receiver<T>>>()
                                 .unwrap()

--- a/crossbeam-channel/tests/zero.rs
+++ b/crossbeam-channel/tests/zero.rs
@@ -534,7 +534,7 @@ fn channel_through_channel() {
 
             for _ in 0..COUNT {
                 let (new_s, new_r) = bounded(0);
-                let mut new_r: T = Box::new(Some(new_r));
+                let new_r: T = Box::new(Some(new_r));
 
                 s.send(new_r).unwrap();
                 s = new_s;


### PR DESCRIPTION
The CI says (https://travis-ci.org/crossbeam-rs/crossbeam/jobs/523343513#L485):

```
error: variable does not need to be mutable
  --> crossbeam-channel/src/flavors/tick.rs:63:21
   |
63 |                 let mut delivery_time = self.delivery_time.load();
   |                     ----^^^^^^^^^^^^^
   |                     |
   |                     help: remove this `mut`
   |
   = note: `-D unused-mut` implied by `-D warnings`
error: aborting due to previous error
```

(Not sure why warning is issued as an error.)  Fixing this error.