### PR TITLE
De-deprecate AtomicCell::get_mut

### DIFF
--- a/crossbeam-utils/src/atomic/atomic_cell.rs
+++ b/crossbeam-utils/src/atomic/atomic_cell.rs
@@ -169,8 +169,11 @@ impl<T: ?Sized> AtomicCell<T> {
     ///
     /// assert_eq!(a.load(), 8);
     /// ```
-    #[doc(hidden)]
-    #[deprecated(note = "this method is unsound and will be removed in the next release")]
+    ///
+    /// # Caveat
+    ///
+    /// This method might be unsound and removed in a future release, but we haven't decided
+    /// yet. See [#315](https://github.com/crossbeam-rs/crossbeam/issues/315) for more details.
     pub fn get_mut(&mut self) -> &mut T {
         unsafe { &mut *self.value.get() }
     }


### PR DESCRIPTION
PR #332 deprecated after the discussion of issue #315, but it is a
measure not yet necessary to take. Revert the deprecation and wait
for us to reach a consensus.