### PR TITLE
Fix list's finalize API

### DIFF
--- a/crossbeam-epoch/src/internal.rs
+++ b/crossbeam-epoch/src/internal.rs
@@ -45,7 +45,7 @@ use core::sync::atomic::Ordering;
 use arrayvec::ArrayVec;
 use crossbeam_utils::CachePadded;
 
-use atomic::Owned;
+use atomic::{Shared, Owned};
 use collector::{Collector, LocalHandle};
 use deferred::Deferred;
 use epoch::{AtomicEpoch, Epoch};
@@ -501,9 +501,8 @@ impl IsElement<Local> for Local {
         &*local_ptr
     }
 
-    unsafe fn finalize(entry: &Entry) {
-        let local = Self::element_of(entry);
-        drop(Owned::from_raw(local as *const Local as *mut Local));
+    unsafe fn finalize(entry: &Entry, guard: &Guard) {
+        guard.defer_destroy(Shared::from(Self::element_of(entry) as *const _));
     }
 }
 


### PR DESCRIPTION
When an entry is unlinked from list, the current implementation calls `defer_unchecked()` the invocation of the entry's finalizer.  This PR proposes to fix it in such a way that when an entry is unlinked from list, the finalizer is immediately called.

Here is an example why the current implementation is wrong, and this PR fixes it.  Suppose an element is in two (intrusive) linked lists, and their corresponding two finalizers (1) check if the element is unlinked from both lists, and if so, (2) defer the deallocation of the element.  The current implementation cannot express this idea because the invocation of the entry's finalizer is deferred.  On the other hand, this PR can express this idea directly.