### PR TITLE
Remove ArrayVec dependency

### DIFF
--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["concurrency", "memory-management", "no-std"]
 
 [features]
 default = ["std"]
-nightly = ["crossbeam-utils/nightly", "arrayvec/use_union"]
+nightly = ["crossbeam-utils/nightly"]
 std = ["crossbeam-utils/std", "lazy_static"]
 alloc = ["crossbeam-utils/alloc"]
 sanitize = [] # Makes it more likely to trigger any potential data races.
@@ -25,10 +25,6 @@ sanitize = [] # Makes it more likely to trigger any potential data races.
 [dependencies]
 cfg-if = "0.1.2"
 memoffset = "0.5"
-
-[dependencies.arrayvec]
-version = "0.4"
-default-features = false
 
 [dependencies.crossbeam-utils]
 version = "0.6"

--- a/crossbeam-epoch/src/internal.rs
+++ b/crossbeam-epoch/src/internal.rs
@@ -42,7 +42,6 @@ use core::ptr;
 use core::sync::atomic;
 use core::sync::atomic::Ordering;
 
-use arrayvec::ArrayVec;
 use crossbeam_utils::CachePadded;
 
 use atomic::{Shared, Owned};
@@ -60,10 +59,11 @@ const MAX_OBJECTS: usize = 64;
 const MAX_OBJECTS: usize = 4;
 
 /// A bag of deferred functions.
-#[derive(Default, Debug)]
+// can't #[derive(Debug)] because Debug is not implemented for arrays 64 items long
 pub struct Bag {
     /// Stashed objects.
-    deferreds: ArrayVec<[Deferred; MAX_OBJECTS]>,
+    deferreds: [Deferred; MAX_OBJECTS],
+    len: usize
 }
 
 /// `Bag::try_push()` requires that it is safe for another thread to execute the given functions.
