### PR TITLE
Fix breakage with nightly feature

### DIFF
--- a/crossbeam-epoch/src/lib.rs
+++ b/crossbeam-epoch/src/lib.rs
@@ -73,10 +73,7 @@ cfg_if! {
     }
 }
 
-#[cfg_attr(
-    feature = "nightly",
-    cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
-)]
+#[cfg_attr(feature = "nightly", cfg(target_has_atomic = "ptr"))]
 cfg_if! {
     if #[cfg(any(feature = "alloc", feature = "std"))] {
         extern crate crossbeam_utils;

--- a/crossbeam-skiplist/src/lib.rs
+++ b/crossbeam-skiplist/src/lib.rs
@@ -18,10 +18,7 @@ cfg_if! {
     }
 }
 
-#[cfg_attr(
-    feature = "nightly",
-    cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
-)]
+#[cfg_attr(feature = "nightly", cfg(target_has_atomic = "ptr"))]
 cfg_if! {
     if #[cfg(any(feature = "alloc", feature = "std"))] {
         extern crate crossbeam_epoch as epoch;

--- a/crossbeam-utils/src/lib.rs
+++ b/crossbeam-utils/src/lib.rs
@@ -44,10 +44,7 @@ cfg_if! {
     }
 }
 
-#[cfg_attr(
-    feature = "nightly",
-    cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
-)]
+#[cfg_attr(feature = "nightly", cfg(target_has_atomic = "ptr"))]
 pub mod atomic;
 
 mod cache_padded;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,10 +68,7 @@ pub use _epoch::crossbeam_epoch as epoch;
 
 extern crate crossbeam_utils;
 
-#[cfg_attr(
-    feature = "nightly",
-    cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
-)]
+#[cfg_attr(feature = "nightly", cfg(target_has_atomic = "ptr"))]
 pub use crossbeam_utils::atomic;
 
 /// Miscellaneous utilities.


### PR DESCRIPTION
`target_has_atomic = "cas"` was removed in https://github.com/rust-lang/rust/pull/65214.

Fixes https://github.com/rust-lang/rust/issues/65424 

