### PR TITLE
relax memory ordering of treiber stack

### DIFF
--- a/crossbeam-epoch/examples/treiber_stack.rs
+++ b/crossbeam-epoch/examples/treiber_stack.rs
@@ -64,7 +64,7 @@ impl<T> TreiberStack<T> {
 
                     if self
                         .head
-                        .compare_and_set(head, next, Release, &guard)
+                        .compare_and_set(head, next, Relaxed, &guard)
                         .is_ok()
                     {
                         unsafe {


### PR DESCRIPTION
I think it is correct to use relaxed ordering, since:
1. pop function has no data to publish to other thread.
2. all write operations on `TreiberStack.head` is atomic read-modify-write, so will be part of the `release sequence` headed by the release operation in `push` function, according to the [cpp ref](https://en.cppreference.com/w/cpp/atomic/memory_order).