### PR TITLE
Remove deprecated methods

### DIFF
--- a/crossbeam-utils/src/atomic/atomic_cell.rs
+++ b/crossbeam-utils/src/atomic/atomic_cell.rs
@@ -162,24 +162,6 @@ impl<T: ?Sized> AtomicCell<T> {
     pub fn as_ptr(&self) -> *mut T {
         self.value.get()
     }
-
-    /// Returns a mutable reference to the inner value.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use crossbeam_utils::atomic::AtomicCell;
-    ///
-    /// let mut a = AtomicCell::new(7);
-    /// *a.get_mut() += 1;
-    ///
-    /// assert_eq!(a.load(), 8);
-    /// ```
-    #[doc(hidden)]
-    #[deprecated(note = "this method is unsound and will be removed in the next release")]
-    pub fn get_mut(&mut self) -> &mut T {
-        unsafe { &mut *self.value.get() }
-    }
 }
 
 impl<T: Default> AtomicCell<T> {

--- a/crossbeam-utils/src/backoff.rs
+++ b/crossbeam-utils/src/backoff.rs
@@ -267,13 +267,6 @@ impl Backoff {
     pub fn is_completed(&self) -> bool {
         self.step.get() > YIELD_LIMIT
     }
-
-    #[inline]
-    #[doc(hidden)]
-    #[deprecated(note = "use `is_completed` instead")]
-    pub fn is_complete(&self) -> bool {
-        self.is_completed()
-    }
 }
 
 impl fmt::Debug for Backoff {


### PR DESCRIPTION
Remove deprecated `AtomicCell::get_mut` and `Backoff::is_complete`

This is a breaking change proposed in #503.