### PR TITLE
SeqLock: Aborted writes should not update the stamp.

### DIFF
--- a/crossbeam-utils/src/atomic/seq_lock.rs
+++ b/crossbeam-utils/src/atomic/seq_lock.rs
@@ -1,5 +1,5 @@
+use core::mem;
 use core::sync::atomic::{self, AtomicUsize, Ordering};
-use std::mem;
 
 use Backoff;
 
@@ -75,6 +75,9 @@ impl SeqLockWriteGuard {
     #[inline]
     pub fn abort(self) {
         self.lock.state.store(self.state, Ordering::Release);
+
+        // We specifically don't want to call drop(), since that's
+        // what increments the stamp.
         mem::forget(self);
     }
 }


### PR DESCRIPTION
This is minor, but I noticed it on a read of the code. `abort()` would
write back the old stamp, but would then immediately drop `self`,
which would bump the stamp anyways.

I included a test; SeqLock isn't exported, so it wasn't possible to
add this to the integratio suite so I added it directly in the file.