### PR TITLE
Limit lazy_static version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ std = [
 alloc = ["crossbeam-epoch/alloc", "crossbeam-utils/alloc"]
 
 [dependencies]
-cfg-if = "0.1.2"
+cfg-if = "~0.1.9"
 
 [dependencies.crossbeam-channel]
 version = "0.3.9"

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -23,7 +23,7 @@ alloc = ["crossbeam-utils/alloc"]
 sanitize = [] # Makes it more likely to trigger any potential data races.
 
 [dependencies]
-cfg-if = "0.1.2"
+cfg-if = "~0.1.9"
 memoffset = "0.5"
 
 [dependencies.crossbeam-utils]

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -32,7 +32,7 @@ path = "../crossbeam-utils"
 default-features = false
 
 [dependencies.lazy_static]
-version = "1"
+version = "~1.3.0"
 optional = true
 
 [dependencies.scopeguard]

--- a/crossbeam-skiplist/Cargo.toml
+++ b/crossbeam-skiplist/Cargo.toml
@@ -22,7 +22,7 @@ std = ["crossbeam-epoch/std", "crossbeam-utils/std"]
 alloc = ["crossbeam-epoch/alloc", "crossbeam-utils/alloc"]
 
 [dependencies]
-cfg-if = "0.1.2"
+cfg-if = "~0.1.9"
 
 [dependencies.crossbeam-epoch]
 version = "0.7"

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -22,7 +22,7 @@ std = ["lazy_static"]
 alloc = []
 
 [dependencies]
-cfg-if = "0.1.2"
+cfg-if = "~0.1.9"
 lazy_static = { version = "~1.3.0", optional = true }
 
 [dev-dependencies]

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -23,7 +23,7 @@ alloc = []
 
 [dependencies]
 cfg-if = "0.1.2"
-lazy_static = { version = "1.1.0", optional = true }
+lazy_static = { version = "~1.3.0", optional = true }
 
 [dev-dependencies]
 rand = "0.6"


### PR DESCRIPTION
Closes #412 

It's necessary to accept #428, which is fixing a breakage of Rust ecosystems...