### PR TITLE
[WIP] Add push/pop lockless

### DIFF
--- a/crossbeam-queue/src/array_queue.rs
+++ b/crossbeam-queue/src/array_queue.rs
@@ -441,10 +441,10 @@ impl<T> ArrayQueue<T> {
                     return Err(PopError);
                 }
 
-                return Err(PushError(value));
+                return Err(PopError);
             } else {
                 // We need to wait for the stamp to get updated, but we cannot lock, so return
-                return Err(PushError(value));
+                return Err(PopError);
             }
         }
     }


### PR DESCRIPTION
This PR will add non-deadlocking push/pop operations to queues -- they will never deadlock even if a concurrent push/pop stalls for whatever reason indefinitely.