### PR TITLE
epoch: Move away from pointers as usize

### DIFF
--- a/crossbeam-epoch/src/atomic.rs
+++ b/crossbeam-epoch/src/atomic.rs
@@ -621,14 +621,36 @@ pub trait Pointer<T> {
     fn into_usize(self) -> usize;
 
     /// Returns the machine representation of the pointer.
-    fn into_ptr(self) -> *mut T;
+    ///
+    /// The Self: Sized bound will go away once the deprecated into_usize is removed.
+    fn into_ptr(self) -> *mut T
+    where
+        Self: Sized,
+    {
+        // this fallback impl is only provided to be backwards compatible.
+        // remove when default impl when into_usize is removed.
+        // transmute preserves pointer provenance
+        #[allow(deprecated)]
+        core::mem::transmute(self.into_usize())
+    }
 
     /// Returns a new pointer pointing to the tagged pointer `data`.
     #[deprecated(since = "0.8.3", note = "prefer `from_ptr`")]
     unsafe fn from_usize(data: usize) -> Self;
 
     /// Returns a new pointer pointing to the tagged pointer `data`.
-    unsafe fn from_ptr(data: *mut T) -> Self;
+    ///
+    /// The Self: Sized bound will go away once the deprecated from_usize is removed.
+    unsafe fn from_ptr(data: *mut T) -> Self
+    where
+        Self: Sized,
+    {
+        // this fallback impl is only provided to be backwards compatible.
+        // remove when default impl when from_usize is removed.
+        // transmute preserves pointer provenance
+        #[allow(deprecated)]
+        Self::from_usize(core::mem::transmute(data))
+    }
 }
 
 /// An owned heap-allocated object.


### PR DESCRIPTION
Pointers stored as `usize` tend to cause miri to lose pointer provenance
tracking, which means we can't take advantage of its checking! See also
the discussion at
https://github.com/rust-lang/miri/issues/940#issuecomment-612097677.

This does not yet compile since `AtomicPtr` does not have `fetch_*`
methods. They were added and then removed from the standard library back
in the day (https://github.com/rust-lang/rust/pull/10154), but I think
the reason they were removed has now been remedied, so they will
hopefully come back again!

cc @RalfJung 