### PR TITLE
Fix golang test (chan_test)

### DIFF
--- a/crossbeam-channel/tests/golang.rs
+++ b/crossbeam-channel/tests/golang.rs
@@ -946,14 +946,14 @@ mod chan_test {
 
                 go!(c, done, {
                     let v = c.try_recv();
-                    done.send(v.is_some());
+                    done.send(v.is_none());
                 });
 
                 thread::sleep(ms(1));
                 c.close();
 
                 if !done.recv().unwrap() {
-                    // panic!();
+                    panic!();
                 }
             }
 


### PR DESCRIPTION
The original test has:

https://github.com/golang/go/blob/03bb3e9ad13ef49afbed7e422d21ef6eb00389c1/src/runtime/chan_test.go#L105-L108

Notably `done <- v == 0 && ok == false`, which in Rust ought to be `done.send(v.is_none())`.