### PR TITLE
Require 1.26.0 in deque and utils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ matrix:
   - rust: 1.28.0
     name: "crossbeam-channel on 1.28.0"
     script: ./ci/crossbeam-channel.sh
-  - rust: 1.28.0
-    name: "crossbeam-deque on 1.28.0"
+  - rust: 1.26.0
+    name: "crossbeam-deque on 1.26.0"
     script: ./ci/crossbeam-deque.sh
   - rust: 1.28.0
     name: "crossbeam-epoch on 1.28.0"
@@ -31,8 +31,8 @@ matrix:
   - rust: 1.28.0
     name: "crossbeam-skiplist on 1.28.0"
     script: ./ci/crossbeam-skiplist.sh
-  - rust: 1.28.0
-    name: "crossbeam-utils on 1.28.0"
+  - rust: 1.26.0
+    name: "crossbeam-utils on 1.26.0"
     script: ./ci/crossbeam-utils.sh
 
   # Test crates on nightly Rust.

--- a/crossbeam-deque/README.md
+++ b/crossbeam-deque/README.md
@@ -8,7 +8,7 @@ https://github.com/crossbeam-rs/crossbeam-deque)
 https://crates.io/crates/crossbeam-deque)
 [![Documentation](https://docs.rs/crossbeam-deque/badge.svg)](
 https://docs.rs/crossbeam-deque)
-[![Rust 1.28+](https://img.shields.io/badge/rust-1.28+-lightgray.svg)](
+[![Rust 1.26+](https://img.shields.io/badge/rust-1.26+-lightgray.svg)](
 https://www.rust-lang.org)
 [![chat](https://img.shields.io/discord/569610676205781012.svg?logo=discord)](https://discord.gg/BBYwKq)
 

--- a/crossbeam-utils/README.md
+++ b/crossbeam-utils/README.md
@@ -8,7 +8,7 @@ https://github.com/crossbeam-rs/crossbeam-utils/tree/master/src)
 https://crates.io/crates/crossbeam-utils)
 [![Documentation](https://docs.rs/crossbeam-utils/badge.svg)](
 https://docs.rs/crossbeam-utils)
-[![Rust 1.28+](https://img.shields.io/badge/rust-1.28+-lightgray.svg)](
+[![Rust 1.26+](https://img.shields.io/badge/rust-1.26+-lightgray.svg)](
 https://www.rust-lang.org)
 [![chat](https://img.shields.io/discord/569610676205781012.svg?logo=discord)](https://discord.gg/BBYwKq)
 


### PR DESCRIPTION
`crossbeam-deque` and `crossbeam-utils` don't really need 1.28.0, we can support 1.26.0