### PR TITLE
Format with rustfmt

### DIFF
--- a/crossbeam-epoch/src/default.rs
+++ b/crossbeam-epoch/src/default.rs
@@ -70,6 +70,7 @@ mod tests {
                 super::pin();
                 // At thread exit, `HANDLE` gets dropped first and `FOO` second.
             });
-        }).unwrap();
+        })
+        .unwrap();
     }
 }

--- a/crossbeam-epoch/src/internal.rs
+++ b/crossbeam-epoch/src/internal.rs
@@ -38,13 +38,13 @@
 use core::cell::{Cell, UnsafeCell};
 use core::mem::{self, ManuallyDrop};
 use core::num::Wrapping;
-use core::{ptr, fmt};
 use core::sync::atomic;
 use core::sync::atomic::Ordering;
+use core::{fmt, ptr};
 
 use crossbeam_utils::CachePadded;
 
-use atomic::{Shared, Owned};
+use atomic::{Owned, Shared};
 use collector::{Collector, LocalHandle};
 use deferred::Deferred;
 use epoch::{AtomicEpoch, Epoch};
@@ -62,7 +62,7 @@ const MAX_OBJECTS: usize = 4;
 pub struct Bag {
     /// Stashed objects.
     deferreds: [Deferred; MAX_OBJECTS],
-    len: usize
+    len: usize,
 }
 
 /// `Bag::try_push()` requires that it is safe for another thread to execute the given functions.
@@ -104,6 +104,9 @@ impl Bag {
 }
 
 impl Default for Bag {
+    // TODO(taiki-e): when the minimum supported Rust version is bumped to 1.31+,
+    // replace this with `#[rustfmt::skip]`.
+    #[cfg_attr(rustfmt, rustfmt_skip)]
     fn default() -> Self {
         // TODO: [no_op; MAX_OBJECTS] syntax blocked by https://github.com/rust-lang/rust/issues/49147
         #[cfg(not(feature = "sanitize"))]
@@ -126,7 +129,15 @@ impl Default for Bag {
              Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func)]
         };
         #[cfg(feature = "sanitize")]
-        return Bag { len: 0, deferreds: [Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func), Deferred::new(no_op_func)] };
+        return Bag {
+            len: 0,
+            deferreds: [
+                Deferred::new(no_op_func),
+                Deferred::new(no_op_func),
+                Deferred::new(no_op_func),
+                Deferred::new(no_op_func),
+            ],
+        };
     }
 }
 
@@ -144,7 +155,9 @@ impl Drop for Bag {
 // can't #[derive(Debug)] because Debug is not implemented for arrays 64 items long
 impl fmt::Debug for Bag {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Bag").field("deferreds", &&self.deferreds[..self.len]).finish()
+        f.debug_struct("Bag")
+            .field("deferreds", &&self.deferreds[..self.len])
+            .finish()
     }
 }
 

--- a/crossbeam-skiplist/src/map.rs
+++ b/crossbeam-skiplist/src/map.rs
@@ -111,10 +111,7 @@ where
     }
 
     /// Returns an iterator over a subset of entries in the skip list.
-    pub fn range<Q, R>(
-        &self,
-        range: R,
-    ) -> Range<'_, Q, R, K, V>
+    pub fn range<Q, R>(&self, range: R) -> Range<'_, Q, R, K, V>
     where
         K: Borrow<Q>,
         R: RangeBounds<Q>,
@@ -231,7 +228,9 @@ pub struct Entry<'a, K: 'a, V: 'a> {
 
 impl<'a, K, V> Entry<'a, K, V> {
     fn new(inner: base::RefEntry<'a, K, V>) -> Entry<'a, K, V> {
-        Entry { inner: ManuallyDrop::new(inner) }
+        Entry {
+            inner: ManuallyDrop::new(inner),
+        }
     }
 
     /// Returns a reference to the key.
@@ -250,8 +249,7 @@ impl<'a, K, V> Entry<'a, K, V> {
     }
 }
 
-impl<'a, K, V> Drop for Entry<'a, K, V>
-{
+impl<'a, K, V> Drop for Entry<'a, K, V> {
     fn drop(&mut self) {
         unsafe {
             ManuallyDrop::into_inner(ptr::read(&mut self.inner)).release_with_pin(epoch::pin);

--- a/crossbeam-skiplist/src/set.rs
+++ b/crossbeam-skiplist/src/set.rs
@@ -101,10 +101,7 @@ where
     }
 
     /// Returns an iterator over a subset of entries in the skip list.
-    pub fn range<Q, R>(
-        &self,
-        range: R,
-    ) -> Range<'_, Q, R, T>
+    pub fn range<Q, R>(&self, range: R) -> Range<'_, Q, R, T>
     where
         T: Borrow<Q>,
         R: RangeBounds<Q>,

--- a/crossbeam-utils/src/atomic/seq_lock_wide.rs
+++ b/crossbeam-utils/src/atomic/seq_lock_wide.rs
@@ -121,7 +121,9 @@ impl Drop for SeqLockWriteGuard {
         // Release ordering for synchronizing with `optimistic_read`.
         if state_lo == 0 {
             let state_hi = self.lock.state_hi.load(Ordering::Relaxed);
-            self.lock.state_hi.store(state_hi.wrapping_add(1), Ordering::Release);
+            self.lock
+                .state_hi
+                .store(state_hi.wrapping_add(1), Ordering::Release);
         }
 
         // Release the lock and increment the stamp.

--- a/crossbeam-utils/src/sync/mod.rs
+++ b/crossbeam-utils/src/sync/mod.rs
@@ -12,6 +12,6 @@ mod parker;
 mod sharded_lock;
 mod wait_group;
 
-pub use self::sharded_lock::{ShardedLock, ShardedLockReadGuard, ShardedLockWriteGuard};
 pub use self::parker::{Parker, Unparker};
+pub use self::sharded_lock::{ShardedLock, ShardedLockReadGuard, ShardedLockWriteGuard};
 pub use self::wait_group::WaitGroup;

--- a/crossbeam-utils/src/sync/wait_group.rs
+++ b/crossbeam-utils/src/sync/wait_group.rs
@@ -132,8 +132,6 @@ impl Clone for WaitGroup {
 impl fmt::Debug for WaitGroup {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let count: &usize = &*self.inner.count.lock().unwrap();
-        f.debug_struct("WaitGroup")
-            .field("count", count)
-            .finish()
+        f.debug_struct("WaitGroup").field("count", count).finish()
     }
 }


### PR DESCRIPTION
This fix build failure in #449 and #448

It seems old rustfmt did not properly format the module in the macro.