### PR TITLE
add BSD license to crossbeam-queue metadata

### DIFF
--- a/crossbeam-channel/Cargo.toml
+++ b/crossbeam-channel/Cargo.toml
@@ -6,7 +6,7 @@ name = "crossbeam-channel"
 # - Create "crossbeam-channel-X.Y.Z" git tag
 version = "0.3.8"
 authors = ["The Crossbeam Project Developers"]
-license = "MIT/Apache-2.0"
+license = "MIT/Apache-2.0 AND BSD-2-Clause"
 readme = "README.md"
 repository = "https://github.com/crossbeam-rs/crossbeam"
 homepage = "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-channel"

--- a/crossbeam-queue/Cargo.toml
+++ b/crossbeam-queue/Cargo.toml
@@ -6,7 +6,7 @@ name = "crossbeam-queue"
 # - Create "crossbeam-queue-X.Y.Z" git tag
 version = "0.1.2"
 authors = ["The Crossbeam Project Developers"]
-license = "MIT OR Apache-2.0 AND BSD-2-Clause"
+license = "MIT/Apache-2.0 AND BSD-2-Clause"
 readme = "README.md"
 repository = "https://github.com/crossbeam-rs/crossbeam"
 homepage = "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-utils"

--- a/crossbeam-queue/Cargo.toml
+++ b/crossbeam-queue/Cargo.toml
@@ -6,7 +6,7 @@ name = "crossbeam-queue"
 # - Create "crossbeam-queue-X.Y.Z" git tag
 version = "0.1.2"
 authors = ["The Crossbeam Project Developers"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0 AND BSD-2-Clause"
 readme = "README.md"
 repository = "https://github.com/crossbeam-rs/crossbeam"
 homepage = "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-utils"


### PR DESCRIPTION
The BSD License is mentioned in the code, but not visible in the metadata. I want to use this crate at work and fixing the metadata would help.