### PR TITLE
Reduce stall in list iteration

### DIFF
--- a/crossbeam-epoch/src/sync/list.rs
+++ b/crossbeam-epoch/src/sync/list.rs
@@ -243,7 +243,7 @@ impl<'g, T: 'g, C: IsElement<T>> Iterator for Iter<'g, T, C> {
                 // This entry was removed. Try unlinking it from the list.
                 let succ = succ.with_tag(0);
 
-                // The tag should never be zero, because removing a node after a logically deleted
+                // The tag should always be zero, because removing a node after a logically deleted
                 // node leaves the list in an invalid state.
                 debug_assert!(self.curr.tag() == 0);
 


### PR DESCRIPTION
In list iteration, even though the CAS to delete a node fails, the iteration may be able to proceed by re-reading the predecessor's next pointer.  A more precise explanation is in the comments.