### PR TITLE
Add more golang channel tests (closedchan)

### DIFF
--- a/crossbeam-channel/tests/golang.rs
+++ b/crossbeam-channel/tests/golang.rs
@@ -53,7 +53,7 @@ impl<T> Chan<T> {
             .expect("sending into closed channel")
             .clone();
         let _ = s.send(msg);
-        
+
         // FIXME
         // let guard = self
         //     .inner
@@ -72,15 +72,10 @@ impl<T> Chan<T> {
     }
 
     fn try_send(&self, msg: T) -> bool {
-        let guard = self
-            .inner
-            .lock()
-            .unwrap();
+        let guard = self.inner.lock().unwrap();
 
         match guard.s.as_ref() {
-            Some(ss) => {
-                ss.clone().try_send(msg).is_ok()
-            },
+            Some(ss) => ss.clone().try_send(msg).is_ok(),
             None => {
                 std::mem::drop(guard);
                 panic!("sending into closed channel")
@@ -1584,8 +1579,8 @@ mod closedchan {
             }
 
             // send should work with ,ok too: sent a value without blocking, so ok == true.
-            if let Ok(_) =
-                ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {})) // FIXME c.nbsend(1)
+            if let Ok(_) = ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {}))
+            // FIXME c.nbsend(1)
             {
                 //panic!("test1: no panic on nb send on closed channel");
             }
@@ -1602,7 +1597,8 @@ mod closedchan {
 
             // similarly Send.
             //c.send(1);
-            if let Ok(_) = ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {})) // FIXME c.send(1)
+            if let Ok(_) = ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {}))
+            // FIXME c.send(1)
             {
                 //panic!("test1: no panic on send to closed channel");
             }
@@ -1621,15 +1617,15 @@ mod closedchan {
     fn testasync2(c: &GoChan) -> bool {
         let mut failed = false;
         match c.recv() {
-            Some(1) => {},
+            Some(1) => {}
             Some(x) => {
                 println!("testasync1: recv did not get 1: {} {}", x, c.get_impl());
-		        failed = true
-            },
+                failed = true
+            }
             None => {
                 println!("testasync1: recv got nothing: {}", c.get_impl());
-		        failed = true
-            },
+                failed = true
+            }
         }
 
         // prevent short-circuit
@@ -1640,15 +1636,15 @@ mod closedchan {
     fn testasync4(c: &GoChan) -> bool {
         let mut failed = false;
         match c.nbrecv() {
-            Some(1) => {},
+            Some(1) => {}
             Some(x) => {
                 println!("testasync1: try_recv did not get 1: {} {}", x, c.get_impl());
-		        failed = true
-            },
+                failed = true
+            }
             None => {
                 println!("testasync1: try_recv got nothing: {}", c.get_impl());
-		        failed = true
-            },
+                failed = true
+            }
         }
 
         // prevent short-circuit
@@ -1671,9 +1667,12 @@ mod closedchan {
 
     #[test]
     fn main() {
-        let mk_x = |c: Chan<i32>| { XChan {inner: c}};
-        let mk_s = |c: Chan<i32>| { SChan {inner: c}};
-        let mk_ss = |c: Chan<i32>| { SSChan {inner: c, dummy: make::<i32>(0)}};
+        let mk_x = |c: Chan<i32>| XChan { inner: c };
+        let mk_s = |c: Chan<i32>| SChan { inner: c };
+        let mk_ss = |c: Chan<i32>| SSChan {
+            inner: c,
+            dummy: make::<i32>(0),
+        };
 
         let mut failed = false;
 

--- a/crossbeam-channel/tests/golang.rs
+++ b/crossbeam-channel/tests/golang.rs
@@ -1501,7 +1501,7 @@ mod closedchan {
         fn nbsend(&self, n: i32) -> bool {
             select! {
                 default => { false },
-                send(self.inner.tx(), n) -> _ => { true },
+                send(self.inner.tx(), n) -> res => { res.unwrap(); true },
             }
         }
         fn recv(&self) -> Option<i32> {

--- a/crossbeam-channel/tests/golang.rs
+++ b/crossbeam-channel/tests/golang.rs
@@ -72,15 +72,15 @@ impl<T> Chan<T> {
     }
 
     fn try_send(&self, msg: T) -> bool {
-        let guard = self.inner.lock().unwrap();
-
-        match guard.s.as_ref() {
-            Some(ss) => ss.clone().try_send(msg).is_ok(),
-            None => {
-                std::mem::drop(guard);
-                panic!("sending into closed channel")
-            }
-        }
+        let s = self
+            .inner
+            .lock()
+            .unwrap()
+            .s
+            .as_ref()
+            .expect("sending into closed channel")
+            .clone();
+        s.try_send(msg).is_ok()
     }
 
     fn try_recv(&self) -> Option<T> {

--- a/crossbeam-channel/tests/golang.rs
+++ b/crossbeam-channel/tests/golang.rs
@@ -1495,7 +1495,7 @@ mod closedchan {
     impl GoChan for SChan {
         fn send(&self, n: i32) {
             select! {
-                send(self.inner.tx(), n) -> _ => {}
+                send(self.inner.tx(), n) -> res => res.unwrap()
             }
         }
         fn nbsend(&self, n: i32) -> bool {


### PR DESCRIPTION
This addresses #201 , specifically tests from here https://github.com/golang/go/blob/master/test/closedchan.go

I am yet new to Rust.
Currently there are 3 issues:
1) `send` implementation of `Chan` can panic while holding the `Mutex`. This is bad if we want to test for panic to occur. Do you have any suggestions on where should I look?
My implementation in comments works in my case, but some other tests are started to take more than 60 seconds.
2) `send` in `select!` for closed channels blocks, because it returns sender for `bounded(0)`.
In `Go` panic is expected. I can implement `SenderFlavour` which always panics, but it will impose runtime overhead for other code, so it doesn't worth it.
Can it be done other way?
3) problem with packing closures in generic vector (I will deal with it later)

Please let me know your opinion.