### PR TITLE
Add a ping-pong benchmark to crossbeam-channel

### DIFF
--- a/crossbeam-channel/benchmarks/crossbeam-channel.rs
+++ b/crossbeam-channel/benchmarks/crossbeam-channel.rs
@@ -27,6 +27,28 @@ fn seq(cap: Option<usize>) {
     }
 }
 
+fn ping_pong(cap: Option<usize>) {
+    let (txa, rxb) = new(cap);
+    let (txb, rxa) = new::<message::Message>(cap);
+
+    crossbeam::scope(|scope| {
+        scope.spawn(|_| {
+            // This enforces a proper data dependency between the read/write
+            let mut val = message::new(0);
+            for _ in 0..MESSAGES {
+                txa.send(val).unwrap();
+                val = rxa.recv().unwrap();
+            }
+        });
+
+        for _ in 0..MESSAGES {
+            let val = rxb.recv().unwrap();
+            txb.send(val).unwrap();
+        }
+    })
+    .unwrap();
+}
+
 fn spsc(cap: Option<usize>) {
     let (tx, rx) = new(cap);
 
@@ -167,12 +189,14 @@ fn main() {
     run!("bounded0_select_both", select_both(Some(0)));
     run!("bounded0_select_rx", select_rx(Some(0)));
     run!("bounded0_spsc", spsc(Some(0)));
+    run!("bounded0_ping_pong", ping_pong(Some(0)));
 
     run!("bounded1_mpmc", mpmc(Some(1)));
     run!("bounded1_mpsc", mpsc(Some(1)));
     run!("bounded1_select_both", select_both(Some(1)));
     run!("bounded1_select_rx", select_rx(Some(1)));
     run!("bounded1_spsc", spsc(Some(1)));
+    run!("bounded1_ping_pong", ping_pong(Some(1)));
 
     run!("bounded_mpmc", mpmc(Some(MESSAGES)));
     run!("bounded_mpsc", mpsc(Some(MESSAGES)));
@@ -180,6 +204,7 @@ fn main() {
     run!("bounded_select_rx", select_rx(Some(MESSAGES)));
     run!("bounded_seq", seq(Some(MESSAGES)));
     run!("bounded_spsc", spsc(Some(MESSAGES)));
+    run!("bounded_ping_pong", ping_pong(Some(MESSAGES)));
 
     run!("unbounded_mpmc", mpmc(None));
     run!("unbounded_mpsc", mpsc(None));
@@ -187,4 +212,5 @@ fn main() {
     run!("unbounded_select_rx", select_rx(None));
     run!("unbounded_seq", seq(None));
     run!("unbounded_spsc", spsc(None));
+    run!("unbounded_ping_pong", ping_pong(None));
 }

--- a/crossbeam-channel/benchmarks/go.go
+++ b/crossbeam-channel/benchmarks/go.go
@@ -38,6 +38,29 @@ func spsc(cap int) {
     <-done
 }
 
+func ping_pong(cap int) {
+    var ca = make(chan Message, cap)
+    var cb = make(chan Message, cap)
+    var done = make(chan bool)
+
+    go func() {
+        var val = Message(0)
+        for i := 0; i < MESSAGES; i++ {
+            ca <- val
+            val = <- cb
+        }
+        done <- true
+    }()
+
+    for i := 0; i < MESSAGES; i++ {
+        var val = Message(0)
+        val = <- ca
+        cb <- val
+    }
+
+    <-done
+}
+
 func mpsc(cap int) {
     var c = make(chan Message, cap)
     var done = make(chan bool)
@@ -180,12 +203,14 @@ func main() {
     run("bounded0_select_both", select_both, 0)
     run("bounded0_select_rx", select_rx, 0)
     run("bounded0_spsc", spsc, 0)
+    run("bounded0_ping_pong", ping_pong, 0)
 
     run("bounded1_mpmc", mpmc, 1)
     run("bounded1_mpsc", mpsc, 1)
     run("bounded1_select_both", select_both, 1)
     run("bounded1_select_rx", select_rx, 1)
     run("bounded1_spsc", spsc, 1)
+    run("bounded1_ping_pong", ping_pong, 1)
 
     run("bounded_mpmc", mpmc, MESSAGES)
     run("bounded_mpsc", mpsc, MESSAGES)
@@ -193,4 +218,5 @@ func main() {
     run("bounded_select_rx", select_rx, MESSAGES)
     run("bounded_seq", seq, MESSAGES)
     run("bounded_spsc", spsc, MESSAGES)
+    run("bounded_ping_pong", ping_pong, MESSAGES)
 }

--- a/crossbeam-channel/benchmarks/plot.py
+++ b/crossbeam-channel/benchmarks/plot.py
@@ -84,28 +84,28 @@ plot(
     221,
     "Bounded channel of capacity 0",
     'bounded0',
-    ['spsc', 'mpsc', 'mpmc', 'select_rx', 'select_both'],
+    ['spsc', 'ping_pong', 'mpsc', 'mpmc', 'select_rx', 'select_both'],
 )
 
 plot(
     222,
     "Bounded channel of capacity 1",
     'bounded1',
-    ['spsc', 'mpsc', 'mpmc', 'select_rx', 'select_both'],
+    ['spsc', 'ping_pong', 'mpsc', 'mpmc', 'select_rx', 'select_both'],
 )
 
 plot(
     223,
     "Bounded channel of capacity N",
     'bounded',
-    ['seq', 'spsc', 'mpsc', 'mpmc', 'select_rx', 'select_both'],
+    ['seq', 'spsc', 'ping_pong', 'mpsc', 'mpmc', 'select_rx', 'select_both'],
 )
 
 plot(
     224,
     "Unbounded channel",
     'unbounded',
-    ['seq', 'spsc', 'mpsc', 'mpmc', 'select_rx', 'select_both'],
+    ['seq', 'spsc', 'ping_pong', 'mpsc', 'mpmc', 'select_rx', 'select_both'],
 )
 
 plt.subplots_adjust(


### PR DESCRIPTION
Ping-pong is an important benchmark since it measure latency
characteristics of the transport as opposed to plain throughput
characteristics. In addition, it also is a decent test of the
empty-channel read cost