### PR TITLE
Prevent drift in tick delivery (fix #406)

### DIFF
--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -272,9 +272,9 @@ pub fn never<T>() -> Receiver<T> {
 /// assert!(eq(r.recv().unwrap(), start + ms(200)));
 /// assert!(eq(Instant::now(), start + ms(600)));
 ///
-/// // This message was sent 700 ms from the start and received 700 ms from the start.
-/// assert!(eq(r.recv().unwrap(), start + ms(700)));
-/// assert!(eq(Instant::now(), start + ms(700)));
+/// // This message was sent 300 ms from the start and received 600 ms from the start.
+/// assert!(eq(r.recv().unwrap(), start + ms(300)));
+/// assert!(eq(Instant::now(), start + ms(600)));
 /// ```
 pub fn tick(duration: Duration) -> Receiver<Instant> {
     Receiver {

--- a/crossbeam-channel/src/flavors/tick.rs
+++ b/crossbeam-channel/src/flavors/tick.rs
@@ -46,7 +46,7 @@ impl Channel {
 
             if self
                 .delivery_time
-                .compare_exchange(delivery_time, now + self.duration)
+                .compare_exchange(delivery_time, delivery_time + self.duration)
                 .is_ok()
             {
                 return Ok(delivery_time);
@@ -67,7 +67,7 @@ impl Channel {
                 if now >= delivery_time
                     && self
                         .delivery_time
-                        .compare_exchange(delivery_time, now + self.duration)
+                        .compare_exchange(delivery_time, delivery_time + self.duration)
                         .is_ok()
                 {
                     return Ok(delivery_time);

--- a/crossbeam-channel/tests/tick.rs
+++ b/crossbeam-channel/tests/tick.rs
@@ -23,7 +23,7 @@ fn fire() {
     let r = tick(ms(50));
 
     assert_eq!(r.try_recv(), Err(TryRecvError::Empty));
-    thread::sleep(ms(100));
+    thread::sleep(ms(80));
 
     let fired = r.try_recv().unwrap();
     assert!(start < fired);
@@ -31,7 +31,7 @@ fn fire() {
 
     let now = Instant::now();
     assert!(fired < now);
-    assert!(now - fired >= ms(50));
+    assert!(now - fired >= ms(30));
 
     assert_eq!(r.try_recv(), Err(TryRecvError::Empty));
 
@@ -60,6 +60,9 @@ fn intervals() {
     assert!(start + ms(100) <= t2);
     assert!(start + ms(150) > t2);
 
+    for _ in 0..5 {
+        r.try_recv().unwrap();
+    }
     assert_eq!(r.try_recv(), Err(TryRecvError::Empty));
     let t3 = r.recv().unwrap();
     assert!(start + ms(400) <= t3);
@@ -86,7 +89,7 @@ fn len_empty_full() {
     assert_eq!(r.is_empty(), true);
     assert_eq!(r.is_full(), false);
 
-    thread::sleep(ms(100));
+    thread::sleep(ms(50));
 
     assert_eq!(r.len(), 1);
     assert_eq!(r.is_empty(), false);


### PR DESCRIPTION
Calculate the next delivery time based on the previous one instead of the time the thread awoke, preventing a small but noticeable drift from accumulating.