### PR TITLE
Implement OS extension traits for ScopedJoinHandle

### DIFF
--- a/crossbeam-utils/tests/thread.rs
+++ b/crossbeam-utils/tests/thread.rs
@@ -179,3 +179,33 @@ fn join_nested() {
     })
     .unwrap();
 }
+
+#[cfg(unix)]
+#[test]
+fn as_pthread_t() {
+    use std::os::unix::thread::JoinHandleExt;
+    thread::scope(|scope| {
+        let handle = scope.spawn(|_scope| {
+            sleep(Duration::from_millis(100));
+            42
+        });
+        let _pthread_t = handle.as_pthread_t();
+        handle.join().unwrap();
+    })
+    .unwrap();
+}
+
+#[cfg(windows)]
+#[test]
+fn as_raw_handle() {
+    use std::os::windows::io::AsRawHandle;
+    thread::scope(|scope| {
+        let handle = scope.spawn(|_scope| {
+            sleep(Duration::from_millis(100));
+            42
+        });
+        let _raw_handle = handle.as_raw_handle();
+        handle.join().unwrap();
+    })
+    .unwrap();
+}


### PR DESCRIPTION
Resolves #197

I implemented `into_pthread_t()`/`into_raw_handle()` methods by calling the `as` variants, as I'm not sure it would be sound to consume the join handle, since there would then be no guarantee the thread is joined before the end of the scope.