### PR TITLE
Do not perform superfluous bounds checks on dropping crossbeam-epoch::Bag

### DIFF
--- a/crossbeam-epoch/src/internal.rs
+++ b/crossbeam-epoch/src/internal.rs
@@ -133,10 +133,10 @@ impl Default for Bag {
 impl Drop for Bag {
     fn drop(&mut self) {
         // Call all deferred functions.
-        for i in 0..self.len {
+        for deferred in &mut self.deferreds[..self.len] {
             let no_op = Deferred::new(no_op_func);
-            let deferred = mem::replace(&mut self.deferreds[i], no_op);
-            deferred.call();
+            let owned_deferred = mem::replace(deferred, no_op);
+            owned_deferred.call();
         }
     }
 }


### PR DESCRIPTION
Addresses [this comment](https://github.com/crossbeam-rs/crossbeam/pull/414#discussion_r328208426) that I didn't get a chance to act upon before merging #414. 

This way bounds checks should be performed only once. However, this does not measurably impact benchmarks.