### PR TITLE
Add {Sender, Receiver}::is_connected

### DIFF
--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -440,6 +440,16 @@ impl<T> Sender<T> {
         }
     }
 
+    /// Returns `true` if one or more receivers are connected, `false`
+    /// otherwise.
+    pub fn is_connected(&self) -> bool {
+        match &self.flavor {
+            SenderFlavor::Array(chan) => chan.is_connected(),
+            SenderFlavor::List(chan) => chan.is_connected(),
+            SenderFlavor::Zero(chan) => chan.is_connected(),
+        }
+    }
+
     /// Returns `true` if the channel is empty.
     ///
     /// Note: Zero-capacity channels are always empty.
@@ -805,6 +815,20 @@ impl<T> Receiver<T> {
                 }
             }
             ReceiverFlavor::Never(chan) => chan.recv(Some(deadline)),
+        }
+    }
+
+    /// Returns `true` if one or more senders are connected, `false` otherwise.
+    ///
+    /// For [`after`] and [`tick`] channels this always returns `true`. For
+    /// [`never`] channels this always returns `false`.
+    pub fn is_connected(&self) -> bool {
+        match &self.flavor {
+            ReceiverFlavor::Array(chan) => chan.is_connected(),
+            ReceiverFlavor::List(chan) => chan.is_connected(),
+            ReceiverFlavor::Zero(chan) => chan.is_connected(),
+            ReceiverFlavor::After(_) | ReceiverFlavor::Tick(_) => true,
+            ReceiverFlavor::Never(_) => false,
         }
     }
 

--- a/crossbeam-channel/src/counter.rs
+++ b/crossbeam-channel/src/counter.rs
@@ -44,6 +44,10 @@ impl<C> Sender<C> {
         unsafe { &*self.counter }
     }
 
+    pub fn is_connected(&self) -> bool {
+        self.counter().receivers.load(Ordering::Relaxed) >= 1
+    }
+
     /// Acquires another sender reference.
     pub fn acquire(&self) -> Sender<C> {
         let count = self.counter().senders.fetch_add(1, Ordering::Relaxed);
@@ -97,6 +101,10 @@ impl<C> Receiver<C> {
     /// Returns the internal `Counter`.
     fn counter(&self) -> &Counter<C> {
         unsafe { &*self.counter }
+    }
+
+    pub fn is_connected(&self) -> bool {
+        self.counter().senders.load(Ordering::Relaxed) >= 1
     }
 
     /// Acquires another receiver reference.

--- a/crossbeam-channel/tests/after.rs
+++ b/crossbeam-channel/tests/after.rs
@@ -337,3 +337,9 @@ fn fairness_duplicates() {
         assert!(hits.iter().all(|x| *x >= COUNT / hits.len() / 2));
     }
 }
+
+#[test]
+fn is_connected() {
+    let r = after(ms(100));
+    assert!(r.is_connected());
+}

--- a/crossbeam-channel/tests/array.rs
+++ b/crossbeam-channel/tests/array.rs
@@ -657,3 +657,17 @@ fn channel_through_channel() {
     })
     .unwrap();
 }
+
+#[test]
+fn is_connected() {
+    let (s, r) = bounded::<i32>(1);
+    assert!(s.is_connected());
+    assert!(r.is_connected());
+
+    drop(s);
+    assert!(!r.is_connected());
+
+    let (s, r) = bounded::<i32>(1);
+    drop(r);
+    assert!(!s.is_connected());
+}

--- a/crossbeam-channel/tests/list.rs
+++ b/crossbeam-channel/tests/list.rs
@@ -536,3 +536,17 @@ fn channel_through_channel() {
     })
     .unwrap();
 }
+
+#[test]
+fn is_connected() {
+    let (s, r) = unbounded::<i32>();
+    assert!(s.is_connected());
+    assert!(r.is_connected());
+
+    drop(s);
+    assert!(!r.is_connected());
+
+    let (s, r) = unbounded::<i32>();
+    drop(r);
+    assert!(!s.is_connected());
+}

--- a/crossbeam-channel/tests/never.rs
+++ b/crossbeam-channel/tests/never.rs
@@ -97,3 +97,9 @@ fn recv_timeout() {
     assert!(now - start >= ms(200));
     assert!(now - start <= ms(250));
 }
+
+#[test]
+fn is_connected() {
+    let r = never::<i32>();
+    assert!(!r.is_connected());
+}

--- a/crossbeam-channel/tests/tick.rs
+++ b/crossbeam-channel/tests/tick.rs
@@ -351,3 +351,9 @@ fn fairness_duplicates() {
         assert!(hits.iter().all(|x| *x >= COUNT / hits.len() / 2));
     }
 }
+
+#[test]
+fn is_connected() {
+    let r = after(ms(50));
+    assert!(r.is_connected());
+}

--- a/crossbeam-channel/tests/zero.rs
+++ b/crossbeam-channel/tests/zero.rs
@@ -557,3 +557,17 @@ fn channel_through_channel() {
     })
     .unwrap();
 }
+
+#[test]
+fn is_connected() {
+    let (s, r) = bounded::<i32>(0);
+    assert!(s.is_connected());
+    assert!(r.is_connected());
+
+    drop(s);
+    assert!(!r.is_connected());
+
+    let (s, r) = bounded::<i32>(0);
+    drop(r);
+    assert!(!s.is_connected());
+}


### PR DESCRIPTION
Checks if the other side of the channel is connected.

Updates https://github.com/crossbeam-rs/crossbeam/issues/256#issuecomment-444620303