@@ -77,7 +77,7 @@ impl Bag {
 
     /// Returns `true` if the bag is empty.
     pub fn is_empty(&self) -> bool {
-        self.deferreds.is_empty()
+        self.len == 0
     }
 
     /// Attempts to insert a deferred function into the bag.
@@ -89,7 +89,13 @@ impl Bag {
     ///
     /// It should be safe for another thread to execute the given function.
     pub unsafe fn try_push(&mut self, deferred: Deferred) -> Result<(), Deferred> {
-        self.deferreds.try_push(deferred).map_err(|e| e.element())
+        if self.len < MAX_OBJECTS {
+            self.deferreds[self.len] = deferred;
+            self.len += 1;
+            Ok(())
+        } else {
+            Err(deferred)
+        }
     }
 
     /// Seals the bag with the given epoch.
@@ -98,17 +104,48 @@ impl Bag {
     }
 }
 
+impl Default for Bag {
+    fn default() -> Self {
+        // [no_op; MAX_OBJECTS] blocked by https://github.com/rust-lang/rust/issues/49147
+        #[cfg(not(feature = "sanitize"))]
+        return Bag { len: 0, deferreds:
+            [Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func),
+             Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func),
+             Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func),
+             Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func),
+             Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func),
+             Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func),
+             Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func),
+             Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func),
+             Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func),
+             Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func),
+             Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func),
+             Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func),
+             Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func),
+             Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func),
+             Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func),
+             Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func)]
+        };
+        #[cfg(feature = "sanitize")]
+        return Bag { len: 0, deferreds: [Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func)] };
+    }
+}
+
 impl Drop for Bag {
     fn drop(&mut self) {
         // Call all deferred functions.
-        for deferred in self.deferreds.drain(..) {
+        for i in 0..self.len {
+            let no_op = Deferred::new(no_op_func);
+            let deferred = mem::replace(&mut self.deferreds[i], no_op);
             deferred.call();
         }
     }
 }
 
+fn no_op_func() {}
+
 /// A pair of an epoch and a bag.
-#[derive(Default, Debug)]
+#[derive(Default)]
 struct SealedBag {
     epoch: Epoch,
     bag: Bag,

--- a/crossbeam-epoch/src/internal.rs
+++ b/crossbeam-epoch/src/internal.rs
@@ -38,7 +38,7 @@
 use core::cell::{Cell, UnsafeCell};
 use core::mem::{self, ManuallyDrop};
 use core::num::Wrapping;
-use core::ptr;
+use core::{ptr, fmt};
 use core::sync::atomic;
 use core::sync::atomic::Ordering;
 
@@ -142,8 +142,8 @@ impl Drop for Bag {
 }
 
 // can't #[derive(Debug)] because Debug is not implemented for arrays 64 items long
-impl core::fmt::Debug for Bag {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+impl fmt::Debug for Bag {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Bag").field("deferreds", &&self.deferreds[..self.len]).finish()
     }
 }

--- a/crossbeam-epoch/src/internal.rs
+++ b/crossbeam-epoch/src/internal.rs
@@ -59,7 +59,6 @@ const MAX_OBJECTS: usize = 64;
 const MAX_OBJECTS: usize = 4;
 
 /// A bag of deferred functions.
-// can't #[derive(Debug)] because Debug is not implemented for arrays 64 items long
 pub struct Bag {
     /// Stashed objects.
     deferreds: [Deferred; MAX_OBJECTS],
@@ -142,10 +141,25 @@ impl Drop for Bag {
     }
 }
 
+// can't #[derive(Debug)] because Debug is not implemented for arrays 64 items long
+impl core::fmt::Debug for Bag {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "Bag {{ deferreds: [")?;
+        if ! self.is_empty() {
+            write!(f, "{:?}", self.deferreds[0])?;
+        }
+        for i in 1..self.len {
+            write!(f, ", {:?}", self.deferreds[i])?;
+        }
+        write!(f, "] }}")?;
+        Ok(())
+    }
+}
+
 fn no_op_func() {}
 
 /// A pair of an epoch and a bag.
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct SealedBag {
     epoch: Epoch,
     bag: Bag,

--- a/crossbeam-epoch/src/internal.rs
+++ b/crossbeam-epoch/src/internal.rs
@@ -144,15 +144,7 @@ impl Drop for Bag {
 // can't #[derive(Debug)] because Debug is not implemented for arrays 64 items long
 impl core::fmt::Debug for Bag {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "Bag {{ deferreds: [")?;
-        if ! self.is_empty() {
-            write!(f, "{:?}", self.deferreds[0])?;
-        }
-        for i in 1..self.len {
-            write!(f, ", {:?}", self.deferreds[i])?;
-        }
-        write!(f, "] }}")?;
-        Ok(())
+        f.debug_struct("Bag").field("deferreds", &&self.deferreds[..self.len]).finish()
     }
 }
 

--- a/crossbeam-epoch/src/internal.rs
+++ b/crossbeam-epoch/src/internal.rs
@@ -105,7 +105,7 @@ impl Bag {
 
 impl Default for Bag {
     fn default() -> Self {
-        // [no_op; MAX_OBJECTS] blocked by https://github.com/rust-lang/rust/issues/49147
+        // TODO: [no_op; MAX_OBJECTS] syntax blocked by https://github.com/rust-lang/rust/issues/49147
         #[cfg(not(feature = "sanitize"))]
         return Bag { len: 0, deferreds:
             [Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func),

--- a/crossbeam-epoch/src/lib.rs
+++ b/crossbeam-epoch/src/lib.rs
@@ -79,7 +79,6 @@ cfg_if! {
 )]
 cfg_if! {
     if #[cfg(any(feature = "alloc", feature = "std"))] {
-        extern crate arrayvec;
         extern crate crossbeam_utils;
         #[macro_use]
         extern crate memoffset;


### PR DESCRIPTION
`ArrayVec` is used in just one place, and even there crossbeam uses a small part of its API surface. This PR replaces ArrayVec with 100% safe code using a plain old array and ditches the ArrayVec dependency altogether.

This removes 170 unsafe expressions from the dependency tree according to [cargo-geiger](https://github.com/anderejd/cargo-geiger). With less unsafe code to worry about there's less chance of memory safety bugs, and safety/security audits will be cheaper and easier to perform.

An unfortunate casualty of this change is `#[derive(Debug)]` on internal structures because there is no Debug implementation for `[T; 64]` - these impls are only generated up to length of 32. It will be possible to re-enable it once const generics are stabilized. For now they're implemented manually.

`cargo bench` results are unaffected - or might be within experimental noise of 2% or so, hard to tell without statistical analysis on benchmark results.