### PR TITLE
Cheat around the unsafe_code lint in the select macro

### DIFF
--- a/crossbeam-channel/src/lib.rs
+++ b/crossbeam-channel/src/lib.rs
@@ -364,6 +364,7 @@ mod waker;
 pub mod internal {
     pub use select::SelectHandle;
     pub use select::{select, select_timeout, try_select};
+    pub use select_macro::unsafe_transmute;
 }
 
 pub use channel::{after, never, tick};

--- a/crossbeam-channel/tests/select_macro.rs
+++ b/crossbeam-channel/tests/select_macro.rs
@@ -1,6 +1,6 @@
 //! Tests for the `select!` macro.
 
-#![deny(unsafe_code)]
+#![forbid(unsafe_code)]
 
 #[macro_use]
 extern crate crossbeam_channel;


### PR DESCRIPTION
Fixes #405.