### PR TITLE
Prepare for the next release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Version 0.7.3
+
+- Fix breakage with nightly feature due to rust-lang/rust#65214.
+- Bump `crossbeam-channel` to `0.4`.
+- Bump `crossbeam-epoch` to `0.8`.
+- Bump `crossbeam-queue` to `0.2`.
+- Bump `crossbeam-utils` to `0.7`.
+
 # Version 0.7.2
 
 - Bump `crossbeam-channel` to `0.3.9`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-X.Y.Z" git tag
-version = "0.7.2"
+version = "0.7.3"
 authors = ["The Crossbeam Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -35,7 +35,7 @@ alloc = ["crossbeam-epoch/alloc", "crossbeam-utils/alloc"]
 cfg-if = "0.1.2"
 
 [dependencies.crossbeam-channel]
-version = "0.3.9"
+version = "0.4"
 path = "./crossbeam-channel"
 optional = true
 
@@ -45,17 +45,17 @@ path = "./crossbeam-deque"
 optional = true
 
 [dependencies.crossbeam-epoch]
-version = "0.7.2"
+version = "0.8"
 path = "./crossbeam-epoch"
 default-features = false
 
 [dependencies.crossbeam-queue]
-version = "0.1.0"
+version = "0.2"
 path = "./crossbeam-queue"
 optional = true
 
 [dependencies.crossbeam-utils]
-version = "0.6.6"
+version = "0.7"
 path = "./crossbeam-utils"
 default-features = false
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ Next, add this to your crate:
 extern crate crossbeam;
 ```
 
+## Compatibility
+
+The minimum supported Rust version is 1.28. Any change to this is considered a breaking change.
+
 ## Contributing
 
 Crossbeam welcomes contribution from everyone in the form of suggestions, bug reports,

--- a/crossbeam-channel/CHANGELOG.md
+++ b/crossbeam-channel/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 0.4.0
+
+- Bump the minimum required version to 1.28.
+- Bump `crossbeam-utils` to `0.7`.
+
 # Version 0.3.9
 
 - Fix a bug in reference counting.

--- a/crossbeam-channel/Cargo.toml
+++ b/crossbeam-channel/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-channel"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-channel-X.Y.Z" git tag
-version = "0.3.9"
+version = "0.4.0"
 authors = ["The Crossbeam Project Developers"]
 license = "MIT/Apache-2.0 AND BSD-2-Clause"
 readme = "README.md"
@@ -16,7 +16,7 @@ keywords = ["channel", "mpmc", "select", "golang", "message"]
 categories = ["algorithms", "concurrency", "data-structures"]
 
 [dependencies.crossbeam-utils]
-version = "0.6.5"
+version = "0.7"
 path = "../crossbeam-utils"
 
 [dev-dependencies]

--- a/crossbeam-channel/README.md
+++ b/crossbeam-channel/README.md
@@ -51,6 +51,10 @@ Next, add this to your crate:
 extern crate crossbeam_channel;
 ```
 
+## Compatibility
+
+The minimum supported Rust version is 1.28. Any change to this is considered a breaking change.
+
 ## License
 
 Licensed under either of

--- a/crossbeam-deque/CHANGELOG.md
+++ b/crossbeam-deque/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 0.7.2
+
+- Bump `crossbeam-epoch` to `0.8`.
+- Bump `crossbeam-utils` to `0.7`.
+
 # Version 0.7.1
 
 - Bump the minimum required version of `crossbeam-utils`.

--- a/crossbeam-deque/Cargo.toml
+++ b/crossbeam-deque/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-deque"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-deque-X.Y.Z" git tag
-version = "0.7.1"
+version = "0.7.2"
 authors = ["The Crossbeam Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -16,11 +16,11 @@ keywords = ["chase-lev", "lock-free", "scheduler", "scheduling"]
 categories = ["algorithms", "concurrency", "data-structures"]
 
 [dependencies.crossbeam-epoch]
-version = "0.7"
+version = "0.8"
 path = "../crossbeam-epoch"
 
 [dependencies.crossbeam-utils]
-version = "0.6.5"
+version = "0.7"
 path = "../crossbeam-utils"
 
 [dev-dependencies]

--- a/crossbeam-deque/README.md
+++ b/crossbeam-deque/README.md
@@ -30,6 +30,10 @@ Next, add this to your crate:
 extern crate crossbeam_deque;
 ```
 
+## Compatibility
+
+The minimum supported Rust version is 1.28. Any change to this is considered a breaking change.
+
 ## License
 
 Licensed under either of

--- a/crossbeam-epoch/CHANGELOG.md
+++ b/crossbeam-epoch/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Version 0.8.0
+
+- Bump the minimum required version to 1.28.
+- Fix breakage with nightly feature due to rust-lang/rust#65214.
+- Make `Atomic::null()` const function at 1.31+.
+- Bump `crossbeam-utils` to `0.7`.
+
 # Version 0.7.2
 
 - Add `Atomic::into_owned()`.

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-epoch"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-epoch-X.Y.Z" git tag
-version = "0.7.2"
+version = "0.8.0"
 authors = ["The Crossbeam Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -27,7 +27,7 @@ cfg-if = "0.1.2"
 memoffset = "0.5"
 
 [dependencies.crossbeam-utils]
-version = "0.6"
+version = "0.7"
 path = "../crossbeam-utils"
 default-features = false
 

--- a/crossbeam-epoch/README.md
+++ b/crossbeam-epoch/README.md
@@ -37,6 +37,10 @@ Next, add this to your crate:
 extern crate crossbeam_epoch as epoch;
 ```
 
+## Compatibility
+
+The minimum supported Rust version is 1.28. Any change to this is considered a breaking change.
+
 ## License
 
 Licensed under either of

--- a/crossbeam-queue/CHANGELOG.md
+++ b/crossbeam-queue/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 0.2.0
+
+- Bump the minimum required version to 1.28.
+- Bump `crossbeam-utils` to `0.7`.
+
 # Version 0.1.2
 
 - Update `crossbeam-utils` to `0.6.5`.

--- a/crossbeam-queue/Cargo.toml
+++ b/crossbeam-queue/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-queue"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-queue-X.Y.Z" git tag
-version = "0.1.2"
+version = "0.2.0"
 authors = ["The Crossbeam Project Developers"]
 license = "MIT/Apache-2.0 AND BSD-2-Clause"
 readme = "README.md"
@@ -16,7 +16,7 @@ keywords = ["queue", "mpmc", "lock-free", "producer", "consumer"]
 categories = ["concurrency", "data-structures"]
 
 [dependencies.crossbeam-utils]
-version = "0.6.5"
+version = "0.7"
 path = "../crossbeam-utils"
 
 [dev-dependencies]

--- a/crossbeam-queue/README.md
+++ b/crossbeam-queue/README.md
@@ -37,7 +37,7 @@ extern crate crossbeam_queue;
 
 ## Compatibility
 
-The minimum supported Rust version is 1.28.
+The minimum supported Rust version is 1.28. Any change to this is considered a breaking change.
 
 ## License
 

--- a/crossbeam-skiplist/Cargo.toml
+++ b/crossbeam-skiplist/Cargo.toml
@@ -25,12 +25,12 @@ alloc = ["crossbeam-epoch/alloc", "crossbeam-utils/alloc"]
 cfg-if = "0.1.2"
 
 [dependencies.crossbeam-epoch]
-version = "0.7"
+version = "0.8"
 path = "../crossbeam-epoch"
 default-features = false
 
 [dependencies.crossbeam-utils]
-version = "0.6"
+version = "0.7"
 path = "../crossbeam-utils"
 default-features = false
 

--- a/crossbeam-skiplist/README.md
+++ b/crossbeam-skiplist/README.md
@@ -33,6 +33,10 @@ extern crate crossbeam_skiplist;
 ```
 -->
 
+## Compatibility
+
+The minimum supported Rust version is 1.28. Any change to this is considered a breaking change.
+
 ## License
 
 Licensed under either of

--- a/crossbeam-utils/CHANGELOG.md
+++ b/crossbeam-utils/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Version 0.7.0
+
+- Bump the minimum required version to 1.28.
+- Fix breakage with nightly feature due to rust-lang/rust#65214.
+- Apply `#[repr(transparent)]` to `AtomicCell`.
+- Make `AtomicCell::new()` const function at 1.31+.
+
 # Version 0.6.6
 
 - Add `UnwindSafe` and `RefUnwindSafe` impls for `AtomicCell`.
@@ -30,7 +37,7 @@
 
 - Fix a soundness bug in `Scope::spawn()`.
 - Remove the `T: 'scope` bound on `ScopedJoinHandle`.
- 
+
 # Version 0.6.0
 
 - Move `AtomicConsume` to `atomic` module.

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-utils"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-utils-X.Y.Z" git tag
-version = "0.6.6"
+version = "0.7.0"
 authors = ["The Crossbeam Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/crossbeam-utils/README.md
+++ b/crossbeam-utils/README.md
@@ -57,6 +57,10 @@ Next, add this to your crate:
 extern crate crossbeam_utils;
 ```
 
+## Compatibility
+
+The minimum supported Rust version is 1.28. Any change to this is considered a breaking change.
+
 ## License
 
 Licensed under either of


### PR DESCRIPTION
This updates version numbers and changelogs.

- crossbeam 0.7.3
- crossbeam-channel 0.4.0
- crossbeam-deque 0.7.2
- crossbeam-epoch 0.8.0
- crossbeam-queue 0.2.0
- crossbeam-utils 0.7.0

cc #435 
cc #443 
cc #446