### PR TITLE
Support dynamically sized types

### DIFF
--- a/crossbeam-epoch/src/atomic.rs
+++ b/crossbeam-epoch/src/atomic.rs
@@ -8,6 +8,7 @@ use core::slice;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::alloc::alloc;
+use crate::alloc::boxed::Box;
 use crate::guard::Guard;
 use crossbeam_utils::atomic::AtomicConsume;
 

--- a/crossbeam-epoch/src/atomic.rs
+++ b/crossbeam-epoch/src/atomic.rs
@@ -130,7 +130,7 @@ fn decompose_tag<T: ?Sized + Pointable>(data: usize) -> (usize, usize) {
 ///
 /// ```
 /// use std::mem::MaybeUninit;
-/// use crossbeam_epoch::{self as epoch, Owned};
+/// use crossbeam_epoch::Owned;
 ///
 /// let o = Owned::<[MaybeUninit<i32>]>::init(10); // allocating [i32; 10]
 /// ```
@@ -862,7 +862,7 @@ impl<T> Owned<T> {
     /// # Examples
     ///
     /// ```
-    /// use crossbeam_epoch::{self as epoch, Owned};
+    /// use crossbeam_epoch::Owned;
     ///
     /// let o = Owned::new(1234);
     /// let b: Box<i32> = o.into_box();
@@ -907,7 +907,7 @@ impl<T: ?Sized + Pointable> Owned<T> {
     /// # Examples
     ///
     /// ```
-    /// use crossbeam_epoch::Owned;
+    /// use crossbeam_epoch::{self as epoch, Owned};
     ///
     /// let o = Owned::new(1234);
     /// let guard = &epoch::pin();

--- a/crossbeam-epoch/src/atomic.rs
+++ b/crossbeam-epoch/src/atomic.rs
@@ -1016,7 +1016,7 @@ pub struct Shared<'g, T: 'g + ?Sized + Pointable> {
 
 impl<T: ?Sized + Pointable> Clone for Shared<'_, T> {
     fn clone(&self) -> Self {
-        Shared {
+        Self {
             data: self.data,
             _marker: PhantomData,
         }

--- a/crossbeam-epoch/src/atomic.rs
+++ b/crossbeam-epoch/src/atomic.rs
@@ -200,6 +200,9 @@ impl<T> Pointable for T {
 ///
 /// Elements are not present in the type, but they will be in the allocation.
 /// ```
+///
+// TODO(@jeehoonkang): once we bump the minimum required Rust version to 1.44 or newer, use
+// [`alloc::alloc::Layout::extend`] instead.
 #[repr(C)]
 struct Array<T> {
     size: usize,

--- a/crossbeam-epoch/src/collector.rs
+++ b/crossbeam-epoch/src/collector.rs
@@ -12,9 +12,9 @@
 ///
 /// handle.pin().flush();
 /// ```
-use alloc::sync::Arc;
 use core::fmt;
 
+use crate::alloc::sync::Arc;
 use crate::guard::Guard;
 use crate::internal::{Global, Local};
 

--- a/crossbeam-epoch/src/internal.rs
+++ b/crossbeam-epoch/src/internal.rs
@@ -395,8 +395,8 @@ impl Local {
                 handle_count: Cell::new(1),
                 pin_count: Cell::new(Wrapping(0)),
             })
-            .into_shared(&unprotected());
-            collector.global.locals.insert(local, &unprotected());
+            .into_shared(unprotected());
+            collector.global.locals.insert(local, unprotected());
             LocalHandle {
                 local: local.as_raw(),
             }
@@ -586,7 +586,7 @@ impl Local {
             let collector: Collector = ptr::read(&*(*self.collector.get()));
 
             // Mark this node in the linked list as deleted.
-            self.entry.delete(&unprotected());
+            self.entry.delete(unprotected());
 
             // Finally, drop the reference to the global. Note that this might be the last reference
             // to the `Global`. If so, the global data will be destroyed and all deferred functions

--- a/crossbeam-epoch/src/lib.rs
+++ b/crossbeam-epoch/src/lib.rs
@@ -64,6 +64,7 @@
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]
+#![cfg_attr(feature = "nightly", feature(const_fn))]
 
 use cfg_if::cfg_if;
 
@@ -80,7 +81,7 @@ cfg_if! {
         mod internal;
         mod sync;
 
-        pub use self::atomic::{Atomic, CompareAndSetError, CompareAndSetOrdering, Owned, Pointer, Shared};
+        pub use self::atomic::{Pointable, Atomic, CompareAndSetError, CompareAndSetOrdering, Owned, Pointer, Shared};
         pub use self::collector::{Collector, LocalHandle};
         pub use self::guard::{unprotected, Guard};
     }

--- a/crossbeam-epoch/src/sync/list.rs
+++ b/crossbeam-epoch/src/sync/list.rs
@@ -218,7 +218,7 @@ impl<T, C: IsElement<T>> List<T, C> {
 impl<T, C: IsElement<T>> Drop for List<T, C> {
     fn drop(&mut self) {
         unsafe {
-            let guard = &unprotected();
+            let guard = unprotected();
             let mut curr = self.head.load(Relaxed, guard);
             while let Some(c) = curr.as_ref() {
                 let succ = c.next.load(Relaxed, guard);

--- a/crossbeam-epoch/src/sync/queue.rs
+++ b/crossbeam-epoch/src/sync/queue.rs
@@ -52,7 +52,7 @@ impl<T> Queue<T> {
             next: Atomic::null(),
         });
         unsafe {
-            let guard = &unprotected();
+            let guard = unprotected();
             let sentinel = sentinel.into_shared(guard);
             q.head.store(sentinel, Relaxed);
             q.tail.store(sentinel, Relaxed);
@@ -196,7 +196,7 @@ impl<T> Queue<T> {
 impl<T> Drop for Queue<T> {
     fn drop(&mut self) {
         unsafe {
-            let guard = &unprotected();
+            let guard = unprotected();
 
             while let Some(_) = self.try_pop(guard) {}
 


### PR DESCRIPTION
It supersedes #209 for supporting dynamically sized types (DST) in Crossbeam.  It's much cleaner and less intrusive than the previous attempts in that it doesn't introduce another `Atomic` type.  `Atomic<T>` is still there without significant changes.

The key idea is (1) instead of requiring the condition on `T: Sized`, (2) requiring `T: Pointable` that means an object of type `T` can be pointed to by a single word.  For instance, `Atomic` becomes: `pub struct Atomic<T: ?Sized + Pointable> { ... }`.

It is breaking the backward compatibility in that it ~~(1) increases the minimum required Rust version to 1.36 (for `MaybeUninit`) and (2)~~ now `const fn Atomic::null()` is Nightly only.