### PR TITLE
fix broken doc link

### DIFF
--- a/crossbeam-epoch/src/lib.rs
+++ b/crossbeam-epoch/src/lib.rs
@@ -52,7 +52,7 @@
 //! [`Collector`]: struct.Collector.html
 //! [`Shared`]: struct.Shared.html
 //! [`pin`]: fn.pin.html
-//! [`defer`]: fn.defer.html
+//! [`defer`]: struct.Guard.html#method.defer
 
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]


### PR DESCRIPTION
The docs tried to refer to a top-level 'defer' function; instead link to
Guard::defer.