### PR TITLE
Make the `queue` module available on no_std + alloc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ std = [
   "crossbeam-queue",
   "crossbeam-utils/std",
 ]
-alloc = ["crossbeam-epoch/alloc", "crossbeam-utils/alloc"]
+alloc = ["crossbeam-epoch/alloc", "crossbeam-utils/alloc", "crossbeam-queue/alloc"]
 
 [dependencies]
 cfg-if = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ std = [
   "crossbeam-channel",
   "crossbeam-deque",
   "crossbeam-epoch/std",
-  "crossbeam-queue",
+  "crossbeam-queue/std",
   "crossbeam-utils/std",
 ]
 alloc = ["crossbeam-epoch/alloc", "crossbeam-utils/alloc", "crossbeam-queue/alloc"]
@@ -52,6 +52,7 @@ default-features = false
 [dependencies.crossbeam-queue]
 version = "0.2"
 path = "./crossbeam-queue"
+default-features = false
 optional = true
 
 [dependencies.crossbeam-utils]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ travis-ci = { repository = "crossbeam-rs/crossbeam" }
 
 [features]
 default = ["std"]
-nightly = ["crossbeam-epoch/nightly", "crossbeam-utils/nightly"]
+nightly = ["crossbeam-epoch/nightly", "crossbeam-utils/nightly", "crossbeam-queue/nightly"]
 std = [
   "crossbeam-channel",
   "crossbeam-deque",

--- a/crossbeam-queue/Cargo.toml
+++ b/crossbeam-queue/Cargo.toml
@@ -19,6 +19,7 @@ categories = ["concurrency", "data-structures"]
 default = ["std"]
 std = ["crossbeam-utils/std"]
 alloc = ["crossbeam-utils/alloc"]
+nightly = []
 
 [dependencies]
 cfg-if = "0.1.2"

--- a/crossbeam-queue/src/lib.rs
+++ b/crossbeam-queue/src/lib.rs
@@ -11,6 +11,7 @@
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]
 
 #[macro_use]
 extern crate cfg_if;
@@ -29,6 +30,7 @@ cfg_if! {
 
 extern crate crossbeam_utils;
 
+#[cfg_attr(feature = "nightly", cfg(target_has_atomic = "ptr"))]
 cfg_if! {
     if #[cfg(any(feature = "alloc", feature = "std"))] {
         mod array_queue;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,12 @@ pub mod utils {
     pub use crossbeam_utils::CachePadded;
 }
 
+mod _queue {
+    pub extern crate crossbeam_queue;
+}
+#[doc(inline)]
+pub use _queue::crossbeam_queue as queue;
+
 cfg_if! {
     if #[cfg(feature = "std")] {
         mod _deque {
@@ -95,12 +101,6 @@ cfg_if! {
         // HACK(stjepang): This is the only way to reexport `select!` in Rust older than 1.30.0
         #[doc(hidden)]
         pub use _channel::*;
-
-        mod _queue {
-            pub extern crate crossbeam_queue;
-        }
-        #[doc(inline)]
-        pub use _queue::crossbeam_queue as queue;
 
         pub use crossbeam_utils::sync;
         pub use crossbeam_utils::thread;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@ pub mod utils {
     pub use crossbeam_utils::CachePadded;
 }
 
+#[cfg_attr(feature = "nightly", cfg(target_has_atomic = "ptr"))]
 cfg_if! {
     if #[cfg(any(feature = "std", feature = "alloc"))] {
         mod _queue {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,6 @@ pub mod utils {
     pub use crossbeam_utils::CachePadded;
 }
 
-#[cfg_attr(feature = "nightly", cfg(target_has_atomic = "ptr"))]
 cfg_if! {
     if #[cfg(any(feature = "std", feature = "alloc"))] {
         mod _queue {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,11 +77,15 @@ pub mod utils {
     pub use crossbeam_utils::CachePadded;
 }
 
-mod _queue {
-    pub extern crate crossbeam_queue;
+cfg_if! {
+    if #[cfg(any(feature = "std", feature = "alloc"))] {
+        mod _queue {
+            pub extern crate crossbeam_queue;
+        }
+        #[doc(inline)]
+        pub use _queue::crossbeam_queue as queue;
+    }
 }
-#[doc(inline)]
-pub use _queue::crossbeam_queue as queue;
 
 cfg_if! {
     if #[cfg(feature = "std")] {


### PR DESCRIPTION
The crossbeam_queue crate is no_std compatible since #455.