### PR TITLE
Fix leaks

### DIFF
--- a/crossbeam-epoch/src/guard.rs
+++ b/crossbeam-epoch/src/guard.rs
@@ -193,6 +193,8 @@ impl Guard {
     {
         if let Some(local) = self.local.as_ref() {
             local.defer(Deferred::new(move || drop(f())), self);
+        } else {
+            drop(f());
         }
     }
 


### PR DESCRIPTION
This commit fixes the leak of Crossbeam.

When you run the following command for the current master, the address sanitizers detect a handful of leaks:

```sh
RUST_BACKTRACE=1 RUSTFLAGS="-Z sanitizer=address" cargo test
```

This commit fixes such leaks.