### PR TITLE
Fix `features` typo in ArrayQueue's error types (crossbeam-queue)

### DIFF
--- a/crossbeam-queue/src/err.rs
+++ b/crossbeam-queue/src/err.rs
@@ -16,7 +16,7 @@ impl fmt::Display for PopError {
     }
 }
 
-#[cfg(features = "std")]
+#[cfg(feature = "std")]
 impl std::error::Error for PopError {
     fn description(&self) -> &str {
         "popping from an empty queue"
@@ -39,7 +39,7 @@ impl<T> fmt::Display for PushError<T> {
     }
 }
 
-#[cfg(features = "std")]
+#[cfg(feature = "std")]
 impl<T: Send> std::error::Error for PushError<T> {
     fn description(&self) -> &str {
         "pushing into a full queue"

--- a/crossbeam-queue/src/err.rs
+++ b/crossbeam-queue/src/err.rs
@@ -17,7 +17,7 @@ impl fmt::Display for PopError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for PopError {
+impl ::std::error::Error for PopError {
     fn description(&self) -> &str {
         "popping from an empty queue"
     }
@@ -40,7 +40,7 @@ impl<T> fmt::Display for PushError<T> {
 }
 
 #[cfg(feature = "std")]
-impl<T: Send> std::error::Error for PushError<T> {
+impl<T: Send> ::std::error::Error for PushError<T> {
     fn description(&self) -> &str {
         "pushing into a full queue"
     }


### PR DESCRIPTION
Currenly, `PushError` and `PopError` do not implement `std::error::Error` even when `std` feature is activated :(