### PR TITLE
fix discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ https://crates.io/crates/crossbeam)
 https://docs.rs/crossbeam)
 [![Rust 1.28+](https://img.shields.io/badge/rust-1.28+-lightgray.svg)](
 https://www.rust-lang.org)
-[![chat](https://img.shields.io/discord/569610676205781012.svg?logo=discord)](https://discord.gg/JXYwgWZ)
+[![chat](https://img.shields.io/discord/569610676205781012.svg?logo=discord)](https://discordapp.com/invite/JXYwgWZ)
 
 This crate provides a set of tools for concurrent programming:
 


### PR DESCRIPTION
found this *working* invite link here: https://github.com/crossbeam-rs/crossbeam/issues/366#issue-437944578

fixes #483