### PR TITLE
Migrate to Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ alloc = ["crossbeam-epoch/alloc", "crossbeam-queue/alloc"]
 nightly = ["crossbeam-epoch/nightly", "crossbeam-utils/nightly", "crossbeam-queue/nightly"]
 
 [dependencies]
-cfg-if = "0.1.2"
+cfg-if = "0.1.10"
 
 [dependencies.crossbeam-channel]
 version = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ name = "crossbeam"
 # - Create "crossbeam-X.Y.Z" git tag
 version = "0.7.3"
 authors = ["The Crossbeam Project Developers"]
+edition = "2018"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/crossbeam-rs/crossbeam"

--- a/README.md
+++ b/README.md
@@ -90,12 +90,6 @@ Add this to your `Cargo.toml`:
 crossbeam = "0.7"
 ```
 
-Next, add this to your crate:
-
-```rust
-extern crate crossbeam;
-```
-
 ## Compatibility
 
 Crossbeam supports stable Rust releases going back at least six months,

--- a/crossbeam-channel/Cargo.toml
+++ b/crossbeam-channel/Cargo.toml
@@ -6,6 +6,7 @@ name = "crossbeam-channel"
 # - Create "crossbeam-channel-X.Y.Z" git tag
 version = "0.4.2"
 authors = ["The Crossbeam Project Developers"]
+edition = "2018"
 license = "MIT/Apache-2.0 AND BSD-2-Clause"
 readme = "README.md"
 repository = "https://github.com/crossbeam-rs/crossbeam"

--- a/crossbeam-channel/Cargo.toml
+++ b/crossbeam-channel/Cargo.toml
@@ -24,7 +24,7 @@ default = ["std"]
 std = ["crossbeam-utils/std"]
 
 [dependencies]
-cfg-if = "0.1.2"
+cfg-if = "0.1.10"
 
 [dependencies.crossbeam-utils]
 version = "0.7"

--- a/crossbeam-channel/README.md
+++ b/crossbeam-channel/README.md
@@ -44,13 +44,6 @@ Add this to your `Cargo.toml`:
 crossbeam-channel = "0.4"
 ```
 
-Next, add this to your crate:
-
-```rust
-#[macro_use]
-extern crate crossbeam_channel;
-```
-
 ## Compatibility
 
 Crossbeam Channel supports stable Rust releases going back at least six months,

--- a/crossbeam-channel/benches/crossbeam.rs
+++ b/crossbeam-channel/benches/crossbeam.rs
@@ -1,8 +1,5 @@
 #![feature(test)]
 
-extern crate crossbeam_channel;
-extern crate crossbeam_utils;
-extern crate num_cpus;
 extern crate test;
 
 use crossbeam_channel::{bounded, unbounded};

--- a/crossbeam-channel/benchmarks/Cargo.toml
+++ b/crossbeam-channel/benchmarks/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "benchmarks"
 version = "0.1.0"
+edition = "2018"
 publish = false
 
 [dependencies]

--- a/crossbeam-channel/benchmarks/atomicring.rs
+++ b/crossbeam-channel/benchmarks/atomicring.rs
@@ -1,6 +1,3 @@
-extern crate atomicring;
-extern crate crossbeam;
-
 use atomicring::AtomicRingBuffer;
 use std::thread;
 

--- a/crossbeam-channel/benchmarks/atomicringqueue.rs
+++ b/crossbeam-channel/benchmarks/atomicringqueue.rs
@@ -1,6 +1,3 @@
-extern crate atomicring;
-extern crate crossbeam;
-
 use atomicring::AtomicRingQueue;
 use std::thread;
 

--- a/crossbeam-channel/benchmarks/bus.rs
+++ b/crossbeam-channel/benchmarks/bus.rs
@@ -1,6 +1,3 @@
-extern crate bus;
-extern crate crossbeam;
-
 use bus::Bus;
 
 mod message;

--- a/crossbeam-channel/benchmarks/chan.rs
+++ b/crossbeam-channel/benchmarks/chan.rs
@@ -1,6 +1,4 @@
-#[macro_use]
-extern crate chan;
-extern crate crossbeam;
+use chan::chan_select;
 
 mod message;
 
@@ -9,7 +7,7 @@ const THREADS: usize = 4;
 
 fn new<T>(cap: Option<usize>) -> (chan::Sender<T>, chan::Receiver<T>) {
     match cap {
-        None => chan::async(),
+        None => chan::r#async(),
         Some(cap) => chan::sync(cap),
     }
 }

--- a/crossbeam-channel/benchmarks/crossbeam-channel.rs
+++ b/crossbeam-channel/benchmarks/crossbeam-channel.rs
@@ -1,6 +1,3 @@
-extern crate crossbeam;
-extern crate crossbeam_channel;
-
 use crossbeam_channel::{bounded, unbounded, Receiver, Select, Sender};
 
 mod message;

--- a/crossbeam-channel/benchmarks/crossbeam-deque.rs
+++ b/crossbeam-channel/benchmarks/crossbeam-deque.rs
@@ -1,7 +1,7 @@
 extern crate crossbeam;
 extern crate crossbeam_deque as deque;
 
-use deque::{Steal, Worker};
+use crate::deque::{Steal, Worker};
 use std::thread;
 
 mod message;

--- a/crossbeam-channel/benchmarks/crossbeam-deque.rs
+++ b/crossbeam-channel/benchmarks/crossbeam-deque.rs
@@ -1,7 +1,4 @@
-extern crate crossbeam;
-extern crate crossbeam_deque as deque;
-
-use crate::deque::{Steal, Worker};
+use crossbeam_deque::{Steal, Worker};
 use std::thread;
 
 mod message;

--- a/crossbeam-channel/benchmarks/flume.rs
+++ b/crossbeam-channel/benchmarks/flume.rs
@@ -1,5 +1,3 @@
-extern crate crossbeam;
-
 mod message;
 
 const MESSAGES: usize = 5_000_000;

--- a/crossbeam-channel/benchmarks/futures-channel.rs
+++ b/crossbeam-channel/benchmarks/futures-channel.rs
@@ -1,6 +1,3 @@
-extern crate crossbeam;
-extern crate futures;
-
 use futures::channel::mpsc;
 use futures::executor::ThreadPool;
 use futures::prelude::*;

--- a/crossbeam-channel/benchmarks/lockfree.rs
+++ b/crossbeam-channel/benchmarks/lockfree.rs
@@ -1,6 +1,3 @@
-extern crate crossbeam;
-extern crate lockfree;
-
 use lockfree::channel;
 
 mod message;

--- a/crossbeam-channel/benchmarks/message.rs
+++ b/crossbeam-channel/benchmarks/message.rs
@@ -6,7 +6,7 @@ const LEN: usize = 1;
 pub struct Message(pub [usize; LEN]);
 
 impl fmt::Debug for Message {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("Message")
     }
 }

--- a/crossbeam-channel/benchmarks/mpmc.rs
+++ b/crossbeam-channel/benchmarks/mpmc.rs
@@ -1,6 +1,3 @@
-extern crate crossbeam;
-extern crate mpmc;
-
 use std::thread;
 
 mod message;

--- a/crossbeam-channel/benchmarks/mpsc.rs
+++ b/crossbeam-channel/benchmarks/mpsc.rs
@@ -1,5 +1,3 @@
-extern crate crossbeam;
-
 use std::sync::mpsc;
 
 mod message;

--- a/crossbeam-channel/benchmarks/segqueue.rs
+++ b/crossbeam-channel/benchmarks/segqueue.rs
@@ -1,5 +1,3 @@
-extern crate crossbeam;
-
 use crossbeam::queue::SegQueue;
 use std::thread;
 

--- a/crossbeam-channel/examples/fibonacci.rs
+++ b/crossbeam-channel/examples/fibonacci.rs
@@ -1,7 +1,5 @@
 //! An asynchronous fibonacci sequence generator.
 
-extern crate crossbeam_channel;
-
 use std::thread;
 
 use crossbeam_channel::{bounded, Sender};

--- a/crossbeam-channel/examples/matching.rs
+++ b/crossbeam-channel/examples/matching.rs
@@ -42,11 +42,7 @@
 //! }
 //! ```
 
-#[macro_use]
-extern crate crossbeam_channel;
-extern crate crossbeam_utils;
-
-use crossbeam_channel::bounded;
+use crossbeam_channel::{bounded, select};
 use crossbeam_utils::thread;
 
 fn main() {

--- a/crossbeam-channel/examples/stopwatch.rs
+++ b/crossbeam-channel/examples/stopwatch.rs
@@ -1,14 +1,10 @@
 //! Prints the elapsed time every 1 second and quits on Ctrl+C.
 
-#[macro_use]
-extern crate crossbeam_channel;
-extern crate signal_hook;
-
 use std::io;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use crossbeam_channel::{bounded, tick, Receiver};
+use crossbeam_channel::{bounded, select, tick, Receiver};
 use signal_hook::iterator::Signals;
 use signal_hook::SIGINT;
 

--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -7,11 +7,11 @@ use std::panic::{RefUnwindSafe, UnwindSafe};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use context::Context;
-use counter;
-use err::{RecvError, RecvTimeoutError, SendError, SendTimeoutError, TryRecvError, TrySendError};
-use flavors;
-use select::{Operation, SelectHandle, Token};
+use crate::context::Context;
+use crate::counter;
+use crate::err::{RecvError, RecvTimeoutError, SendError, SendTimeoutError, TryRecvError, TrySendError};
+use crate::flavors;
+use crate::select::{Operation, SelectHandle, Token};
 
 /// Creates a channel of unbounded capacity.
 ///

--- a/crossbeam-channel/src/context.rs
+++ b/crossbeam-channel/src/context.rs
@@ -8,7 +8,7 @@ use std::time::Instant;
 
 use crossbeam_utils::Backoff;
 
-use select::Selected;
+use crate::select::Selected;
 
 /// Thread-local context used in select.
 #[derive(Debug, Clone)]

--- a/crossbeam-channel/src/err.rs
+++ b/crossbeam-channel/src/err.rs
@@ -116,13 +116,13 @@ pub struct TryReadyError;
 pub struct ReadyTimeoutError;
 
 impl<T> fmt::Debug for SendError<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         "SendError(..)".fmt(f)
     }
 }
 
 impl<T> fmt::Display for SendError<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         "sending on a disconnected channel".fmt(f)
     }
 }
@@ -150,7 +150,7 @@ impl<T> SendError<T> {
 }
 
 impl<T> fmt::Debug for TrySendError<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             TrySendError::Full(..) => "Full(..)".fmt(f),
             TrySendError::Disconnected(..) => "Disconnected(..)".fmt(f),
@@ -159,7 +159,7 @@ impl<T> fmt::Debug for TrySendError<T> {
 }
 
 impl<T> fmt::Display for TrySendError<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             TrySendError::Full(..) => "sending on a full channel".fmt(f),
             TrySendError::Disconnected(..) => "sending on a disconnected channel".fmt(f),
@@ -216,13 +216,13 @@ impl<T> TrySendError<T> {
 }
 
 impl<T> fmt::Debug for SendTimeoutError<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         "SendTimeoutError(..)".fmt(f)
     }
 }
 
 impl<T> fmt::Display for SendTimeoutError<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             SendTimeoutError::Timeout(..) => "timed out waiting on send operation".fmt(f),
             SendTimeoutError::Disconnected(..) => "sending on a disconnected channel".fmt(f),
@@ -280,7 +280,7 @@ impl<T> SendTimeoutError<T> {
 }
 
 impl fmt::Display for RecvError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         "receiving on an empty and disconnected channel".fmt(f)
     }
 }
@@ -288,7 +288,7 @@ impl fmt::Display for RecvError {
 impl error::Error for RecvError {}
 
 impl fmt::Display for TryRecvError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             TryRecvError::Empty => "receiving on an empty channel".fmt(f),
             TryRecvError::Disconnected => "receiving on an empty and disconnected channel".fmt(f),
@@ -325,7 +325,7 @@ impl TryRecvError {
 }
 
 impl fmt::Display for RecvTimeoutError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             RecvTimeoutError::Timeout => "timed out waiting on receive operation".fmt(f),
             RecvTimeoutError::Disconnected => "channel is empty and disconnected".fmt(f),
@@ -362,7 +362,7 @@ impl RecvTimeoutError {
 }
 
 impl fmt::Display for TrySelectError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         "all operations in select would block".fmt(f)
     }
 }
@@ -370,7 +370,7 @@ impl fmt::Display for TrySelectError {
 impl error::Error for TrySelectError {}
 
 impl fmt::Display for SelectTimeoutError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         "timed out waiting on select".fmt(f)
     }
 }

--- a/crossbeam-channel/src/flavors/after.rs
+++ b/crossbeam-channel/src/flavors/after.rs
@@ -6,10 +6,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use context::Context;
-use err::{RecvTimeoutError, TryRecvError};
-use select::{Operation, SelectHandle, Token};
-use utils;
+use crate::context::Context;
+use crate::err::{RecvTimeoutError, TryRecvError};
+use crate::select::{Operation, SelectHandle, Token};
+use crate::utils;
 
 /// Result of a receive operation.
 pub type AfterToken = Option<Instant>;

--- a/crossbeam-channel/src/flavors/array.rs
+++ b/crossbeam-channel/src/flavors/array.rs
@@ -22,10 +22,10 @@ use std::time::Instant;
 
 use crossbeam_utils::{Backoff, CachePadded};
 
-use context::Context;
-use err::{RecvTimeoutError, SendTimeoutError, TryRecvError, TrySendError};
-use select::{Operation, SelectHandle, Selected, Token};
-use waker::SyncWaker;
+use crate::context::Context;
+use crate::err::{RecvTimeoutError, SendTimeoutError, TryRecvError, TrySendError};
+use crate::select::{Operation, SelectHandle, Selected, Token};
+use crate::waker::SyncWaker;
 
 /// A slot in a channel.
 struct Slot<T> {

--- a/crossbeam-channel/src/flavors/array.rs
+++ b/crossbeam-channel/src/flavors/array.rs
@@ -143,12 +143,12 @@ impl<T> Channel<T> {
     }
 
     /// Returns a receiver handle to the channel.
-    pub fn receiver(&self) -> Receiver<T> {
+    pub fn receiver(&self) -> Receiver<'_, T> {
         Receiver(self)
     }
 
     /// Returns a sender handle to the channel.
-    pub fn sender(&self) -> Sender<T> {
+    pub fn sender(&self) -> Sender<'_, T> {
         Sender(self)
     }
 
@@ -559,12 +559,12 @@ impl<T> Drop for Channel<T> {
 }
 
 /// Receiver handle to a channel.
-pub struct Receiver<'a, T: 'a>(&'a Channel<T>);
+pub struct Receiver<'a, T>(&'a Channel<T>);
 
 /// Sender handle to a channel.
-pub struct Sender<'a, T: 'a>(&'a Channel<T>);
+pub struct Sender<'a, T>(&'a Channel<T>);
 
-impl<'a, T> SelectHandle for Receiver<'a, T> {
+impl<T> SelectHandle for Receiver<'_, T> {
     fn try_select(&self, token: &mut Token) -> bool {
         self.0.start_recv(token)
     }
@@ -600,7 +600,7 @@ impl<'a, T> SelectHandle for Receiver<'a, T> {
     }
 }
 
-impl<'a, T> SelectHandle for Sender<'a, T> {
+impl<T> SelectHandle for Sender<'_, T> {
     fn try_select(&self, token: &mut Token) -> bool {
         self.0.start_send(token)
     }

--- a/crossbeam-channel/src/flavors/list.rs
+++ b/crossbeam-channel/src/flavors/list.rs
@@ -183,12 +183,12 @@ impl<T> Channel<T> {
     }
 
     /// Returns a receiver handle to the channel.
-    pub fn receiver(&self) -> Receiver<T> {
+    pub fn receiver(&self) -> Receiver<'_, T> {
         Receiver(self)
     }
 
     /// Returns a sender handle to the channel.
-    pub fn sender(&self) -> Sender<T> {
+    pub fn sender(&self) -> Sender<'_, T> {
         Sender(self)
     }
 
@@ -597,12 +597,12 @@ impl<T> Drop for Channel<T> {
 }
 
 /// Receiver handle to a channel.
-pub struct Receiver<'a, T: 'a>(&'a Channel<T>);
+pub struct Receiver<'a, T>(&'a Channel<T>);
 
 /// Sender handle to a channel.
-pub struct Sender<'a, T: 'a>(&'a Channel<T>);
+pub struct Sender<'a, T>(&'a Channel<T>);
 
-impl<'a, T> SelectHandle for Receiver<'a, T> {
+impl<T> SelectHandle for Receiver<'_, T> {
     fn try_select(&self, token: &mut Token) -> bool {
         self.0.start_recv(token)
     }
@@ -638,7 +638,7 @@ impl<'a, T> SelectHandle for Receiver<'a, T> {
     }
 }
 
-impl<'a, T> SelectHandle for Sender<'a, T> {
+impl<T> SelectHandle for Sender<'_, T> {
     fn try_select(&self, token: &mut Token) -> bool {
         self.0.start_send(token)
     }

--- a/crossbeam-channel/src/flavors/list.rs
+++ b/crossbeam-channel/src/flavors/list.rs
@@ -9,10 +9,10 @@ use std::time::Instant;
 
 use crossbeam_utils::{Backoff, CachePadded};
 
-use context::Context;
-use err::{RecvTimeoutError, SendTimeoutError, TryRecvError, TrySendError};
-use select::{Operation, SelectHandle, Selected, Token};
-use waker::SyncWaker;
+use crate::context::Context;
+use crate::err::{RecvTimeoutError, SendTimeoutError, TryRecvError, TrySendError};
+use crate::select::{Operation, SelectHandle, Selected, Token};
+use crate::waker::SyncWaker;
 
 // TODO(stjepang): Once we bump the minimum required Rust version to 1.28 or newer, re-apply the
 // following changes by @kleimkuhler:

--- a/crossbeam-channel/src/flavors/never.rs
+++ b/crossbeam-channel/src/flavors/never.rs
@@ -5,10 +5,10 @@
 use std::marker::PhantomData;
 use std::time::Instant;
 
-use context::Context;
-use err::{RecvTimeoutError, TryRecvError};
-use select::{Operation, SelectHandle, Token};
-use utils;
+use crate::context::Context;
+use crate::err::{RecvTimeoutError, TryRecvError};
+use crate::select::{Operation, SelectHandle, Token};
+use crate::utils;
 
 /// This flavor doesn't need a token.
 pub type NeverToken = ();

--- a/crossbeam-channel/src/flavors/tick.rs
+++ b/crossbeam-channel/src/flavors/tick.rs
@@ -7,9 +7,9 @@ use std::time::{Duration, Instant};
 
 use crossbeam_utils::atomic::AtomicCell;
 
-use context::Context;
-use err::{RecvTimeoutError, TryRecvError};
-use select::{Operation, SelectHandle, Token};
+use crate::context::Context;
+use crate::err::{RecvTimeoutError, TryRecvError};
+use crate::select::{Operation, SelectHandle, Token};
 
 /// Result of a receive operation.
 pub type TickToken = Option<Instant>;

--- a/crossbeam-channel/src/flavors/zero.rs
+++ b/crossbeam-channel/src/flavors/zero.rs
@@ -102,12 +102,12 @@ impl<T> Channel<T> {
     }
 
     /// Returns a receiver handle to the channel.
-    pub fn receiver(&self) -> Receiver<T> {
+    pub fn receiver(&self) -> Receiver<'_, T> {
         Receiver(self)
     }
 
     /// Returns a sender handle to the channel.
-    pub fn sender(&self) -> Sender<T> {
+    pub fn sender(&self) -> Sender<'_, T> {
         Sender(self)
     }
 
@@ -360,12 +360,12 @@ impl<T> Channel<T> {
 }
 
 /// Receiver handle to a channel.
-pub struct Receiver<'a, T: 'a>(&'a Channel<T>);
+pub struct Receiver<'a, T>(&'a Channel<T>);
 
 /// Sender handle to a channel.
-pub struct Sender<'a, T: 'a>(&'a Channel<T>);
+pub struct Sender<'a, T>(&'a Channel<T>);
 
-impl<'a, T> SelectHandle for Receiver<'a, T> {
+impl<T> SelectHandle for Receiver<'_, T> {
     fn try_select(&self, token: &mut Token) -> bool {
         self.0.start_recv(token)
     }
@@ -415,7 +415,7 @@ impl<'a, T> SelectHandle for Receiver<'a, T> {
     }
 }
 
-impl<'a, T> SelectHandle for Sender<'a, T> {
+impl<T> SelectHandle for Sender<'_, T> {
     fn try_select(&self, token: &mut Token) -> bool {
         self.0.start_send(token)
     }

--- a/crossbeam-channel/src/flavors/zero.rs
+++ b/crossbeam-channel/src/flavors/zero.rs
@@ -9,11 +9,11 @@ use std::time::Instant;
 
 use crossbeam_utils::Backoff;
 
-use context::Context;
-use err::{RecvTimeoutError, SendTimeoutError, TryRecvError, TrySendError};
-use select::{Operation, SelectHandle, Selected, Token};
-use utils::Spinlock;
-use waker::Waker;
+use crate::context::Context;
+use crate::err::{RecvTimeoutError, SendTimeoutError, TryRecvError, TrySendError};
+use crate::select::{Operation, SelectHandle, Selected, Token};
+use crate::utils::Spinlock;
+use crate::waker::Waker;
 
 /// A pointer to a packet.
 pub type ZeroToken = usize;

--- a/crossbeam-channel/src/lib.rs
+++ b/crossbeam-channel/src/lib.rs
@@ -368,19 +368,19 @@ cfg_if! {
         /// Crate internals used by the `select!` macro.
         #[doc(hidden)]
         pub mod internal {
-            pub use select::SelectHandle;
-            pub use select::{select, select_timeout, try_select};
+            pub use crate::select::SelectHandle;
+            pub use crate::select::{select, select_timeout, try_select};
         }
 
-        pub use channel::{after, never, tick};
-        pub use channel::{bounded, unbounded};
-        pub use channel::{IntoIter, Iter, TryIter};
-        pub use channel::{Receiver, Sender};
+        pub use crate::channel::{after, never, tick};
+        pub use crate::channel::{bounded, unbounded};
+        pub use crate::channel::{IntoIter, Iter, TryIter};
+        pub use crate::channel::{Receiver, Sender};
 
-        pub use select::{Select, SelectedOperation};
+        pub use crate::select::{Select, SelectedOperation};
 
-        pub use err::{ReadyTimeoutError, SelectTimeoutError, TryReadyError, TrySelectError};
-        pub use err::{RecvError, RecvTimeoutError, TryRecvError};
-        pub use err::{SendError, SendTimeoutError, TrySendError};
+        pub use crate::err::{ReadyTimeoutError, SelectTimeoutError, TryReadyError, TrySelectError};
+        pub use crate::err::{RecvError, RecvTimeoutError, TryRecvError};
+        pub use crate::err::{SendError, SendTimeoutError, TrySendError};
     }
 }

--- a/crossbeam-channel/src/lib.rs
+++ b/crossbeam-channel/src/lib.rs
@@ -122,8 +122,6 @@
 //! It's also possible to share senders and receivers by reference:
 //!
 //! ```
-//! # extern crate crossbeam_channel;
-//! # extern crate crossbeam_utils;
 //! # fn main() {
 //! use std::thread;
 //! use crossbeam_channel::bounded;
@@ -271,12 +269,10 @@
 //! An example of receiving a message from two channels:
 //!
 //! ```
-//! # #[macro_use]
-//! # extern crate crossbeam_channel;
 //! # fn main() {
 //! use std::thread;
 //! use std::time::Duration;
-//! use crossbeam_channel::unbounded;
+//! use crossbeam_channel::{select, unbounded};
 //!
 //! let (s1, r1) = unbounded();
 //! let (s2, r2) = unbounded();
@@ -310,11 +306,9 @@
 //! An example that prints elapsed time every 50 milliseconds for the duration of 1 second:
 //!
 //! ```
-//! # #[macro_use]
-//! # extern crate crossbeam_channel;
 //! # fn main() {
 //! use std::time::{Duration, Instant};
-//! use crossbeam_channel::{after, tick};
+//! use crossbeam_channel::{after, select, tick};
 //!
 //! let start = Instant::now();
 //! let ticker = tick(Duration::from_millis(50));
@@ -344,17 +338,13 @@
 //! [`Sender`]: struct.Sender.html
 //! [`Receiver`]: struct.Receiver.html
 
-#![warn(missing_docs)]
-#![warn(missing_debug_implementations)]
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[macro_use]
-extern crate cfg_if;
+use cfg_if::cfg_if;
 
 cfg_if! {
     if #[cfg(feature = "std")] {
-        extern crate crossbeam_utils;
-
         mod channel;
         mod context;
         mod counter;

--- a/crossbeam-channel/src/select.rs
+++ b/crossbeam-channel/src/select.rs
@@ -119,7 +119,7 @@ pub trait SelectHandle {
     fn unwatch(&self, oper: Operation);
 }
 
-impl<'a, T: SelectHandle> SelectHandle for &'a T {
+impl<T: SelectHandle> SelectHandle for &T {
     fn try_select(&self, token: &mut Token) -> bool {
         (**self).try_select(token)
     }
@@ -585,8 +585,8 @@ pub struct Select<'a> {
     next_index: usize,
 }
 
-unsafe impl<'a> Send for Select<'a> {}
-unsafe impl<'a> Sync for Select<'a> {}
+unsafe impl Send for Select<'_> {}
+unsafe impl Sync for Select<'_> {}
 
 impl<'a> Select<'a> {
     /// Creates an empty list of channel operations for selection.
@@ -1017,8 +1017,8 @@ impl<'a> Default for Select<'a> {
     }
 }
 
-impl<'a> fmt::Debug for Select<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl fmt::Debug for Select<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("Select { .. }")
     }
 }
@@ -1049,7 +1049,7 @@ pub struct SelectedOperation<'a> {
     _marker: PhantomData<&'a ()>,
 }
 
-impl<'a> SelectedOperation<'a> {
+impl SelectedOperation<'_> {
     /// Returns the index of the selected operation.
     ///
     /// # Examples
@@ -1153,13 +1153,13 @@ impl<'a> SelectedOperation<'a> {
     }
 }
 
-impl<'a> fmt::Debug for SelectedOperation<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl fmt::Debug for SelectedOperation<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("SelectedOperation { .. }")
     }
 }
 
-impl<'a> Drop for SelectedOperation<'a> {
+impl Drop for SelectedOperation<'_> {
     fn drop(&mut self) {
         panic!("dropped `SelectedOperation` without completing the operation");
     }

--- a/crossbeam-channel/src/select.rs
+++ b/crossbeam-channel/src/select.rs
@@ -7,13 +7,13 @@ use std::time::{Duration, Instant};
 
 use crossbeam_utils::Backoff;
 
-use channel::{self, Receiver, Sender};
-use context::Context;
-use err::{ReadyTimeoutError, TryReadyError};
-use err::{RecvError, SendError};
-use err::{SelectTimeoutError, TrySelectError};
-use flavors;
-use utils;
+use crate::channel::{self, Receiver, Sender};
+use crate::context::Context;
+use crate::err::{ReadyTimeoutError, TryReadyError};
+use crate::err::{RecvError, SendError};
+use crate::err::{SelectTimeoutError, TrySelectError};
+use crate::flavors;
+use crate::utils;
 
 /// Temporary data that gets initialized during select or a blocking operation, and is consumed by
 /// `read` or `write`.

--- a/crossbeam-channel/src/select_macro.rs
+++ b/crossbeam-channel/src/select_macro.rs
@@ -5,10 +5,7 @@
 /// This is just an ugly workaround until it becomes possible to import macros with `use`
 /// statements.
 ///
-/// TODO(stjepang): Once we bump the minimum required Rust version to 1.30 or newer, we should:
-///
-/// 1. Remove all `#[macro_export(local_inner_macros)]` lines.
-/// 2. Replace `crossbeam_channel_delegate` with direct macro invocations.
+/// TODO(stjepang): Replace `crossbeam_channel_delegate` with direct macro invocations.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! crossbeam_channel_delegate {
@@ -53,7 +50,7 @@ macro_rules! crossbeam_channel_internal {
         ()
         ($($head:tt)*)
     ) => {
-        crossbeam_channel_internal!(
+        $crate::crossbeam_channel_internal!(
             @case
             ($($head)*)
             ()
@@ -65,7 +62,7 @@ macro_rules! crossbeam_channel_internal {
         (default => $($tail:tt)*)
         ($($head:tt)*)
     ) => {
-        crossbeam_channel_internal!(
+        $crate::crossbeam_channel_internal!(
             @list
             (default() => $($tail)*)
             ($($head)*)
@@ -76,7 +73,7 @@ macro_rules! crossbeam_channel_internal {
         (default -> $($tail:tt)*)
         ($($head:tt)*)
     ) => {
-        crossbeam_channel_delegate!(compile_error(
+        $crate::crossbeam_channel_delegate!(compile_error(
             "expected `=>` after `default` case, found `->`"
         ))
     };
@@ -85,7 +82,7 @@ macro_rules! crossbeam_channel_internal {
         (default $args:tt -> $($tail:tt)*)
         ($($head:tt)*)
     ) => {
-        crossbeam_channel_delegate!(compile_error(
+        $crate::crossbeam_channel_delegate!(compile_error(
             "expected `=>` after `default` case, found `->`"
         ))
     };
@@ -94,7 +91,7 @@ macro_rules! crossbeam_channel_internal {
         (recv($($args:tt)*) => $($tail:tt)*)
         ($($head:tt)*)
     ) => {
-        crossbeam_channel_delegate!(compile_error(
+        $crate::crossbeam_channel_delegate!(compile_error(
             "expected `->` after `recv` case, found `=>`"
         ))
     };
@@ -103,7 +100,7 @@ macro_rules! crossbeam_channel_internal {
         (send($($args:tt)*) => $($tail:tt)*)
         ($($head:tt)*)
     ) => {
-        crossbeam_channel_delegate!(compile_error(
+        $crate::crossbeam_channel_delegate!(compile_error(
             "expected `->` after `send` operation, found `=>`"
         ))
     };
@@ -112,14 +109,14 @@ macro_rules! crossbeam_channel_internal {
         ($case:ident $args:tt -> $res:tt -> $($tail:tt)*)
         ($($head:tt)*)
     ) => {
-        crossbeam_channel_delegate!(compile_error("expected `=>`, found `->`"))
+        $crate::crossbeam_channel_delegate!(compile_error("expected `=>`, found `->`"))
     };
     // Print an error if there is a semicolon after the block.
     (@list
         ($case:ident $args:tt $(-> $res:pat)* => $body:block; $($tail:tt)*)
         ($($head:tt)*)
     ) => {
-        crossbeam_channel_delegate!(compile_error(
+        $crate::crossbeam_channel_delegate!(compile_error(
             "did you mean to put a comma instead of the semicolon after `}`?"
         ))
     };
@@ -128,7 +125,7 @@ macro_rules! crossbeam_channel_internal {
         ($case:ident ($($args:tt)*) $(-> $res:pat)* => $body:expr, $($tail:tt)*)
         ($($head:tt)*)
     ) => {
-        crossbeam_channel_internal!(
+        $crate::crossbeam_channel_internal!(
             @list
             ($($tail)*)
             ($($head)* $case ($($args)*) $(-> $res)* => { $body },)
@@ -139,7 +136,7 @@ macro_rules! crossbeam_channel_internal {
         ($case:ident ($($args:tt)*) $(-> $res:pat)* => $body:block $($tail:tt)*)
         ($($head:tt)*)
     ) => {
-        crossbeam_channel_internal!(
+        $crate::crossbeam_channel_internal!(
             @list
             ($($tail)*)
             ($($head)* $case ($($args)*) $(-> $res)* => { $body },)
@@ -150,7 +147,7 @@ macro_rules! crossbeam_channel_internal {
         ($case:ident ($($args:tt)*) $(-> $res:pat)* => $body:expr)
         ($($head:tt)*)
     ) => {
-        crossbeam_channel_internal!(
+        $crate::crossbeam_channel_internal!(
             @list
             ()
             ($($head)* $case ($($args)*) $(-> $res)* => { $body },)
@@ -161,7 +158,7 @@ macro_rules! crossbeam_channel_internal {
         ($case:ident ($($args:tt)*) $(-> $res:pat)* => $body:expr,)
         ($($head:tt)*)
     ) => {
-        crossbeam_channel_internal!(
+        $crate::crossbeam_channel_internal!(
             @list
             ()
             ($($head)* $case ($($args)*) $(-> $res)* => { $body },)
@@ -172,216 +169,216 @@ macro_rules! crossbeam_channel_internal {
         ($($tail:tt)*)
         ($($head:tt)*)
     ) => {
-        crossbeam_channel_internal!(@list_error1 $($tail)*)
+        $crate::crossbeam_channel_internal!(@list_error1 $($tail)*)
     };
     // Stage 1: check the case type.
     (@list_error1 recv $($tail:tt)*) => {
-        crossbeam_channel_internal!(@list_error2 recv $($tail)*)
+        $crate::crossbeam_channel_internal!(@list_error2 recv $($tail)*)
     };
     (@list_error1 send $($tail:tt)*) => {
-        crossbeam_channel_internal!(@list_error2 send $($tail)*)
+        $crate::crossbeam_channel_internal!(@list_error2 send $($tail)*)
     };
     (@list_error1 default $($tail:tt)*) => {
-        crossbeam_channel_internal!(@list_error2 default $($tail)*)
+        $crate::crossbeam_channel_internal!(@list_error2 default $($tail)*)
     };
     (@list_error1 $t:tt $($tail:tt)*) => {
-        crossbeam_channel_delegate!(compile_error(
-            crossbeam_channel_delegate!(concat(
+        $crate::crossbeam_channel_delegate!(compile_error(
+            $crate::crossbeam_channel_delegate!(concat(
                 "expected one of `recv`, `send`, or `default`, found `",
-                crossbeam_channel_delegate!(stringify($t)),
+                $crate::crossbeam_channel_delegate!(stringify($t)),
                 "`",
             ))
         ))
     };
     (@list_error1 $($tail:tt)*) => {
-        crossbeam_channel_internal!(@list_error2 $($tail)*);
+        $crate::crossbeam_channel_internal!(@list_error2 $($tail)*);
     };
     // Stage 2: check the argument list.
     (@list_error2 $case:ident) => {
-        crossbeam_channel_delegate!(compile_error(
-            crossbeam_channel_delegate!(concat(
+        $crate::crossbeam_channel_delegate!(compile_error(
+            $crate::crossbeam_channel_delegate!(concat(
                 "missing argument list after `",
-                crossbeam_channel_delegate!(stringify($case)),
+                $crate::crossbeam_channel_delegate!(stringify($case)),
                 "`",
             ))
         ))
     };
     (@list_error2 $case:ident => $($tail:tt)*) => {
-        crossbeam_channel_delegate!(compile_error(
-            crossbeam_channel_delegate!(concat(
+        $crate::crossbeam_channel_delegate!(compile_error(
+            $crate::crossbeam_channel_delegate!(concat(
                 "missing argument list after `",
-                crossbeam_channel_delegate!(stringify($case)),
+                $crate::crossbeam_channel_delegate!(stringify($case)),
                 "`",
             ))
         ))
     };
     (@list_error2 $($tail:tt)*) => {
-        crossbeam_channel_internal!(@list_error3 $($tail)*)
+        $crate::crossbeam_channel_internal!(@list_error3 $($tail)*)
     };
     // Stage 3: check the `=>` and what comes after it.
     (@list_error3 $case:ident($($args:tt)*) $(-> $r:pat)*) => {
-        crossbeam_channel_delegate!(compile_error(
-            crossbeam_channel_delegate!(concat(
+        $crate::crossbeam_channel_delegate!(compile_error(
+            $crate::crossbeam_channel_delegate!(concat(
                 "missing `=>` after `",
-                crossbeam_channel_delegate!(stringify($case)),
+                $crate::crossbeam_channel_delegate!(stringify($case)),
                 "` case",
             ))
         ))
     };
     (@list_error3 $case:ident($($args:tt)*) $(-> $r:pat)* =>) => {
-        crossbeam_channel_delegate!(compile_error(
+        $crate::crossbeam_channel_delegate!(compile_error(
             "expected expression after `=>`"
         ))
     };
     (@list_error3 $case:ident($($args:tt)*) $(-> $r:pat)* => $body:expr; $($tail:tt)*) => {
-        crossbeam_channel_delegate!(compile_error(
-            crossbeam_channel_delegate!(concat(
+        $crate::crossbeam_channel_delegate!(compile_error(
+            $crate::crossbeam_channel_delegate!(concat(
                 "did you mean to put a comma instead of the semicolon after `",
-                crossbeam_channel_delegate!(stringify($body)),
+                $crate::crossbeam_channel_delegate!(stringify($body)),
                 "`?",
             ))
         ))
     };
     (@list_error3 $case:ident($($args:tt)*) $(-> $r:pat)* => recv($($a:tt)*) $($tail:tt)*) => {
-        crossbeam_channel_delegate!(compile_error(
+        $crate::crossbeam_channel_delegate!(compile_error(
             "expected an expression after `=>`"
         ))
     };
     (@list_error3 $case:ident($($args:tt)*) $(-> $r:pat)* => send($($a:tt)*) $($tail:tt)*) => {
-        crossbeam_channel_delegate!(compile_error(
+        $crate::crossbeam_channel_delegate!(compile_error(
             "expected an expression after `=>`"
         ))
     };
     (@list_error3 $case:ident($($args:tt)*) $(-> $r:pat)* => default($($a:tt)*) $($tail:tt)*) => {
-        crossbeam_channel_delegate!(compile_error(
+        $crate::crossbeam_channel_delegate!(compile_error(
             "expected an expression after `=>`"
         ))
     };
     (@list_error3 $case:ident($($args:tt)*) $(-> $r:pat)* => $f:ident($($a:tt)*) $($tail:tt)*) => {
-        crossbeam_channel_delegate!(compile_error(
-            crossbeam_channel_delegate!(concat(
+        $crate::crossbeam_channel_delegate!(compile_error(
+            $crate::crossbeam_channel_delegate!(concat(
                 "did you mean to put a comma after `",
-                crossbeam_channel_delegate!(stringify($f)),
+                $crate::crossbeam_channel_delegate!(stringify($f)),
                 "(",
-                crossbeam_channel_delegate!(stringify($($a)*)),
+                $crate::crossbeam_channel_delegate!(stringify($($a)*)),
                 ")`?",
             ))
         ))
     };
     (@list_error3 $case:ident($($args:tt)*) $(-> $r:pat)* => $f:ident!($($a:tt)*) $($tail:tt)*) => {
-        crossbeam_channel_delegate!(compile_error(
-            crossbeam_channel_delegate!(concat(
+        $crate::crossbeam_channel_delegate!(compile_error(
+            $crate::crossbeam_channel_delegate!(concat(
                 "did you mean to put a comma after `",
-                crossbeam_channel_delegate!(stringify($f)),
+                $crate::crossbeam_channel_delegate!(stringify($f)),
                 "!(",
-                crossbeam_channel_delegate!(stringify($($a)*)),
+                $crate::crossbeam_channel_delegate!(stringify($($a)*)),
                 ")`?",
             ))
         ))
     };
     (@list_error3 $case:ident($($args:tt)*) $(-> $r:pat)* => $f:ident![$($a:tt)*] $($tail:tt)*) => {
-        crossbeam_channel_delegate!(compile_error(
-            crossbeam_channel_delegate!(concat(
+        $crate::crossbeam_channel_delegate!(compile_error(
+            $crate::crossbeam_channel_delegate!(concat(
                 "did you mean to put a comma after `",
-                crossbeam_channel_delegate!(stringify($f)),
+                $crate::crossbeam_channel_delegate!(stringify($f)),
                 "![",
-                crossbeam_channel_delegate!(stringify($($a)*)),
+                $crate::crossbeam_channel_delegate!(stringify($($a)*)),
                 "]`?",
             ))
         ))
     };
     (@list_error3 $case:ident($($args:tt)*) $(-> $r:pat)* => $f:ident!{$($a:tt)*} $($tail:tt)*) => {
-        crossbeam_channel_delegate!(compile_error(
-            crossbeam_channel_delegate!(concat(
+        $crate::crossbeam_channel_delegate!(compile_error(
+            $crate::crossbeam_channel_delegate!(concat(
                 "did you mean to put a comma after `",
-                crossbeam_channel_delegate!(stringify($f)),
+                $crate::crossbeam_channel_delegate!(stringify($f)),
                 "!{",
-                crossbeam_channel_delegate!(stringify($($a)*)),
+                $crate::crossbeam_channel_delegate!(stringify($($a)*)),
                 "}`?",
             ))
         ))
     };
     (@list_error3 $case:ident($($args:tt)*) $(-> $r:pat)* => $body:tt $($tail:tt)*) => {
-        crossbeam_channel_delegate!(compile_error(
-            crossbeam_channel_delegate!(concat(
+        $crate::crossbeam_channel_delegate!(compile_error(
+            $crate::crossbeam_channel_delegate!(concat(
                 "did you mean to put a comma after `",
-                crossbeam_channel_delegate!(stringify($body)),
+                $crate::crossbeam_channel_delegate!(stringify($body)),
                 "`?",
             ))
         ))
     };
     (@list_error3 $case:ident($($args:tt)*) -> => $($tail:tt)*) => {
-        crossbeam_channel_delegate!(compile_error("missing pattern after `->`"))
+        $crate::crossbeam_channel_delegate!(compile_error("missing pattern after `->`"))
     };
     (@list_error3 $case:ident($($args:tt)*) $t:tt $(-> $r:pat)* => $($tail:tt)*) => {
-        crossbeam_channel_delegate!(compile_error(
-            crossbeam_channel_delegate!(concat(
+        $crate::crossbeam_channel_delegate!(compile_error(
+            $crate::crossbeam_channel_delegate!(concat(
                 "expected `->`, found `",
-                crossbeam_channel_delegate!(stringify($t)),
+                $crate::crossbeam_channel_delegate!(stringify($t)),
                 "`",
             ))
         ))
     };
     (@list_error3 $case:ident($($args:tt)*) -> $t:tt $($tail:tt)*) => {
-        crossbeam_channel_delegate!(compile_error(
-            crossbeam_channel_delegate!(concat(
+        $crate::crossbeam_channel_delegate!(compile_error(
+            $crate::crossbeam_channel_delegate!(concat(
                 "expected a pattern, found `",
-                crossbeam_channel_delegate!(stringify($t)),
+                $crate::crossbeam_channel_delegate!(stringify($t)),
                 "`",
             ))
         ))
     };
     (@list_error3 recv($($args:tt)*) $t:tt $($tail:tt)*) => {
-        crossbeam_channel_delegate!(compile_error(
-            crossbeam_channel_delegate!(concat(
+        $crate::crossbeam_channel_delegate!(compile_error(
+            $crate::crossbeam_channel_delegate!(concat(
                 "expected `->`, found `",
-                crossbeam_channel_delegate!(stringify($t)),
+                $crate::crossbeam_channel_delegate!(stringify($t)),
                 "`",
             ))
         ))
     };
     (@list_error3 send($($args:tt)*) $t:tt $($tail:tt)*) => {
-        crossbeam_channel_delegate!(compile_error(
-            crossbeam_channel_delegate!(concat(
+        $crate::crossbeam_channel_delegate!(compile_error(
+            $crate::crossbeam_channel_delegate!(concat(
                 "expected `->`, found `",
-                crossbeam_channel_delegate!(stringify($t)),
+                $crate::crossbeam_channel_delegate!(stringify($t)),
                 "`",
             ))
         ))
     };
     (@list_error3 recv $args:tt $($tail:tt)*) => {
-        crossbeam_channel_delegate!(compile_error(
-            crossbeam_channel_delegate!(concat(
+        $crate::crossbeam_channel_delegate!(compile_error(
+            $crate::crossbeam_channel_delegate!(concat(
                 "expected an argument list after `recv`, found `",
-                crossbeam_channel_delegate!(stringify($args)),
+                $crate::crossbeam_channel_delegate!(stringify($args)),
                 "`",
             ))
         ))
     };
     (@list_error3 send $args:tt $($tail:tt)*) => {
-        crossbeam_channel_delegate!(compile_error(
-            crossbeam_channel_delegate!(concat(
+        $crate::crossbeam_channel_delegate!(compile_error(
+            $crate::crossbeam_channel_delegate!(concat(
                 "expected an argument list after `send`, found `",
-                crossbeam_channel_delegate!(stringify($args)),
+                $crate::crossbeam_channel_delegate!(stringify($args)),
                 "`",
             ))
         ))
     };
     (@list_error3 default $args:tt $($tail:tt)*) => {
-        crossbeam_channel_delegate!(compile_error(
-            crossbeam_channel_delegate!(concat(
+        $crate::crossbeam_channel_delegate!(compile_error(
+            $crate::crossbeam_channel_delegate!(concat(
                 "expected an argument list or `=>` after `default`, found `",
-                crossbeam_channel_delegate!(stringify($args)),
+                $crate::crossbeam_channel_delegate!(stringify($args)),
                 "`",
             ))
         ))
     };
     (@list_error3 $($tail:tt)*) => {
-        crossbeam_channel_internal!(@list_error4 $($tail)*)
+        $crate::crossbeam_channel_internal!(@list_error4 $($tail)*)
     };
     // Stage 4: fail with a generic error message.
     (@list_error4 $($tail:tt)*) => {
-        crossbeam_channel_delegate!(compile_error("invalid syntax"))
+        $crate::crossbeam_channel_delegate!(compile_error("invalid syntax"))
     };
 
     // Success! All cases were parsed.
@@ -390,7 +387,7 @@ macro_rules! crossbeam_channel_internal {
         $cases:tt
         $default:tt
     ) => {
-        crossbeam_channel_internal!(
+        $crate::crossbeam_channel_internal!(
             @init
             $cases
             $default
@@ -403,7 +400,7 @@ macro_rules! crossbeam_channel_internal {
         ($($cases:tt)*)
         $default:tt
     ) => {
-        crossbeam_channel_internal!(
+        $crate::crossbeam_channel_internal!(
             @case
             ($($tail)*)
             ($($cases)* recv($r) -> $res => $body,)
@@ -416,7 +413,7 @@ macro_rules! crossbeam_channel_internal {
         ($($cases:tt)*)
         $default:tt
     ) => {
-        crossbeam_channel_internal!(
+        $crate::crossbeam_channel_internal!(
             @case
             ($($tail)*)
             ($($cases)* recv($r) -> $res => $body,)
@@ -429,10 +426,10 @@ macro_rules! crossbeam_channel_internal {
         ($($cases:tt)*)
         $default:tt
     ) => {
-        crossbeam_channel_delegate!(compile_error(
-            crossbeam_channel_delegate!(concat(
+        $crate::crossbeam_channel_delegate!(compile_error(
+            $crate::crossbeam_channel_delegate!(concat(
                 "invalid argument list in `recv(",
-                crossbeam_channel_delegate!(stringify($($args)*)),
+                $crate::crossbeam_channel_delegate!(stringify($($args)*)),
                 ")`",
             ))
         ))
@@ -443,10 +440,10 @@ macro_rules! crossbeam_channel_internal {
         ($($cases:tt)*)
         $default:tt
     ) => {
-        crossbeam_channel_delegate!(compile_error(
-            crossbeam_channel_delegate!(concat(
+        $crate::crossbeam_channel_delegate!(compile_error(
+            $crate::crossbeam_channel_delegate!(concat(
                 "expected an argument list after `recv`, found `",
-                crossbeam_channel_delegate!(stringify($t)),
+                $crate::crossbeam_channel_delegate!(stringify($t)),
                 "`",
             ))
         ))
@@ -458,7 +455,7 @@ macro_rules! crossbeam_channel_internal {
         ($($cases:tt)*)
         $default:tt
     ) => {
-        crossbeam_channel_internal!(
+        $crate::crossbeam_channel_internal!(
             @case
             ($($tail)*)
             ($($cases)* send($s, $m) -> $res => $body,)
@@ -471,7 +468,7 @@ macro_rules! crossbeam_channel_internal {
         ($($cases:tt)*)
         $default:tt
     ) => {
-        crossbeam_channel_internal!(
+        $crate::crossbeam_channel_internal!(
             @case
             ($($tail)*)
             ($($cases)* send($s, $m) -> $res => $body,)
@@ -484,10 +481,10 @@ macro_rules! crossbeam_channel_internal {
         ($($cases:tt)*)
         $default:tt
     ) => {
-        crossbeam_channel_delegate!(compile_error(
-            crossbeam_channel_delegate!(concat(
+        $crate::crossbeam_channel_delegate!(compile_error(
+            $crate::crossbeam_channel_delegate!(concat(
                 "invalid argument list in `send(",
-                crossbeam_channel_delegate!(stringify($($args)*)),
+                $crate::crossbeam_channel_delegate!(stringify($($args)*)),
                 ")`",
             ))
         ))
@@ -498,10 +495,10 @@ macro_rules! crossbeam_channel_internal {
         ($($cases:tt)*)
         $default:tt
     ) => {
-        crossbeam_channel_delegate!(compile_error(
-            crossbeam_channel_delegate!(concat(
+        $crate::crossbeam_channel_delegate!(compile_error(
+            $crate::crossbeam_channel_delegate!(concat(
                 "expected an argument list after `send`, found `",
-                crossbeam_channel_delegate!(stringify($t)),
+                $crate::crossbeam_channel_delegate!(stringify($t)),
                 "`",
             ))
         ))
@@ -513,7 +510,7 @@ macro_rules! crossbeam_channel_internal {
         $cases:tt
         ()
     ) => {
-        crossbeam_channel_internal!(
+        $crate::crossbeam_channel_internal!(
             @case
             ($($tail)*)
             $cases
@@ -526,7 +523,7 @@ macro_rules! crossbeam_channel_internal {
         $cases:tt
         ()
     ) => {
-        crossbeam_channel_internal!(
+        $crate::crossbeam_channel_internal!(
             @case
             ($($tail)*)
             $cases
@@ -539,7 +536,7 @@ macro_rules! crossbeam_channel_internal {
         $cases:tt
         ()
     ) => {
-        crossbeam_channel_internal!(
+        $crate::crossbeam_channel_internal!(
             @case
             ($($tail)*)
             $cases
@@ -552,7 +549,7 @@ macro_rules! crossbeam_channel_internal {
         $cases:tt
         ($($def:tt)+)
     ) => {
-        crossbeam_channel_delegate!(compile_error(
+        $crate::crossbeam_channel_delegate!(compile_error(
             "there can be only one `default` case in a `select!` block"
         ))
     };
@@ -562,10 +559,10 @@ macro_rules! crossbeam_channel_internal {
         $cases:tt
         $default:tt
     ) => {
-        crossbeam_channel_delegate!(compile_error(
-            crossbeam_channel_delegate!(concat(
+        $crate::crossbeam_channel_delegate!(compile_error(
+            $crate::crossbeam_channel_delegate!(concat(
                 "invalid argument list in `default(",
-                crossbeam_channel_delegate!(stringify($($args)*)),
+                $crate::crossbeam_channel_delegate!(stringify($($args)*)),
                 ")`",
             ))
         ))
@@ -576,10 +573,10 @@ macro_rules! crossbeam_channel_internal {
         $cases:tt
         $default:tt
     ) => {
-        crossbeam_channel_delegate!(compile_error(
-            crossbeam_channel_delegate!(concat(
+        $crate::crossbeam_channel_delegate!(compile_error(
+            $crate::crossbeam_channel_delegate!(concat(
                 "expected an argument list or `=>` after `default`, found `",
-                crossbeam_channel_delegate!(stringify($t)),
+                $crate::crossbeam_channel_delegate!(stringify($t)),
                 "`",
             ))
         ))
@@ -591,10 +588,10 @@ macro_rules! crossbeam_channel_internal {
         $cases:tt
         $default:tt
     ) => {
-        crossbeam_channel_delegate!(compile_error(
-            crossbeam_channel_delegate!(concat(
+        $crate::crossbeam_channel_delegate!(compile_error(
+            $crate::crossbeam_channel_delegate!(concat(
                 "expected one of `recv`, `send`, or `default`, found `",
-                crossbeam_channel_delegate!(stringify($case)),
+                $crate::crossbeam_channel_delegate!(stringify($case)),
                 "`",
             ))
         ))
@@ -760,13 +757,13 @@ macro_rules! crossbeam_channel_internal {
         ($($cases:tt)*)
         $default:tt
     ) => {{
-        const _LEN: usize = crossbeam_channel_internal!(@count ($($cases)*));
+        const _LEN: usize = $crate::crossbeam_channel_internal!(@count ($($cases)*));
         let _handle: &$crate::internal::SelectHandle = &$crate::never::<()>();
 
         #[allow(unused_mut)]
         let mut _sel = [(_handle, 0, ::std::ptr::null()); _LEN];
 
-        crossbeam_channel_internal!(
+        $crate::crossbeam_channel_internal!(
             @add
             _sel
             ($($cases)*)
@@ -814,7 +811,7 @@ macro_rules! crossbeam_channel_internal {
         0
     };
     (@count ($oper:ident $args:tt -> $res:pat => $body:tt, $($cases:tt)*)) => {
-        1 + crossbeam_channel_internal!(@count ($($cases)*))
+        1 + $crate::crossbeam_channel_internal!(@count ($($cases)*))
     };
 
     // Run blocking selection.
@@ -832,7 +829,7 @@ macro_rules! crossbeam_channel_internal {
             unsafe { ::std::mem::transmute(_oper) }
         };
 
-        crossbeam_channel_internal! {
+        $crate::crossbeam_channel_internal! {
             @complete
             $sel
             _oper
@@ -860,7 +857,7 @@ macro_rules! crossbeam_channel_internal {
                 $body
             }
             Some(_oper) => {
-                crossbeam_channel_internal! {
+                $crate::crossbeam_channel_internal! {
                     @complete
                     $sel
                     _oper
@@ -890,7 +887,7 @@ macro_rules! crossbeam_channel_internal {
                 $body
             }
             ::std::option::Option::Some(_oper) => {
-                crossbeam_channel_internal! {
+                $crate::crossbeam_channel_internal! {
                     @complete
                     $sel
                     _oper
@@ -907,7 +904,7 @@ macro_rules! crossbeam_channel_internal {
         ()
         $cases:tt
     ) => {
-        crossbeam_channel_delegate!(compile_error("too many operations in a `select!` block"))
+        $crate::crossbeam_channel_delegate!(compile_error("too many operations in a `select!` block"))
     };
     // Add a receive operation to `sel`.
     (@add
@@ -930,7 +927,7 @@ macro_rules! crossbeam_channel_internal {
                 };
                 $sel[$i] = ($var, $i, $var as *const $crate::Receiver<_> as *const u8);
 
-                crossbeam_channel_internal!(
+                $crate::crossbeam_channel_internal!(
                     @add
                     $sel
                     ($($tail)*)
@@ -962,7 +959,7 @@ macro_rules! crossbeam_channel_internal {
                 };
                 $sel[$i] = ($var, $i, $var as *const $crate::Sender<_> as *const u8);
 
-                crossbeam_channel_internal!(
+                $crate::crossbeam_channel_internal!(
                     @add
                     $sel
                     ($($tail)*)
@@ -987,7 +984,7 @@ macro_rules! crossbeam_channel_internal {
             let $res = _res;
             $body
         } else {
-            crossbeam_channel_internal! {
+            $crate::crossbeam_channel_internal! {
                 @complete
                 $sel
                 $oper
@@ -1008,7 +1005,7 @@ macro_rules! crossbeam_channel_internal {
             let $res = _res;
             $body
         } else {
-            crossbeam_channel_internal! {
+            $crate::crossbeam_channel_internal! {
                 @complete
                 $sel
                 $oper
@@ -1022,34 +1019,34 @@ macro_rules! crossbeam_channel_internal {
         $oper:ident
         ()
     ) => {{
-        crossbeam_channel_delegate!(unreachable(
+        $crate::crossbeam_channel_delegate!(unreachable(
             "internal error in crossbeam-channel: invalid case"
         ))
     }};
 
     // Catches a bug within this macro (should not happen).
     (@$($tokens:tt)*) => {
-        crossbeam_channel_delegate!(compile_error(
-            crossbeam_channel_delegate!(concat(
+        $crate::crossbeam_channel_delegate!(compile_error(
+            $crate::crossbeam_channel_delegate!(concat(
                 "internal error in crossbeam-channel: ",
-                crossbeam_channel_delegate!(stringify(@$($tokens)*)),
+                $crate::crossbeam_channel_delegate!(stringify(@$($tokens)*)),
             ))
         ))
     };
 
     // The entry points.
     () => {
-        crossbeam_channel_delegate!(compile_error("empty `select!` block"))
+        $crate::crossbeam_channel_delegate!(compile_error("empty `select!` block"))
     };
     ($($case:ident $(($($args:tt)*))* => $body:expr $(,)*)*) => {
-        crossbeam_channel_internal!(
+        $crate::crossbeam_channel_internal!(
             @list
             ($($case $(($($args)*))* => { $body },)*)
             ()
         )
     };
     ($($tokens:tt)*) => {
-        crossbeam_channel_internal!(
+        $crate::crossbeam_channel_internal!(
             @list
             ($($tokens)*)
             ()
@@ -1079,11 +1076,9 @@ macro_rules! crossbeam_channel_internal {
 /// Block until a send or a receive operation is selected:
 ///
 /// ```
-/// # #[macro_use]
-/// # extern crate crossbeam_channel;
 /// # fn main() {
 /// use std::thread;
-/// use crossbeam_channel::unbounded;
+/// use crossbeam_channel::{select, unbounded};
 ///
 /// let (s1, r1) = unbounded();
 /// let (s2, r2) = unbounded();
@@ -1103,12 +1098,10 @@ macro_rules! crossbeam_channel_internal {
 /// Select from a set of operations without blocking:
 ///
 /// ```
-/// # #[macro_use]
-/// # extern crate crossbeam_channel;
 /// # fn main() {
 /// use std::thread;
 /// use std::time::Duration;
-/// use crossbeam_channel::unbounded;
+/// use crossbeam_channel::{select, unbounded};
 ///
 /// let (s1, r1) = unbounded();
 /// let (s2, r2) = unbounded();
@@ -1134,12 +1127,10 @@ macro_rules! crossbeam_channel_internal {
 /// Select over a set of operations with a timeout:
 ///
 /// ```
-/// # #[macro_use]
-/// # extern crate crossbeam_channel;
 /// # fn main() {
 /// use std::thread;
 /// use std::time::Duration;
-/// use crossbeam_channel::unbounded;
+/// use crossbeam_channel::{select, unbounded};
 ///
 /// let (s1, r1) = unbounded();
 /// let (s2, r2) = unbounded();
@@ -1165,12 +1156,10 @@ macro_rules! crossbeam_channel_internal {
 /// Optionally add a receive operation to `select!` using [`never`]:
 ///
 /// ```
-/// # #[macro_use]
-/// # extern crate crossbeam_channel;
 /// # fn main() {
 /// use std::thread;
 /// use std::time::Duration;
-/// use crossbeam_channel::{never, unbounded};
+/// use crossbeam_channel::{select, never, unbounded};
 ///
 /// let (s1, r1) = unbounded();
 /// let (s2, r2) = unbounded();
@@ -1202,7 +1191,7 @@ macro_rules! crossbeam_channel_internal {
 #[macro_export(local_inner_macros)]
 macro_rules! select {
     ($($tokens:tt)*) => {
-        crossbeam_channel_internal!(
+        $crate::crossbeam_channel_internal!(
             $($tokens)*
         )
     };

--- a/crossbeam-channel/src/utils.rs
+++ b/crossbeam-channel/src/utils.rs
@@ -87,17 +87,17 @@ impl<T> Spinlock<T> {
 }
 
 /// A guard holding a spinlock locked.
-pub struct SpinlockGuard<'a, T: 'a> {
+pub struct SpinlockGuard<'a, T> {
     parent: &'a Spinlock<T>,
 }
 
-impl<'a, T> Drop for SpinlockGuard<'a, T> {
+impl<T> Drop for SpinlockGuard<'_, T> {
     fn drop(&mut self) {
         self.parent.flag.store(false, Ordering::Release);
     }
 }
 
-impl<'a, T> Deref for SpinlockGuard<'a, T> {
+impl<T> Deref for SpinlockGuard<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -105,7 +105,7 @@ impl<'a, T> Deref for SpinlockGuard<'a, T> {
     }
 }
 
-impl<'a, T> DerefMut for SpinlockGuard<'a, T> {
+impl<T> DerefMut for SpinlockGuard<'_, T> {
     fn deref_mut(&mut self) -> &mut T {
         unsafe { &mut *self.parent.value.get() }
     }

--- a/crossbeam-channel/src/waker.rs
+++ b/crossbeam-channel/src/waker.rs
@@ -3,9 +3,9 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::{self, ThreadId};
 
-use context::Context;
-use select::{Operation, Selected};
-use utils::Spinlock;
+use crate::context::Context;
+use crate::select::{Operation, Selected};
+use crate::utils::Spinlock;
 
 /// Represents a thread blocked on a specific channel operation.
 pub struct Entry {

--- a/crossbeam-channel/tests/after.rs
+++ b/crossbeam-channel/tests/after.rs
@@ -1,16 +1,11 @@
 //! Tests for the after channel flavor.
 
-#[macro_use]
-extern crate crossbeam_channel;
-extern crate crossbeam_utils;
-extern crate rand;
-
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use crossbeam_channel::{after, Select, TryRecvError};
+use crossbeam_channel::{after, select, Select, TryRecvError};
 use crossbeam_utils::thread::scope;
 
 fn ms(ms: u64) -> Duration {

--- a/crossbeam-channel/tests/array.rs
+++ b/crossbeam-channel/tests/array.rs
@@ -1,17 +1,12 @@
 //! Tests for the array channel flavor.
 
-#[macro_use]
-extern crate crossbeam_channel;
-extern crate crossbeam_utils;
-extern crate rand;
-
 use std::any::Any;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::thread;
 use std::time::Duration;
 
-use crossbeam_channel::{bounded, Receiver};
+use crossbeam_channel::{bounded, select, Receiver};
 use crossbeam_channel::{RecvError, RecvTimeoutError, TryRecvError};
 use crossbeam_channel::{SendError, SendTimeoutError, TrySendError};
 use crossbeam_utils::thread::scope;

--- a/crossbeam-channel/tests/golang.rs
+++ b/crossbeam-channel/tests/golang.rs
@@ -9,9 +9,6 @@
 //!   - https://golang.org/LICENSE
 //!   - https://golang.org/PATENTS
 
-#[macro_use]
-extern crate crossbeam_channel;
-
 use std::any::Any;
 use std::cell::Cell;
 use std::collections::HashMap;
@@ -19,7 +16,7 @@ use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 use std::time::Duration;
 
-use crossbeam_channel::{bounded, tick, Receiver, Select, Sender};
+use crossbeam_channel::{bounded, select, tick, Receiver, Select, Sender};
 
 fn ms(ms: u64) -> Duration {
     Duration::from_millis(ms)

--- a/crossbeam-channel/tests/golang.rs
+++ b/crossbeam-channel/tests/golang.rs
@@ -435,13 +435,13 @@ mod nonblock {
             }
 
             go!(c32, sync, i32receiver(c32, sync));
-            let mut try = 0;
+            let mut r#try = 0;
             loop {
                 select! {
                     send(c32.tx(), 123) -> _ => break,
                     default => {
-                        try += 1;
-                        if try > MAX_TRIES {
+                        r#try += 1;
+                        if r#try > MAX_TRIES {
                             println!("i32receiver buffer={}", buffer);
                             panic!("fail")
                         }
@@ -454,7 +454,7 @@ mod nonblock {
             if buffer > 0 {
                 sync.recv();
             }
-            let mut try = 0;
+            let mut r#try = 0;
             loop {
                 select! {
                     recv(c32.rx()) -> v => {
@@ -464,8 +464,8 @@ mod nonblock {
                         break;
                     }
                     default => {
-                        try += 1;
-                        if try > MAX_TRIES {
+                        r#try += 1;
+                        if r#try > MAX_TRIES {
                             println!("i32sender buffer={}", buffer);
                             panic!("fail");
                         }
@@ -478,13 +478,13 @@ mod nonblock {
             }
 
             go!(c64, sync, i64receiver(c64, sync));
-            let mut try = 0;
+            let mut r#try = 0;
             loop {
                 select! {
                     send(c64.tx(), 123456) -> _ => break,
                     default => {
-                        try += 1;
-                        if try > MAX_TRIES {
+                        r#try += 1;
+                        if r#try > MAX_TRIES {
                             println!("i64receiver buffer={}", buffer);
                             panic!("fail")
                         }
@@ -497,7 +497,7 @@ mod nonblock {
             if buffer > 0 {
                 sync.recv();
             }
-            let mut try = 0;
+            let mut r#try = 0;
             loop {
                 select! {
                     recv(c64.rx()) -> v => {
@@ -507,8 +507,8 @@ mod nonblock {
                         break;
                     }
                     default => {
-                        try += 1;
-                        if try > MAX_TRIES {
+                        r#try += 1;
+                        if r#try > MAX_TRIES {
                             println!("i64sender buffer={}", buffer);
                             panic!("fail");
                         }
@@ -521,13 +521,13 @@ mod nonblock {
             }
 
             go!(cb, sync, breceiver(cb, sync));
-            let mut try = 0;
+            let mut r#try = 0;
             loop {
                 select! {
                     send(cb.tx(), true) -> _ => break,
                     default => {
-                        try += 1;
-                        if try > MAX_TRIES {
+                        r#try += 1;
+                        if r#try > MAX_TRIES {
                             println!("breceiver buffer={}", buffer);
                             panic!("fail")
                         }
@@ -540,7 +540,7 @@ mod nonblock {
             if buffer > 0 {
                 sync.recv();
             }
-            let mut try = 0;
+            let mut r#try = 0;
             loop {
                 select! {
                     recv(cb.rx()) -> v => {
@@ -550,8 +550,8 @@ mod nonblock {
                         break;
                     }
                     default => {
-                        try += 1;
-                        if try > MAX_TRIES {
+                        r#try += 1;
+                        if r#try > MAX_TRIES {
                             println!("bsender buffer={}", buffer);
                             panic!("fail");
                         }
@@ -564,13 +564,13 @@ mod nonblock {
             }
 
             go!(cs, sync, sreceiver(cs, sync));
-            let mut try = 0;
+            let mut r#try = 0;
             loop {
                 select! {
                     send(cs.tx(), "hello".to_string()) -> _ => break,
                     default => {
-                        try += 1;
-                        if try > MAX_TRIES {
+                        r#try += 1;
+                        if r#try > MAX_TRIES {
                             println!("sreceiver buffer={}", buffer);
                             panic!("fail")
                         }
@@ -583,7 +583,7 @@ mod nonblock {
             if buffer > 0 {
                 sync.recv();
             }
-            let mut try = 0;
+            let mut r#try = 0;
             loop {
                 select! {
                     recv(cs.rx()) -> v => {
@@ -593,8 +593,8 @@ mod nonblock {
                         break;
                     }
                     default => {
-                        try += 1;
-                        if try > MAX_TRIES {
+                        r#try += 1;
+                        if r#try > MAX_TRIES {
                             println!("ssender buffer={}", buffer);
                             panic!("fail");
                         }

--- a/crossbeam-channel/tests/iter.rs
+++ b/crossbeam-channel/tests/iter.rs
@@ -1,8 +1,5 @@
 //! Tests for iteration over receivers.
 
-extern crate crossbeam_channel;
-extern crate crossbeam_utils;
-
 use crossbeam_channel::unbounded;
 use crossbeam_utils::thread::scope;
 

--- a/crossbeam-channel/tests/list.rs
+++ b/crossbeam-channel/tests/list.rs
@@ -1,17 +1,12 @@
 //! Tests for the list channel flavor.
 
-#[macro_use]
-extern crate crossbeam_channel;
-extern crate crossbeam_utils;
-extern crate rand;
-
 use std::any::Any;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::thread;
 use std::time::Duration;
 
-use crossbeam_channel::{unbounded, Receiver};
+use crossbeam_channel::{select, unbounded, Receiver};
 use crossbeam_channel::{RecvError, RecvTimeoutError, TryRecvError};
 use crossbeam_channel::{SendError, SendTimeoutError, TrySendError};
 use crossbeam_utils::thread::scope;

--- a/crossbeam-channel/tests/mpsc.rs
+++ b/crossbeam-channel/tests/mpsc.rs
@@ -20,13 +20,12 @@
 //!   - https://github.com/rust-lang/rust/blob/master/COPYRIGHT
 //!   - https://www.rust-lang.org/en-US/legal.html
 
-#[macro_use]
-extern crate crossbeam_channel as cc;
-
 use std::sync::mpsc::{RecvError, RecvTimeoutError, TryRecvError};
 use std::sync::mpsc::{SendError, TrySendError};
 use std::thread::JoinHandle;
 use std::time::Duration;
+
+use crossbeam_channel as cc;
 
 pub struct Sender<T> {
     pub inner: cc::Sender<T>,
@@ -175,7 +174,7 @@ macro_rules! select {
     (
         $($name:pat = $rx:ident.$meth:ident() => $code:expr),+
     ) => ({
-        crossbeam_channel_internal! {
+        cc::crossbeam_channel_internal! {
             $(
                 recv(($rx).inner) -> res => {
                     let $name = res.map_err(|_| ::std::sync::mpsc::RecvError);

--- a/crossbeam-channel/tests/never.rs
+++ b/crossbeam-channel/tests/never.rs
@@ -1,13 +1,9 @@
 //! Tests for the never channel flavor.
 
-#[macro_use]
-extern crate crossbeam_channel;
-extern crate rand;
-
 use std::thread;
 use std::time::{Duration, Instant};
 
-use crossbeam_channel::{never, tick, unbounded};
+use crossbeam_channel::{never, select, tick, unbounded};
 
 fn ms(ms: u64) -> Duration {
     Duration::from_millis(ms)

--- a/crossbeam-channel/tests/ready.rs
+++ b/crossbeam-channel/tests/ready.rs
@@ -1,8 +1,5 @@
 //! Tests for channel readiness using the `Select` struct.
 
-extern crate crossbeam_channel;
-extern crate crossbeam_utils;
-
 use std::any::Any;
 use std::cell::Cell;
 use std::thread;

--- a/crossbeam-channel/tests/same_channel.rs
+++ b/crossbeam-channel/tests/same_channel.rs
@@ -1,5 +1,3 @@
-extern crate crossbeam_channel;
-
 use std::time::Duration;
 
 use crossbeam_channel::{after, bounded, never, tick, unbounded};

--- a/crossbeam-channel/tests/select.rs
+++ b/crossbeam-channel/tests/select.rs
@@ -1,8 +1,5 @@
 //! Tests for channel selection using the `Select` struct.
 
-extern crate crossbeam_channel;
-extern crate crossbeam_utils;
-
 use std::any::Any;
 use std::cell::Cell;
 use std::thread;

--- a/crossbeam-channel/tests/select_macro.rs
+++ b/crossbeam-channel/tests/select_macro.rs
@@ -2,17 +2,13 @@
 
 #![forbid(unsafe_code)] // select! is safe.
 
-#[macro_use]
-extern crate crossbeam_channel;
-extern crate crossbeam_utils;
-
 use std::any::Any;
 use std::cell::Cell;
 use std::ops::Deref;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use crossbeam_channel::{after, bounded, never, tick, unbounded};
+use crossbeam_channel::{after, bounded, never, select, tick, unbounded};
 use crossbeam_channel::{Receiver, RecvError, SendError, Sender, TryRecvError};
 use crossbeam_utils::thread::scope;
 

--- a/crossbeam-channel/tests/thread_locals.rs
+++ b/crossbeam-channel/tests/thread_locals.rs
@@ -1,13 +1,9 @@
 //! Tests that make sure accessing thread-locals while exiting the thread doesn't cause panics.
 
-#[macro_use]
-extern crate crossbeam_channel;
-extern crate crossbeam_utils;
-
 use std::thread;
 use std::time::Duration;
 
-use crossbeam_channel::unbounded;
+use crossbeam_channel::{select, unbounded};
 use crossbeam_utils::thread::scope;
 
 fn ms(ms: u64) -> Duration {

--- a/crossbeam-channel/tests/tick.rs
+++ b/crossbeam-channel/tests/tick.rs
@@ -1,16 +1,11 @@
 //! Tests for the tick channel flavor.
 
-#[macro_use]
-extern crate crossbeam_channel;
-extern crate crossbeam_utils;
-extern crate rand;
-
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use crossbeam_channel::{after, tick, Select, TryRecvError};
+use crossbeam_channel::{after, select, tick, Select, TryRecvError};
 use crossbeam_utils::thread::scope;
 
 fn ms(ms: u64) -> Duration {

--- a/crossbeam-channel/tests/zero.rs
+++ b/crossbeam-channel/tests/zero.rs
@@ -1,17 +1,12 @@
 //! Tests for the zero channel flavor.
 
-#[macro_use]
-extern crate crossbeam_channel;
-extern crate crossbeam_utils;
-extern crate rand;
-
 use std::any::Any;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::thread;
 use std::time::Duration;
 
-use crossbeam_channel::{bounded, Receiver};
+use crossbeam_channel::{bounded, select, Receiver};
 use crossbeam_channel::{RecvError, RecvTimeoutError, TryRecvError};
 use crossbeam_channel::{SendError, SendTimeoutError, TrySendError};
 use crossbeam_utils::thread::scope;

--- a/crossbeam-deque/Cargo.toml
+++ b/crossbeam-deque/Cargo.toml
@@ -24,7 +24,7 @@ default = ["std"]
 std = ["crossbeam-epoch/std", "crossbeam-utils/std"]
 
 [dependencies]
-cfg-if = "0.1.2"
+cfg-if = "0.1.10"
 
 [dependencies.crossbeam-epoch]
 version = "0.8"

--- a/crossbeam-deque/Cargo.toml
+++ b/crossbeam-deque/Cargo.toml
@@ -6,6 +6,7 @@ name = "crossbeam-deque"
 # - Create "crossbeam-deque-X.Y.Z" git tag
 version = "0.7.3"
 authors = ["The Crossbeam Project Developers"]
+edition = "2018"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/crossbeam-rs/crossbeam"

--- a/crossbeam-deque/README.md
+++ b/crossbeam-deque/README.md
@@ -24,12 +24,6 @@ Add this to your `Cargo.toml`:
 crossbeam-deque = "0.7"
 ```
 
-Next, add this to your crate:
-
-```rust
-extern crate crossbeam_deque;
-```
-
 ## Compatibility
 
 Crossbeam Deque supports stable Rust releases going back at least six months,

--- a/crossbeam-deque/src/deque.rs
+++ b/crossbeam-deque/src/deque.rs
@@ -8,8 +8,8 @@ use std::ptr;
 use std::sync::atomic::{self, AtomicIsize, AtomicPtr, AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use epoch::{Atomic, Owned};
-use utils::{Backoff, CachePadded};
+use crate::epoch::{Atomic, Owned};
+use crate::utils::{Backoff, CachePadded};
 
 // Minimum buffer capacity.
 const MIN_CAP: usize = 64;

--- a/crossbeam-deque/src/deque.rs
+++ b/crossbeam-deque/src/deque.rs
@@ -8,7 +8,7 @@ use std::ptr;
 use std::sync::atomic::{self, AtomicIsize, AtomicPtr, AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use crate::epoch::{Atomic, Owned};
+use crate::epoch::{self, Atomic, Owned};
 use crate::utils::{Backoff, CachePadded};
 
 // Minimum buffer capacity.
@@ -532,7 +532,7 @@ impl<T> Worker<T> {
 }
 
 impl<T> fmt::Debug for Worker<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("Worker { .. }")
     }
 }
@@ -1040,7 +1040,7 @@ impl<T> Clone for Stealer<T> {
 }
 
 impl<T> fmt::Debug for Stealer<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("Stealer { .. }")
     }
 }
@@ -1798,7 +1798,7 @@ impl<T> Drop for Injector<T> {
 }
 
 impl<T> fmt::Debug for Injector<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("Worker { .. }")
     }
 }
@@ -1951,7 +1951,7 @@ impl<T> Steal<T> {
 }
 
 impl<T> fmt::Debug for Steal<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Steal::Empty => f.pad("Empty"),
             Steal::Success(_) => f.pad("Success(..)"),

--- a/crossbeam-deque/src/lib.rs
+++ b/crossbeam-deque/src/lib.rs
@@ -86,17 +86,15 @@
 //! [`steal_batch()`]: struct.Stealer.html#method.steal_batch
 //! [`steal_batch_and_pop()`]: struct.Stealer.html#method.steal_batch_and_pop
 
-#![warn(missing_docs)]
-#![warn(missing_debug_implementations)]
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[macro_use]
-extern crate cfg_if;
+use cfg_if::cfg_if;
 
 cfg_if! {
     if #[cfg(feature = "std")] {
-        extern crate crossbeam_epoch as epoch;
-        extern crate crossbeam_utils as utils;
+        use crossbeam_epoch as epoch;
+        use crossbeam_utils as utils;
 
         mod deque;
         pub use crate::deque::{Injector, Steal, Stealer, Worker};

--- a/crossbeam-deque/src/lib.rs
+++ b/crossbeam-deque/src/lib.rs
@@ -99,6 +99,6 @@ cfg_if! {
         extern crate crossbeam_utils as utils;
 
         mod deque;
-        pub use deque::{Injector, Steal, Stealer, Worker};
+        pub use crate::deque::{Injector, Steal, Stealer, Worker};
     }
 }

--- a/crossbeam-deque/tests/fifo.rs
+++ b/crossbeam-deque/tests/fifo.rs
@@ -6,10 +6,10 @@ use std::sync::atomic::Ordering::SeqCst;
 use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::sync::{Arc, Mutex};
 
-use deque::Steal::{Empty, Success};
-use deque::Worker;
+use crate::deque::Steal::{Empty, Success};
+use crate::deque::Worker;
 use rand::Rng;
-use utils::thread::scope;
+use crate::utils::thread::scope;
 
 #[test]
 fn smoke() {

--- a/crossbeam-deque/tests/fifo.rs
+++ b/crossbeam-deque/tests/fifo.rs
@@ -1,15 +1,11 @@
-extern crate crossbeam_deque as deque;
-extern crate crossbeam_utils as utils;
-extern crate rand;
-
 use std::sync::atomic::Ordering::SeqCst;
 use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::sync::{Arc, Mutex};
 
-use crate::deque::Steal::{Empty, Success};
-use crate::deque::Worker;
+use crossbeam_deque::Steal::{Empty, Success};
+use crossbeam_deque::Worker;
+use crossbeam_utils::thread::scope;
 use rand::Rng;
-use crate::utils::thread::scope;
 
 #[test]
 fn smoke() {

--- a/crossbeam-deque/tests/injector.rs
+++ b/crossbeam-deque/tests/injector.rs
@@ -6,10 +6,10 @@ use std::sync::atomic::Ordering::SeqCst;
 use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::sync::{Arc, Mutex};
 
-use deque::Steal::{Empty, Success};
-use deque::{Injector, Worker};
+use crate::deque::Steal::{Empty, Success};
+use crate::deque::{Injector, Worker};
 use rand::Rng;
-use utils::thread::scope;
+use crate::utils::thread::scope;
 
 #[test]
 fn smoke() {

--- a/crossbeam-deque/tests/injector.rs
+++ b/crossbeam-deque/tests/injector.rs
@@ -1,15 +1,11 @@
-extern crate crossbeam_deque as deque;
-extern crate crossbeam_utils as utils;
-extern crate rand;
-
 use std::sync::atomic::Ordering::SeqCst;
 use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::sync::{Arc, Mutex};
 
-use crate::deque::Steal::{Empty, Success};
-use crate::deque::{Injector, Worker};
+use crossbeam_deque::Steal::{Empty, Success};
+use crossbeam_deque::{Injector, Worker};
+use crossbeam_utils::thread::scope;
 use rand::Rng;
-use crate::utils::thread::scope;
 
 #[test]
 fn smoke() {

--- a/crossbeam-deque/tests/lifo.rs
+++ b/crossbeam-deque/tests/lifo.rs
@@ -6,10 +6,10 @@ use std::sync::atomic::Ordering::SeqCst;
 use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::sync::{Arc, Mutex};
 
-use deque::Steal::{Empty, Success};
-use deque::Worker;
+use crate::deque::Steal::{Empty, Success};
+use crate::deque::Worker;
 use rand::Rng;
-use utils::thread::scope;
+use crate::utils::thread::scope;
 
 #[test]
 fn smoke() {

--- a/crossbeam-deque/tests/lifo.rs
+++ b/crossbeam-deque/tests/lifo.rs
@@ -1,15 +1,11 @@
-extern crate crossbeam_deque as deque;
-extern crate crossbeam_utils as utils;
-extern crate rand;
-
 use std::sync::atomic::Ordering::SeqCst;
 use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::sync::{Arc, Mutex};
 
-use crate::deque::Steal::{Empty, Success};
-use crate::deque::Worker;
+use crossbeam_deque::Steal::{Empty, Success};
+use crossbeam_deque::Worker;
+use crossbeam_utils::thread::scope;
 use rand::Rng;
-use crate::utils::thread::scope;
 
 #[test]
 fn smoke() {

--- a/crossbeam-deque/tests/steal.rs
+++ b/crossbeam-deque/tests/steal.rs
@@ -1,7 +1,5 @@
-extern crate crossbeam_deque as deque;
-
-use crate::deque::Steal::Success;
-use crate::deque::{Injector, Worker};
+use crossbeam_deque::Steal::Success;
+use crossbeam_deque::{Injector, Worker};
 
 #[test]
 fn steal_fifo() {

--- a/crossbeam-deque/tests/steal.rs
+++ b/crossbeam-deque/tests/steal.rs
@@ -1,7 +1,7 @@
 extern crate crossbeam_deque as deque;
 
-use deque::Steal::Success;
-use deque::{Injector, Worker};
+use crate::deque::Steal::Success;
+use crate::deque::{Injector, Worker};
 
 #[test]
 fn steal_fifo() {

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -37,8 +37,8 @@ nightly = ["crossbeam-utils/nightly"]
 sanitize = [] # Makes it more likely to trigger any potential data races.
 
 [dependencies]
-cfg-if = "0.1.2"
-memoffset = "0.5"
+cfg-if = "0.1.10"
+memoffset = "0.5.1"
 
 [dependencies.crossbeam-utils]
 version = "0.7"

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -6,6 +6,7 @@ name = "crossbeam-epoch"
 # - Create "crossbeam-epoch-X.Y.Z" git tag
 version = "0.8.2"
 authors = ["The Crossbeam Project Developers"]
+edition = "2018"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/crossbeam-rs/crossbeam"

--- a/crossbeam-epoch/README.md
+++ b/crossbeam-epoch/README.md
@@ -31,12 +31,6 @@ Add this to your `Cargo.toml`:
 crossbeam-epoch = "0.8"
 ```
 
-Next, add this to your crate:
-
-```rust
-extern crate crossbeam_epoch as epoch;
-```
-
 ## Compatibility
 
 Crossbeam Epoch supports stable Rust releases going back at least six months,

--- a/crossbeam-epoch/benches/defer.rs
+++ b/crossbeam-epoch/benches/defer.rs
@@ -1,12 +1,10 @@
 #![feature(test)]
 
-extern crate crossbeam_epoch as epoch;
-extern crate crossbeam_utils as utils;
 extern crate test;
 
-use crate::epoch::Owned;
+use crossbeam_epoch::{self as epoch, Owned};
+use crossbeam_utils::thread::scope;
 use test::Bencher;
-use crate::utils::thread::scope;
 
 #[bench]
 fn single_alloc_defer_free(b: &mut Bencher) {

--- a/crossbeam-epoch/benches/defer.rs
+++ b/crossbeam-epoch/benches/defer.rs
@@ -4,9 +4,9 @@ extern crate crossbeam_epoch as epoch;
 extern crate crossbeam_utils as utils;
 extern crate test;
 
-use epoch::Owned;
+use crate::epoch::Owned;
 use test::Bencher;
-use utils::thread::scope;
+use crate::utils::thread::scope;
 
 #[bench]
 fn single_alloc_defer_free(b: &mut Bencher) {

--- a/crossbeam-epoch/benches/flush.rs
+++ b/crossbeam-epoch/benches/flush.rs
@@ -1,13 +1,12 @@
 #![feature(test)]
 
-extern crate crossbeam_epoch as epoch;
-extern crate crossbeam_utils as utils;
 extern crate test;
 
 use std::sync::Barrier;
 
+use crossbeam_epoch as epoch;
+use crossbeam_utils::thread::scope;
 use test::Bencher;
-use crate::utils::thread::scope;
 
 #[bench]
 fn single_flush(b: &mut Bencher) {

--- a/crossbeam-epoch/benches/flush.rs
+++ b/crossbeam-epoch/benches/flush.rs
@@ -7,7 +7,7 @@ extern crate test;
 use std::sync::Barrier;
 
 use test::Bencher;
-use utils::thread::scope;
+use crate::utils::thread::scope;
 
 #[bench]
 fn single_flush(b: &mut Bencher) {

--- a/crossbeam-epoch/benches/pin.rs
+++ b/crossbeam-epoch/benches/pin.rs
@@ -5,7 +5,7 @@ extern crate crossbeam_utils as utils;
 extern crate test;
 
 use test::Bencher;
-use utils::thread::scope;
+use crate::utils::thread::scope;
 
 #[bench]
 fn single_pin(b: &mut Bencher) {

--- a/crossbeam-epoch/benches/pin.rs
+++ b/crossbeam-epoch/benches/pin.rs
@@ -1,11 +1,10 @@
 #![feature(test)]
 
-extern crate crossbeam_epoch as epoch;
-extern crate crossbeam_utils as utils;
 extern crate test;
 
+use crossbeam_epoch as epoch;
+use crossbeam_utils::thread::scope;
 use test::Bencher;
-use crate::utils::thread::scope;
 
 #[bench]
 fn single_pin(b: &mut Bencher) {

--- a/crossbeam-epoch/examples/sanitize.rs
+++ b/crossbeam-epoch/examples/sanitize.rs
@@ -1,13 +1,10 @@
-extern crate crossbeam_epoch as epoch;
-extern crate rand;
-
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::{AcqRel, Acquire, Relaxed};
 use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use crate::epoch::{Atomic, Collector, LocalHandle, Owned, Shared};
+use crossbeam_epoch::{self as epoch, Atomic, Collector, LocalHandle, Owned, Shared};
 use rand::Rng;
 
 fn worker(a: Arc<Atomic<AtomicUsize>>, handle: LocalHandle) -> usize {

--- a/crossbeam-epoch/examples/sanitize.rs
+++ b/crossbeam-epoch/examples/sanitize.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use epoch::{Atomic, Collector, LocalHandle, Owned, Shared};
+use crate::epoch::{Atomic, Collector, LocalHandle, Owned, Shared};
 use rand::Rng;
 
 fn worker(a: Arc<Atomic<AtomicUsize>>, handle: LocalHandle) -> usize {

--- a/crossbeam-epoch/examples/treiber_stack.rs
+++ b/crossbeam-epoch/examples/treiber_stack.rs
@@ -5,8 +5,8 @@ use std::mem::ManuallyDrop;
 use std::ptr;
 use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 
-use epoch::{Atomic, Owned};
-use utils::thread::scope;
+use crate::epoch::{Atomic, Owned};
+use crate::utils::thread::scope;
 
 /// Treiber's lock-free stack.
 ///

--- a/crossbeam-epoch/examples/treiber_stack.rs
+++ b/crossbeam-epoch/examples/treiber_stack.rs
@@ -1,12 +1,9 @@
-extern crate crossbeam_epoch as epoch;
-extern crate crossbeam_utils as utils;
-
 use std::mem::ManuallyDrop;
 use std::ptr;
 use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 
-use crate::epoch::{Atomic, Owned};
-use crate::utils::thread::scope;
+use crossbeam_epoch::{self as epoch, Atomic, Owned};
+use crossbeam_utils::thread::scope;
 
 /// Treiber's lock-free stack.
 ///

--- a/crossbeam-epoch/src/atomic.rs
+++ b/crossbeam-epoch/src/atomic.rs
@@ -9,7 +9,7 @@ use core::ptr;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 use crossbeam_utils::atomic::AtomicConsume;
-use guard::Guard;
+use crate::guard::Guard;
 
 /// Given ordering for the success case in a compare-exchange operation, returns the strongest
 /// appropriate ordering for the failure case.

--- a/crossbeam-epoch/src/collector.rs
+++ b/crossbeam-epoch/src/collector.rs
@@ -15,8 +15,8 @@
 use alloc::sync::Arc;
 use core::fmt;
 
-use guard::Guard;
-use internal::{Global, Local};
+use crate::guard::Guard;
+use crate::internal::{Global, Local};
 
 /// An epoch-based garbage collector.
 pub struct Collector {
@@ -110,7 +110,7 @@ mod tests {
 
     use crossbeam_utils::thread;
 
-    use {Collector, Owned};
+    use crate::{Collector, Owned};
 
     const NUM_THREADS: usize = 8;
 

--- a/crossbeam-epoch/src/collector.rs
+++ b/crossbeam-epoch/src/collector.rs
@@ -50,7 +50,7 @@ impl Clone for Collector {
 }
 
 impl fmt::Debug for Collector {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("Collector { .. }")
     }
 }
@@ -98,7 +98,7 @@ impl Drop for LocalHandle {
 }
 
 impl fmt::Debug for LocalHandle {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("LocalHandle { .. }")
     }
 }

--- a/crossbeam-epoch/src/default.rs
+++ b/crossbeam-epoch/src/default.rs
@@ -4,8 +4,8 @@
 //! is registered in the default collector.  If initialized, the thread's participant will get
 //! destructed on thread exit, which in turn unregisters the thread.
 
-use collector::{Collector, LocalHandle};
-use guard::Guard;
+use crate::collector::{Collector, LocalHandle};
+use crate::guard::Guard;
 
 lazy_static! {
     /// The global data for the default garbage collector.

--- a/crossbeam-epoch/src/default.rs
+++ b/crossbeam-epoch/src/default.rs
@@ -6,6 +6,7 @@
 
 use crate::collector::{Collector, LocalHandle};
 use crate::guard::Guard;
+use lazy_static::lazy_static;
 
 lazy_static! {
     /// The global data for the default garbage collector.

--- a/crossbeam-epoch/src/deferred.rs
+++ b/crossbeam-epoch/src/deferred.rs
@@ -23,7 +23,7 @@ pub struct Deferred {
 }
 
 impl fmt::Debug for Deferred {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         f.pad("Deferred { .. }")
     }
 }

--- a/crossbeam-epoch/src/guard.rs
+++ b/crossbeam-epoch/src/guard.rs
@@ -1,10 +1,10 @@
 use core::fmt;
 use core::mem;
 
-use atomic::Shared;
-use collector::Collector;
-use deferred::Deferred;
-use internal::Local;
+use crate::atomic::Shared;
+use crate::collector::Collector;
+use crate::deferred::Deferred;
+use crate::internal::Local;
 
 /// A guard that keeps the current thread pinned.
 ///

--- a/crossbeam-epoch/src/guard.rs
+++ b/crossbeam-epoch/src/guard.rs
@@ -1,6 +1,8 @@
 use core::fmt;
 use core::mem;
 
+use scopeguard::defer;
+
 use crate::atomic::Shared;
 use crate::collector::Collector;
 use crate::deferred::Deferred;
@@ -268,7 +270,7 @@ impl Guard {
     /// ```
     ///
     /// [`unprotected`]: fn.unprotected.html
-    pub unsafe fn defer_destroy<T>(&self, ptr: Shared<T>) {
+    pub unsafe fn defer_destroy<T>(&self, ptr: Shared<'_, T>) {
         self.defer_unchecked(move || ptr.into_owned());
     }
 
@@ -426,7 +428,7 @@ impl Drop for Guard {
 }
 
 impl fmt::Debug for Guard {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("Guard { .. }")
     }
 }

--- a/crossbeam-epoch/src/internal.rs
+++ b/crossbeam-epoch/src/internal.rs
@@ -43,6 +43,7 @@ use core::sync::atomic::Ordering;
 use core::{fmt, ptr};
 
 use crossbeam_utils::CachePadded;
+use memoffset::offset_of;
 
 use crate::atomic::{Owned, Shared};
 use crate::collector::{Collector, LocalHandle};
@@ -205,7 +206,7 @@ impl Drop for Bag {
 
 // can't #[derive(Debug)] because Debug is not implemented for arrays 64 items long
 impl fmt::Debug for Bag {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Bag")
             .field("deferreds", &&self.deferreds[..self.len])
             .finish()

--- a/crossbeam-epoch/src/internal.rs
+++ b/crossbeam-epoch/src/internal.rs
@@ -44,13 +44,13 @@ use core::{fmt, ptr};
 
 use crossbeam_utils::CachePadded;
 
-use atomic::{Owned, Shared};
-use collector::{Collector, LocalHandle};
-use deferred::Deferred;
-use epoch::{AtomicEpoch, Epoch};
-use guard::{unprotected, Guard};
-use sync::list::{Entry, IsElement, IterError, List};
-use sync::queue::Queue;
+use crate::atomic::{Owned, Shared};
+use crate::collector::{Collector, LocalHandle};
+use crate::deferred::Deferred;
+use crate::epoch::{AtomicEpoch, Epoch};
+use crate::guard::{unprotected, Guard};
+use crate::sync::list::{Entry, IsElement, IterError, List};
+use crate::sync::queue::Queue;
 
 /// Maximum number of objects a bag can contain.
 #[cfg(not(feature = "sanitize"))]

--- a/crossbeam-epoch/src/lib.rs
+++ b/crossbeam-epoch/src/lib.rs
@@ -54,26 +54,16 @@
 //! [`pin`]: fn.pin.html
 //! [`defer`]: struct.Guard.html#method.defer
 
-#![warn(missing_docs)]
-#![warn(missing_debug_implementations)]
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]
 
-#[macro_use]
-extern crate cfg_if;
-#[cfg(feature = "alloc")]
-extern crate alloc;
-#[cfg(feature = "std")]
-extern crate core;
+use cfg_if::cfg_if;
 
 #[cfg_attr(feature = "nightly", cfg(target_has_atomic = "ptr"))]
 cfg_if! {
     if #[cfg(feature = "alloc")] {
-        extern crate crossbeam_utils;
-        #[macro_use]
-        extern crate memoffset;
-        #[macro_use]
-        extern crate scopeguard;
+        extern crate alloc;
 
         mod atomic;
         mod collector;
@@ -91,9 +81,6 @@ cfg_if! {
 
 cfg_if! {
     if #[cfg(feature = "std")] {
-        #[macro_use]
-        extern crate lazy_static;
-
         mod default;
         pub use self::default::{default_collector, is_pinned, pin};
     }

--- a/crossbeam-epoch/src/sync/list.rs
+++ b/crossbeam-epoch/src/sync/list.rs
@@ -102,7 +102,7 @@ pub struct List<T, C: IsElement<T> = T> {
 }
 
 /// An iterator used for retrieving values from the list.
-pub struct Iter<'g, T: 'g, C: IsElement<T>> {
+pub struct Iter<'g, T, C: IsElement<T>> {
     /// The guard that protects the iteration.
     guard: &'g Guard,
 
@@ -298,9 +298,9 @@ impl<'g, T: 'g, C: IsElement<T>> Iterator for Iter<'g, T, C> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{Collector, Owned};
     use crossbeam_utils::thread;
     use std::sync::Barrier;
-    use crate::{Collector, Owned};
 
     impl IsElement<Entry> for Entry {
         fn entry_of(entry: &Entry) -> &Entry {

--- a/crossbeam-epoch/src/sync/list.rs
+++ b/crossbeam-epoch/src/sync/list.rs
@@ -6,7 +6,7 @@
 use core::marker::PhantomData;
 use core::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 
-use {unprotected, Atomic, Guard, Shared};
+use crate::{unprotected, Atomic, Guard, Shared};
 
 /// An entry in a linked list.
 ///
@@ -66,7 +66,7 @@ pub struct Entry {
 ///
 pub trait IsElement<T> {
     /// Returns a reference to this element's `Entry`.
-    fn entry_of(&T) -> &Entry;
+    fn entry_of(_: &T) -> &Entry;
 
     /// Given a reference to an element's entry, returns that element.
     ///
@@ -80,7 +80,7 @@ pub trait IsElement<T> {
     ///
     /// The caller has to guarantee that the `Entry` is called with was retrieved from an instance
     /// of the element type (`T`).
-    unsafe fn element_of(&Entry) -> &T;
+    unsafe fn element_of(_: &Entry) -> &T;
 
     /// The function that is called when an entry is unlinked from list.
     ///
@@ -88,7 +88,7 @@ pub trait IsElement<T> {
     ///
     /// The caller has to guarantee that the `Entry` is called with was retrieved from an instance
     /// of the element type (`T`).
-    unsafe fn finalize(&Entry, &Guard);
+    unsafe fn finalize(_: &Entry, _: &Guard);
 }
 
 /// A lock-free, intrusive linked list of type `T`.
@@ -300,7 +300,7 @@ mod tests {
     use super::*;
     use crossbeam_utils::thread;
     use std::sync::Barrier;
-    use {Collector, Owned};
+    use crate::{Collector, Owned};
 
     impl IsElement<Entry> for Entry {
         fn entry_of(entry: &Entry) -> &Entry {

--- a/crossbeam-epoch/src/sync/queue.rs
+++ b/crossbeam-epoch/src/sync/queue.rs
@@ -13,7 +13,7 @@ use core::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 
 use crossbeam_utils::CachePadded;
 
-use {unprotected, Atomic, Guard, Owned, Shared};
+use crate::{unprotected, Atomic, Guard, Owned, Shared};
 
 // The representation here is a singly-linked list, with a sentinel node at the front. In general
 // the `tail` pointer may lag behind the actual tail. Non-sentinel nodes are either all `Data` or
@@ -206,7 +206,7 @@ impl<T> Drop for Queue<T> {
 mod test {
     use super::*;
     use crossbeam_utils::thread;
-    use pin;
+    use crate::pin;
 
     struct Queue<T> {
         queue: super::Queue<T>,

--- a/crossbeam-epoch/src/sync/queue.rs
+++ b/crossbeam-epoch/src/sync/queue.rs
@@ -63,7 +63,7 @@ impl<T> Queue<T> {
     /// Attempts to atomically place `n` into the `next` pointer of `onto`, and returns `true` on
     /// success. The queue's `tail` pointer may be updated.
     #[inline(always)]
-    fn push_internal(&self, onto: Shared<Node<T>>, new: Shared<Node<T>>, guard: &Guard) -> bool {
+    fn push_internal(&self, onto: Shared<'_, Node<T>>, new: Shared<'_, Node<T>>, guard: &Guard) -> bool {
         // is `onto` the actual tail?
         let o = unsafe { onto.deref() };
         let next = o.next.load(Acquire, guard);

--- a/crossbeam-queue/Cargo.toml
+++ b/crossbeam-queue/Cargo.toml
@@ -34,7 +34,7 @@ alloc = []
 nightly = []
 
 [dependencies]
-cfg-if = "0.1.2"
+cfg-if = "0.1.10"
 
 [dependencies.crossbeam-utils]
 version = "0.7"

--- a/crossbeam-queue/Cargo.toml
+++ b/crossbeam-queue/Cargo.toml
@@ -6,6 +6,7 @@ name = "crossbeam-queue"
 # - Create "crossbeam-queue-X.Y.Z" git tag
 version = "0.2.2"
 authors = ["The Crossbeam Project Developers"]
+edition = "2018"
 license = "MIT/Apache-2.0 AND BSD-2-Clause"
 readme = "README.md"
 repository = "https://github.com/crossbeam-rs/crossbeam"

--- a/crossbeam-queue/README.md
+++ b/crossbeam-queue/README.md
@@ -29,12 +29,6 @@ Add this to your `Cargo.toml`:
 crossbeam-queue = "0.2"
 ```
 
-Next, add this to your crate:
-
-```rust
-extern crate crossbeam_queue;
-```
-
 ## Compatibility
 
 Crossbeam Queue supports stable Rust releases going back at least six months,

--- a/crossbeam-queue/src/array_queue.rs
+++ b/crossbeam-queue/src/array_queue.rs
@@ -431,7 +431,7 @@ impl<T> Drop for ArrayQueue<T> {
 }
 
 impl<T> fmt::Debug for ArrayQueue<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("ArrayQueue { .. }")
     }
 }

--- a/crossbeam-queue/src/array_queue.rs
+++ b/crossbeam-queue/src/array_queue.rs
@@ -17,7 +17,7 @@ use core::sync::atomic::{self, AtomicUsize, Ordering};
 
 use crossbeam_utils::{Backoff, CachePadded};
 
-use err::{PopError, PushError};
+use crate::err::{PopError, PushError};
 
 /// A slot in a queue.
 struct Slot<T> {

--- a/crossbeam-queue/src/err.rs
+++ b/crossbeam-queue/src/err.rs
@@ -5,13 +5,13 @@ use core::fmt;
 pub struct PopError;
 
 impl fmt::Debug for PopError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         "PopError".fmt(f)
     }
 }
 
 impl fmt::Display for PopError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         "popping from an empty queue".fmt(f)
     }
 }
@@ -24,13 +24,13 @@ impl ::std::error::Error for PopError {}
 pub struct PushError<T>(pub T);
 
 impl<T> fmt::Debug for PushError<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         "PushError(..)".fmt(f)
     }
 }
 
 impl<T> fmt::Display for PushError<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         "pushing into a full queue".fmt(f)
     }
 }

--- a/crossbeam-queue/src/lib.rs
+++ b/crossbeam-queue/src/lib.rs
@@ -8,24 +8,15 @@
 //! [`ArrayQueue`]: struct.ArrayQueue.html
 //! [`SegQueue`]: struct.SegQueue.html
 
-#![warn(missing_docs)]
-#![warn(missing_debug_implementations)]
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]
 
 #[cfg_attr(feature = "nightly", cfg(target_has_atomic = "ptr"))]
-#[macro_use]
-extern crate cfg_if;
-#[cfg(feature = "alloc")]
-extern crate alloc;
-#[cfg(feature = "std")]
-extern crate core;
-
-extern crate crossbeam_utils;
-
-#[cfg_attr(feature = "nightly", cfg(target_has_atomic = "ptr"))]
-cfg_if! {
+cfg_if::cfg_if! {
     if #[cfg(feature = "alloc")] {
+        extern crate alloc;
+
         mod array_queue;
         mod err;
         mod seg_queue;

--- a/crossbeam-queue/src/seg_queue.rs
+++ b/crossbeam-queue/src/seg_queue.rs
@@ -476,7 +476,7 @@ impl<T> Drop for SegQueue<T> {
 }
 
 impl<T> fmt::Debug for SegQueue<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("SegQueue { .. }")
     }
 }

--- a/crossbeam-queue/src/seg_queue.rs
+++ b/crossbeam-queue/src/seg_queue.rs
@@ -8,7 +8,7 @@ use core::sync::atomic::{self, AtomicPtr, AtomicUsize, Ordering};
 
 use crossbeam_utils::{Backoff, CachePadded};
 
-use err::PopError;
+use crate::err::PopError;
 
 // Bits indicating the state of a slot:
 // * If a value has been written into the slot, `WRITE` is set.

--- a/crossbeam-queue/tests/array_queue.rs
+++ b/crossbeam-queue/tests/array_queue.rs
@@ -1,7 +1,3 @@
-extern crate crossbeam_queue;
-extern crate crossbeam_utils;
-extern crate rand;
-
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crossbeam_queue::ArrayQueue;

--- a/crossbeam-queue/tests/seg_queue.rs
+++ b/crossbeam-queue/tests/seg_queue.rs
@@ -1,7 +1,3 @@
-extern crate crossbeam_queue;
-extern crate crossbeam_utils;
-extern crate rand;
-
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crossbeam_queue::SegQueue;

--- a/crossbeam-skiplist/Cargo.toml
+++ b/crossbeam-skiplist/Cargo.toml
@@ -6,6 +6,7 @@ name = "crossbeam-skiplist"
 # - Create "crossbeam-skiplist-X.Y.Z" git tag
 version = "0.0.0"
 authors = ["The Crossbeam Project Developers"]
+edition = "2018"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/crossbeam-rs/crossbeam"

--- a/crossbeam-skiplist/Cargo.toml
+++ b/crossbeam-skiplist/Cargo.toml
@@ -34,7 +34,7 @@ alloc = ["crossbeam-epoch/alloc"]
 nightly = ["crossbeam-epoch/nightly", "crossbeam-utils/nightly"]
 
 [dependencies]
-cfg-if = "0.1.2"
+cfg-if = "0.1.10"
 
 [dependencies.crossbeam-epoch]
 version = "0.8"

--- a/crossbeam-skiplist/README.md
+++ b/crossbeam-skiplist/README.md
@@ -25,12 +25,6 @@ Add this to your `Cargo.toml`:
 [dependencies]
 crossbeam-skiplist = "0.1"
 ```
-
-Next, add this to your crate:
-
-```rust
-extern crate crossbeam_skiplist;
-```
 -->
 
 ## Compatibility

--- a/crossbeam-skiplist/benches/btree.rs
+++ b/crossbeam-skiplist/benches/btree.rs
@@ -1,6 +1,5 @@
 #![feature(test)]
 
-extern crate crossbeam_skiplist;
 extern crate test;
 
 use test::{black_box, Bencher};

--- a/crossbeam-skiplist/benches/hash.rs
+++ b/crossbeam-skiplist/benches/hash.rs
@@ -1,6 +1,5 @@
 #![feature(test)]
 
-extern crate crossbeam_skiplist;
 extern crate test;
 
 use test::{black_box, Bencher};

--- a/crossbeam-skiplist/benches/skiplist.rs
+++ b/crossbeam-skiplist/benches/skiplist.rs
@@ -1,11 +1,10 @@
 #![feature(test)]
 
-extern crate crossbeam_epoch as epoch;
-extern crate crossbeam_skiplist;
 extern crate test;
 
 use test::{black_box, Bencher};
 
+use crossbeam_epoch as epoch;
 use crossbeam_skiplist::SkipList;
 
 #[bench]

--- a/crossbeam-skiplist/benches/skipmap.rs
+++ b/crossbeam-skiplist/benches/skipmap.rs
@@ -1,6 +1,5 @@
 #![feature(test)]
 
-extern crate crossbeam_skiplist;
 extern crate test;
 
 use test::{black_box, Bencher};

--- a/crossbeam-skiplist/examples/simple.rs
+++ b/crossbeam-skiplist/examples/simple.rs
@@ -1,5 +1,3 @@
-// extern crate crossbeam_skiplist;
-
 // use std::time::Instant;
 
 fn main() {

--- a/crossbeam-skiplist/src/base.rs
+++ b/crossbeam-skiplist/src/base.rs
@@ -10,9 +10,8 @@ use core::ops::{Bound, Deref, Index, RangeBounds};
 use core::ptr;
 use core::sync::atomic::{fence, AtomicUsize, Ordering};
 
-use epoch::{self, Atomic, Collector, Guard, Shared};
-use scopeguard;
-use utils::CachePadded;
+use crate::epoch::{self, Atomic, Collector, Guard, Shared};
+use crate::utils::CachePadded;
 
 /// Number of bits needed to store height.
 const HEIGHT_BITS: usize = 5;

--- a/crossbeam-skiplist/src/lib.rs
+++ b/crossbeam-skiplist/src/lib.rs
@@ -1,23 +1,18 @@
 //! TODO
 
-#![warn(missing_docs)]
-#![warn(missing_debug_implementations)]
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]
 
-#[macro_use]
-extern crate cfg_if;
-#[cfg(feature = "alloc")]
-extern crate alloc;
-#[cfg(feature = "std")]
-extern crate core;
+use cfg_if::cfg_if;
 
 #[cfg_attr(feature = "nightly", cfg(target_has_atomic = "ptr"))]
 cfg_if! {
     if #[cfg(feature = "alloc")] {
-        extern crate crossbeam_epoch as epoch;
-        extern crate crossbeam_utils as utils;
-        extern crate scopeguard;
+        extern crate alloc;
+
+        use crossbeam_epoch as epoch;
+        use crossbeam_utils as utils;
 
         pub mod base;
         #[doc(inline)]

--- a/crossbeam-skiplist/src/lib.rs
+++ b/crossbeam-skiplist/src/lib.rs
@@ -21,7 +21,7 @@ cfg_if! {
 
         pub mod base;
         #[doc(inline)]
-        pub use base::SkipList;
+        pub use crate::base::SkipList;
     }
 }
 
@@ -29,10 +29,10 @@ cfg_if! {
     if #[cfg(feature = "std")] {
         pub mod map;
         #[doc(inline)]
-        pub use map::SkipMap;
+        pub use crate::map::SkipMap;
 
         pub mod set;
         #[doc(inline)]
-        pub use set::SkipSet;
+        pub use crate::set::SkipSet;
     }
 }

--- a/crossbeam-skiplist/src/map.rs
+++ b/crossbeam-skiplist/src/map.rs
@@ -42,13 +42,13 @@ where
     K: Ord,
 {
     /// Returns the entry with the smallest key.
-    pub fn front(&self) -> Option<Entry<K, V>> {
+    pub fn front(&self) -> Option<Entry<'_, K, V>> {
         let guard = &epoch::pin();
         try_pin_loop(|| self.inner.front(guard)).map(Entry::new)
     }
 
     /// Returns the entry with the largest key.
-    pub fn back(&self) -> Option<Entry<K, V>> {
+    pub fn back(&self) -> Option<Entry<'_, K, V>> {
         let guard = &epoch::pin();
         try_pin_loop(|| self.inner.back(guard)).map(Entry::new)
     }
@@ -64,7 +64,7 @@ where
     }
 
     /// Returns an entry with the specified `key`.
-    pub fn get<Q>(&self, key: &Q) -> Option<Entry<K, V>>
+    pub fn get<Q>(&self, key: &Q) -> Option<Entry<'_, K, V>>
     where
         K: Borrow<Q>,
         Q: Ord + ?Sized,
@@ -98,13 +98,13 @@ where
     }
 
     /// Finds an entry with the specified key, or inserts a new `key`-`value` pair if none exist.
-    pub fn get_or_insert(&self, key: K, value: V) -> Entry<K, V> {
+    pub fn get_or_insert(&self, key: K, value: V) -> Entry<'_, K, V> {
         let guard = &epoch::pin();
         Entry::new(self.inner.get_or_insert(key, value, guard))
     }
 
     /// Returns an iterator over all entries in the map.
-    pub fn iter(&self) -> Iter<K, V> {
+    pub fn iter(&self) -> Iter<'_, K, V> {
         Iter {
             inner: self.inner.ref_iter(),
         }
@@ -132,13 +132,13 @@ where
     ///
     /// If there is an existing entry with this key, it will be removed before inserting the new
     /// one.
-    pub fn insert(&self, key: K, value: V) -> Entry<K, V> {
+    pub fn insert(&self, key: K, value: V) -> Entry<'_, K, V> {
         let guard = &epoch::pin();
         Entry::new(self.inner.insert(key, value, guard))
     }
 
     /// Removes an entry with the specified `key` from the map and returns it.
-    pub fn remove<Q>(&self, key: &Q) -> Option<Entry<K, V>>
+    pub fn remove<Q>(&self, key: &Q) -> Option<Entry<'_, K, V>>
     where
         K: Borrow<Q>,
         Q: Ord + ?Sized,
@@ -148,13 +148,13 @@ where
     }
 
     /// Removes an entry from the front of the map.
-    pub fn pop_front(&self) -> Option<Entry<K, V>> {
+    pub fn pop_front(&self) -> Option<Entry<'_, K, V>> {
         let guard = &epoch::pin();
         self.inner.pop_front(guard).map(Entry::new)
     }
 
     /// Removes an entry from the back of the map.
-    pub fn pop_back(&self) -> Option<Entry<K, V>> {
+    pub fn pop_back(&self) -> Option<Entry<'_, K, V>> {
         let guard = &epoch::pin();
         self.inner.pop_back(guard).map(Entry::new)
     }
@@ -177,7 +177,7 @@ where
     K: Ord + fmt::Debug,
     V: fmt::Debug,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("SkipMap { .. }")
     }
 }
@@ -222,7 +222,7 @@ where
 }
 
 /// A reference-counted entry in a map.
-pub struct Entry<'a, K: 'a, V: 'a> {
+pub struct Entry<'a, K, V> {
     inner: ManuallyDrop<base::RefEntry<'a, K, V>>,
 }
 
@@ -249,7 +249,7 @@ impl<'a, K, V> Entry<'a, K, V> {
     }
 }
 
-impl<'a, K, V> Drop for Entry<'a, K, V> {
+impl<K, V> Drop for Entry<'_, K, V> {
     fn drop(&mut self) {
         unsafe {
             ManuallyDrop::into_inner(ptr::read(&mut self.inner)).release_with_pin(epoch::pin);
@@ -286,7 +286,7 @@ where
     }
 }
 
-impl<'a, K, V> Entry<'a, K, V>
+impl<K, V> Entry<'_, K, V>
 where
     K: Ord + Send + 'static,
     V: Send + 'static,
@@ -308,12 +308,12 @@ impl<'a, K, V> Clone for Entry<'a, K, V> {
     }
 }
 
-impl<'a, K, V> fmt::Debug for Entry<'a, K, V>
+impl<K, V> fmt::Debug for Entry<'_, K, V>
 where
     K: fmt::Debug,
     V: fmt::Debug,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("Entry")
             .field(self.key())
             .field(self.value())
@@ -335,13 +335,13 @@ impl<K, V> Iterator for IntoIter<K, V> {
 }
 
 impl<K, V> fmt::Debug for IntoIter<K, V> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("IntoIter { .. }")
     }
 }
 
 /// An iterator over the entries of a `SkipMap`.
-pub struct Iter<'a, K: 'a, V: 'a> {
+pub struct Iter<'a, K, V> {
     inner: base::RefIter<'a, K, V>,
 }
 
@@ -367,14 +367,14 @@ where
     }
 }
 
-impl<'a, K, V> fmt::Debug for Iter<'a, K, V> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl<K, V> fmt::Debug for Iter<'_, K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("Iter { .. }")
     }
 }
 
 /// An iterator over the entries of a `SkipMap`.
-pub struct Range<'a, Q, R, K: 'a, V: 'a>
+pub struct Range<'a, Q, R, K, V>
 where
     K: Ord + Borrow<Q>,
     R: RangeBounds<Q>,
@@ -409,14 +409,14 @@ where
     }
 }
 
-impl<'a, Q, R, K, V> fmt::Debug for Range<'a, Q, R, K, V>
+impl<Q, R, K, V> fmt::Debug for Range<'_, Q, R, K, V>
 where
     K: Ord + Borrow<Q> + fmt::Debug,
     V: fmt::Debug,
     R: RangeBounds<Q> + fmt::Debug,
     Q: Ord + ?Sized,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Range")
             .field("range", &self.inner.range)
             .field("head", &self.inner.head)

--- a/crossbeam-skiplist/src/map.rs
+++ b/crossbeam-skiplist/src/map.rs
@@ -7,8 +7,8 @@ use std::mem::ManuallyDrop;
 use std::ops::{Bound, RangeBounds};
 use std::ptr;
 
-use base::{self, try_pin_loop};
-use epoch;
+use crate::base::{self, try_pin_loop};
+use crate::epoch;
 
 /// A map based on a lock-free skip list.
 pub struct SkipMap<K, V> {

--- a/crossbeam-skiplist/src/set.rs
+++ b/crossbeam-skiplist/src/set.rs
@@ -39,12 +39,12 @@ where
     T: Ord,
 {
     /// Returns the entry with the smallest key.
-    pub fn front(&self) -> Option<Entry<T>> {
+    pub fn front(&self) -> Option<Entry<'_, T>> {
         self.inner.front().map(Entry::new)
     }
 
     /// Returns the entry with the largest key.
-    pub fn back(&self) -> Option<Entry<T>> {
+    pub fn back(&self) -> Option<Entry<'_, T>> {
         self.inner.back().map(Entry::new)
     }
 
@@ -58,7 +58,7 @@ where
     }
 
     /// Returns an entry with the specified `key`.
-    pub fn get<Q>(&self, key: &Q) -> Option<Entry<T>>
+    pub fn get<Q>(&self, key: &Q) -> Option<Entry<'_, T>>
     where
         T: Borrow<Q>,
         Q: Ord + ?Sized,
@@ -89,12 +89,12 @@ where
     }
 
     /// Finds an entry with the specified key, or inserts a new `key`-`value` pair if none exist.
-    pub fn get_or_insert(&self, key: T) -> Entry<T> {
+    pub fn get_or_insert(&self, key: T) -> Entry<'_, T> {
         Entry::new(self.inner.get_or_insert(key, ()))
     }
 
     /// Returns an iterator over all entries in the map.
-    pub fn iter(&self) -> Iter<T> {
+    pub fn iter(&self) -> Iter<'_, T> {
         Iter {
             inner: self.inner.iter(),
         }
@@ -121,12 +121,12 @@ where
     ///
     /// If there is an existing entry with this key, it will be removed before inserting the new
     /// one.
-    pub fn insert(&self, key: T) -> Entry<T> {
+    pub fn insert(&self, key: T) -> Entry<'_, T> {
         Entry::new(self.inner.insert(key, ()))
     }
 
     /// Removes an entry with the specified key from the set and returns it.
-    pub fn remove<Q>(&self, key: &Q) -> Option<Entry<T>>
+    pub fn remove<Q>(&self, key: &Q) -> Option<Entry<'_, T>>
     where
         T: Borrow<Q>,
         Q: Ord + ?Sized,
@@ -135,12 +135,12 @@ where
     }
 
     /// Removes an entry from the front of the map.
-    pub fn pop_front(&self) -> Option<Entry<T>> {
+    pub fn pop_front(&self) -> Option<Entry<'_, T>> {
         self.inner.pop_front().map(Entry::new)
     }
 
     /// Removes an entry from the back of the map.
-    pub fn pop_back(&self) -> Option<Entry<T>> {
+    pub fn pop_back(&self) -> Option<Entry<'_, T>> {
         self.inner.pop_back().map(Entry::new)
     }
 
@@ -160,7 +160,7 @@ impl<T> fmt::Debug for SkipSet<T>
 where
     T: Ord + fmt::Debug,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("SkipSet { .. }")
     }
 }
@@ -205,7 +205,7 @@ where
 }
 
 /// TODO
-pub struct Entry<'a, T: 'a> {
+pub struct Entry<'a, T> {
     inner: map::Entry<'a, T, ()>,
 }
 
@@ -250,7 +250,7 @@ where
     }
 }
 
-impl<'a, T> Entry<'a, T>
+impl<T> Entry<'_, T>
 where
     T: Ord + Send + 'static,
 {
@@ -270,11 +270,11 @@ impl<'a, T> Clone for Entry<'a, T> {
     }
 }
 
-impl<'a, T> fmt::Debug for Entry<'a, T>
+impl<T> fmt::Debug for Entry<'_, T>
 where
     T: fmt::Debug,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Entry")
             .field("value", self.value())
             .finish()
@@ -295,13 +295,13 @@ impl<T> Iterator for IntoIter<T> {
 }
 
 impl<T> fmt::Debug for IntoIter<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("IntoIter { .. }")
     }
 }
 
 /// An iterator over the entries of a `SkipSet`.
-pub struct Iter<'a, T: 'a> {
+pub struct Iter<'a, T> {
     inner: map::Iter<'a, T, ()>,
 }
 
@@ -325,14 +325,14 @@ where
     }
 }
 
-impl<'a, T> fmt::Debug for Iter<'a, T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl<T> fmt::Debug for Iter<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("Iter { .. }")
     }
 }
 
 /// An iterator over the entries of a `SkipMap`.
-pub struct Range<'a, Q, R, T: 'a>
+pub struct Range<'a, Q, R, T>
 where
     T: Ord + Borrow<Q>,
     R: RangeBounds<Q>,
@@ -365,13 +365,13 @@ where
     }
 }
 
-impl<'a, Q, R, T> fmt::Debug for Range<'a, Q, R, T>
+impl<Q, R, T> fmt::Debug for Range<'_, Q, R, T>
 where
     T: Ord + Borrow<Q> + fmt::Debug,
     R: RangeBounds<Q> + fmt::Debug,
     Q: Ord + ?Sized,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Range")
             .field("range", &self.inner.inner.range)
             .field("head", &self.inner.inner.head.as_ref().map(|e| e.key()))

--- a/crossbeam-skiplist/src/set.rs
+++ b/crossbeam-skiplist/src/set.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use std::iter::FromIterator;
 use std::ops::{Bound, RangeBounds};
 
-use map;
+use crate::map;
 
 /// A set based on a lock-free skip list.
 pub struct SkipSet<T> {

--- a/crossbeam-skiplist/tests/base.rs
+++ b/crossbeam-skiplist/tests/base.rs
@@ -1,10 +1,8 @@
-extern crate crossbeam_epoch as epoch;
-extern crate crossbeam_skiplist as skiplist;
-
 use std::ops::Bound;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use crate::skiplist::SkipList;
+use crossbeam_epoch as epoch;
+use crossbeam_skiplist::SkipList;
 
 #[test]
 fn new() {

--- a/crossbeam-skiplist/tests/base.rs
+++ b/crossbeam-skiplist/tests/base.rs
@@ -4,7 +4,7 @@ extern crate crossbeam_skiplist as skiplist;
 use std::ops::Bound;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use skiplist::SkipList;
+use crate::skiplist::SkipList;
 
 #[test]
 fn new() {
@@ -509,7 +509,7 @@ fn iter() {
 
 #[test]
 fn iter_range() {
-    use Bound::*;
+    use crate::Bound::*;
     let guard = &epoch::pin();
     let s = SkipList::new(epoch::default_collector().clone());
     let v = (0..10).map(|x| x * 10).collect::<Vec<_>>();

--- a/crossbeam-skiplist/tests/map.rs
+++ b/crossbeam-skiplist/tests/map.rs
@@ -1,6 +1,4 @@
-extern crate crossbeam_skiplist as skiplist;
-
-use crate::skiplist::SkipMap;
+use crossbeam_skiplist::SkipMap;
 
 #[test]
 fn smoke() {

--- a/crossbeam-skiplist/tests/map.rs
+++ b/crossbeam-skiplist/tests/map.rs
@@ -1,6 +1,6 @@
 extern crate crossbeam_skiplist as skiplist;
 
-use skiplist::SkipMap;
+use crate::skiplist::SkipMap;
 
 #[test]
 fn smoke() {

--- a/crossbeam-skiplist/tests/set.rs
+++ b/crossbeam-skiplist/tests/set.rs
@@ -1,6 +1,4 @@
-extern crate crossbeam_skiplist as skiplist;
-
-use crate::skiplist::SkipSet;
+use crossbeam_skiplist::SkipSet;
 
 #[test]
 fn smoke() {

--- a/crossbeam-skiplist/tests/set.rs
+++ b/crossbeam-skiplist/tests/set.rs
@@ -1,6 +1,6 @@
 extern crate crossbeam_skiplist as skiplist;
 
-use skiplist::SkipSet;
+use crate::skiplist::SkipSet;
 
 #[test]
 fn smoke() {

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -30,7 +30,7 @@ std = ["lazy_static"]
 nightly = []
 
 [dependencies]
-cfg-if = "0.1.2"
+cfg-if = "0.1.10"
 lazy_static = { version = "1.1.0", optional = true }
 
 [build-dependencies]

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -6,6 +6,7 @@ name = "crossbeam-utils"
 # - Create "crossbeam-utils-X.Y.Z" git tag
 version = "0.7.2"
 authors = ["The Crossbeam Project Developers"]
+edition = "2018"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/crossbeam-rs/crossbeam"

--- a/crossbeam-utils/README.md
+++ b/crossbeam-utils/README.md
@@ -51,12 +51,6 @@ Add this to your `Cargo.toml`:
 crossbeam-utils = "0.7"
 ```
 
-Next, add this to your crate:
-
-```rust
-extern crate crossbeam_utils;
-```
-
 ## Compatibility
 
 Crossbeam Utils supports stable Rust releases going back at least six months,

--- a/crossbeam-utils/benches/atomic_cell.rs
+++ b/crossbeam-utils/benches/atomic_cell.rs
@@ -1,6 +1,5 @@
 #![feature(test)]
 
-extern crate crossbeam_utils;
 extern crate test;
 
 use std::sync::Barrier;

--- a/crossbeam-utils/build.rs
+++ b/crossbeam-utils/build.rs
@@ -1,5 +1,3 @@
-extern crate autocfg;
-
 fn main() {
     let cfg = autocfg::new();
     cfg.emit_type_cfg("core::sync::atomic::AtomicU8", "has_atomic_u8");

--- a/crossbeam-utils/src/atomic/atomic_cell.rs
+++ b/crossbeam-utils/src/atomic/atomic_cell.rs
@@ -590,7 +590,7 @@ impl<T: Default> Default for AtomicCell<T> {
 }
 
 impl<T: Copy + fmt::Debug> fmt::Debug for AtomicCell<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("AtomicCell")
             .field("value", &self.load())
             .finish()

--- a/crossbeam-utils/src/atomic/mod.rs
+++ b/crossbeam-utils/src/atomic/mod.rs
@@ -1,5 +1,7 @@
 //! Atomic types.
 
+use cfg_if::cfg_if;
+
 cfg_if! {
     // Use "wide" sequence lock if the pointer width <= 32 for preventing its counter against wrap
     // around.

--- a/crossbeam-utils/src/atomic/seq_lock.rs
+++ b/crossbeam-utils/src/atomic/seq_lock.rs
@@ -1,7 +1,7 @@
 use core::mem;
 use core::sync::atomic::{self, AtomicUsize, Ordering};
 
-use Backoff;
+use crate::Backoff;
 
 /// A simple stamped lock.
 pub struct SeqLock {

--- a/crossbeam-utils/src/atomic/seq_lock_wide.rs
+++ b/crossbeam-utils/src/atomic/seq_lock_wide.rs
@@ -1,6 +1,6 @@
 use core::sync::atomic::{self, AtomicUsize, Ordering};
 
-use Backoff;
+use crate::Backoff;
 
 /// A simple stamped lock.
 ///

--- a/crossbeam-utils/src/backoff.rs
+++ b/crossbeam-utils/src/backoff.rs
@@ -270,7 +270,7 @@ impl Backoff {
 }
 
 impl fmt::Debug for Backoff {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Backoff")
             .field("step", &self.step)
             .field("is_completed", &self.is_completed())

--- a/crossbeam-utils/src/cache_padded.rs
+++ b/crossbeam-utils/src/cache_padded.rs
@@ -125,7 +125,7 @@ impl<T> DerefMut for CachePadded<T> {
 }
 
 impl<T: fmt::Debug> fmt::Debug for CachePadded<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CachePadded")
             .field("value", &self.value)
             .finish()

--- a/crossbeam-utils/src/lib.rs
+++ b/crossbeam-utils/src/lib.rs
@@ -26,15 +26,9 @@
 //! [`CachePadded`]: struct.CachePadded.html
 //! [`scope`]: thread/fn.scope.html
 
-#![warn(missing_docs)]
-#![warn(missing_debug_implementations)]
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]
-
-#[macro_use]
-extern crate cfg_if;
-#[cfg(feature = "std")]
-extern crate core;
 
 #[cfg_attr(feature = "nightly", cfg(target_has_atomic = "ptr"))]
 pub mod atomic;
@@ -45,11 +39,10 @@ pub use crate::cache_padded::CachePadded;
 mod backoff;
 pub use crate::backoff::Backoff;
 
+use cfg_if::cfg_if;
+
 cfg_if! {
     if #[cfg(feature = "std")] {
-        #[macro_use]
-        extern crate lazy_static;
-
         pub mod sync;
         pub mod thread;
     }

--- a/crossbeam-utils/src/lib.rs
+++ b/crossbeam-utils/src/lib.rs
@@ -40,10 +40,10 @@ extern crate core;
 pub mod atomic;
 
 mod cache_padded;
-pub use cache_padded::CachePadded;
+pub use crate::cache_padded::CachePadded;
 
 mod backoff;
-pub use backoff::Backoff;
+pub use crate::backoff::Backoff;
 
 cfg_if! {
     if #[cfg(feature = "std")] {

--- a/crossbeam-utils/src/sync/parker.rs
+++ b/crossbeam-utils/src/sync/parker.rs
@@ -191,7 +191,7 @@ impl Parker {
 }
 
 impl fmt::Debug for Parker {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("Parker { .. }")
     }
 }
@@ -280,7 +280,7 @@ impl Unparker {
 }
 
 impl fmt::Debug for Unparker {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("Unparker { .. }")
     }
 }

--- a/crossbeam-utils/src/sync/sharded_lock.rs
+++ b/crossbeam-utils/src/sync/sharded_lock.rs
@@ -10,6 +10,7 @@ use std::sync::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::thread::{self, ThreadId};
 
 use crate::CachePadded;
+use lazy_static::lazy_static;
 
 /// The number of shards per sharded lock. Must be a power of two.
 const NUM_SHARDS: usize = 8;
@@ -215,7 +216,7 @@ impl<T: ?Sized> ShardedLock<T> {
     ///     Err(_) => unreachable!(),
     /// };
     /// ```
-    pub fn try_read(&self) -> TryLockResult<ShardedLockReadGuard<T>> {
+    pub fn try_read(&self) -> TryLockResult<ShardedLockReadGuard<'_, T>> {
         // Take the current thread index and map it to a shard index. Thread indices will tend to
         // distribute shards among threads equally, thus reducing contention due to read-locking.
         let current_index = current_index().unwrap_or(0);
@@ -266,7 +267,7 @@ impl<T: ?Sized> ShardedLock<T> {
     ///     assert!(r.is_ok());
     /// }).join().unwrap();
     /// ```
-    pub fn read(&self) -> LockResult<ShardedLockReadGuard<T>> {
+    pub fn read(&self) -> LockResult<ShardedLockReadGuard<'_, T>> {
         // Take the current thread index and map it to a shard index. Thread indices will tend to
         // distribute shards among threads equally, thus reducing contention due to read-locking.
         let current_index = current_index().unwrap_or(0);
@@ -308,7 +309,7 @@ impl<T: ?Sized> ShardedLock<T> {
     ///
     /// assert!(lock.try_write().is_err());
     /// ```
-    pub fn try_write(&self) -> TryLockResult<ShardedLockWriteGuard<T>> {
+    pub fn try_write(&self) -> TryLockResult<ShardedLockWriteGuard<'_, T>> {
         let mut poisoned = false;
         let mut blocked = None;
 
@@ -379,7 +380,7 @@ impl<T: ?Sized> ShardedLock<T> {
     ///
     /// assert!(lock.try_read().is_err());
     /// ```
-    pub fn write(&self) -> LockResult<ShardedLockWriteGuard<T>> {
+    pub fn write(&self) -> LockResult<ShardedLockWriteGuard<'_, T>> {
         let mut poisoned = false;
 
         // Write-lock each shard in succession.
@@ -416,7 +417,7 @@ impl<T: ?Sized> ShardedLock<T> {
 }
 
 impl<T: ?Sized + fmt::Debug> fmt::Debug for ShardedLock<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.try_read() {
             Ok(guard) => f
                 .debug_struct("ShardedLock")
@@ -429,7 +430,7 @@ impl<T: ?Sized + fmt::Debug> fmt::Debug for ShardedLock<T> {
             Err(TryLockError::WouldBlock) => {
                 struct LockedPlaceholder;
                 impl fmt::Debug for LockedPlaceholder {
-                    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                         f.write_str("<locked>")
                     }
                 }
@@ -456,15 +457,15 @@ impl<T> From<T> for ShardedLock<T> {
 /// A guard used to release the shared read access of a [`ShardedLock`] when dropped.
 ///
 /// [`ShardedLock`]: struct.ShardedLock.html
-pub struct ShardedLockReadGuard<'a, T: ?Sized + 'a> {
+pub struct ShardedLockReadGuard<'a, T: ?Sized> {
     lock: &'a ShardedLock<T>,
     _guard: RwLockReadGuard<'a, ()>,
     _marker: PhantomData<RwLockReadGuard<'a, T>>,
 }
 
-unsafe impl<'a, T: ?Sized + Sync> Sync for ShardedLockReadGuard<'a, T> {}
+unsafe impl<T: ?Sized + Sync> Sync for ShardedLockReadGuard<'_, T> {}
 
-impl<'a, T: ?Sized> Deref for ShardedLockReadGuard<'a, T> {
+impl<T: ?Sized> Deref for ShardedLockReadGuard<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -472,16 +473,16 @@ impl<'a, T: ?Sized> Deref for ShardedLockReadGuard<'a, T> {
     }
 }
 
-impl<'a, T: fmt::Debug> fmt::Debug for ShardedLockReadGuard<'a, T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl<T: fmt::Debug> fmt::Debug for ShardedLockReadGuard<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ShardedLockReadGuard")
             .field("lock", &self.lock)
             .finish()
     }
 }
 
-impl<'a, T: ?Sized + fmt::Display> fmt::Display for ShardedLockReadGuard<'a, T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl<T: ?Sized + fmt::Display> fmt::Display for ShardedLockReadGuard<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         (**self).fmt(f)
     }
 }
@@ -489,14 +490,14 @@ impl<'a, T: ?Sized + fmt::Display> fmt::Display for ShardedLockReadGuard<'a, T> 
 /// A guard used to release the exclusive write access of a [`ShardedLock`] when dropped.
 ///
 /// [`ShardedLock`]: struct.ShardedLock.html
-pub struct ShardedLockWriteGuard<'a, T: ?Sized + 'a> {
+pub struct ShardedLockWriteGuard<'a, T: ?Sized> {
     lock: &'a ShardedLock<T>,
     _marker: PhantomData<RwLockWriteGuard<'a, T>>,
 }
 
-unsafe impl<'a, T: ?Sized + Sync> Sync for ShardedLockWriteGuard<'a, T> {}
+unsafe impl<T: ?Sized + Sync> Sync for ShardedLockWriteGuard<'_, T> {}
 
-impl<'a, T: ?Sized> Drop for ShardedLockWriteGuard<'a, T> {
+impl<T: ?Sized> Drop for ShardedLockWriteGuard<'_, T> {
     fn drop(&mut self) {
         // Unlock the shards in reverse order of locking.
         for shard in self.lock.shards.iter().rev() {
@@ -509,21 +510,21 @@ impl<'a, T: ?Sized> Drop for ShardedLockWriteGuard<'a, T> {
     }
 }
 
-impl<'a, T: fmt::Debug> fmt::Debug for ShardedLockWriteGuard<'a, T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl<T: fmt::Debug> fmt::Debug for ShardedLockWriteGuard<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ShardedLockWriteGuard")
             .field("lock", &self.lock)
             .finish()
     }
 }
 
-impl<'a, T: ?Sized + fmt::Display> fmt::Display for ShardedLockWriteGuard<'a, T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl<T: ?Sized + fmt::Display> fmt::Display for ShardedLockWriteGuard<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         (**self).fmt(f)
     }
 }
 
-impl<'a, T: ?Sized> Deref for ShardedLockWriteGuard<'a, T> {
+impl<T: ?Sized> Deref for ShardedLockWriteGuard<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -531,7 +532,7 @@ impl<'a, T: ?Sized> Deref for ShardedLockWriteGuard<'a, T> {
     }
 }
 
-impl<'a, T: ?Sized> DerefMut for ShardedLockWriteGuard<'a, T> {
+impl<T: ?Sized> DerefMut for ShardedLockWriteGuard<'_, T> {
     fn deref_mut(&mut self) -> &mut T {
         unsafe { &mut *self.lock.value.get() }
     }

--- a/crossbeam-utils/src/sync/sharded_lock.rs
+++ b/crossbeam-utils/src/sync/sharded_lock.rs
@@ -9,7 +9,7 @@ use std::sync::{LockResult, PoisonError, TryLockError, TryLockResult};
 use std::sync::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::thread::{self, ThreadId};
 
-use CachePadded;
+use crate::CachePadded;
 
 /// The number of shards per sharded lock. Must be a power of two.
 const NUM_SHARDS: usize = 8;

--- a/crossbeam-utils/src/sync/wait_group.rs
+++ b/crossbeam-utils/src/sync/wait_group.rs
@@ -130,7 +130,7 @@ impl Clone for WaitGroup {
 }
 
 impl fmt::Debug for WaitGroup {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let count: &usize = &*self.inner.count.lock().unwrap();
         f.debug_struct("WaitGroup").field("count", count).finish()
     }

--- a/crossbeam-utils/src/thread.rs
+++ b/crossbeam-utils/src/thread.rs
@@ -121,7 +121,7 @@ use std::panic;
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-use sync::WaitGroup;
+use crate::sync::WaitGroup;
 
 type SharedVec<T> = Arc<Mutex<Vec<T>>>;
 type SharedOption<T> = Arc<Mutex<Option<T>>>;

--- a/crossbeam-utils/src/thread.rs
+++ b/crossbeam-utils/src/thread.rs
@@ -122,6 +122,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 
 use crate::sync::WaitGroup;
+use cfg_if::cfg_if;
 
 type SharedVec<T> = Arc<Mutex<Vec<T>>>;
 type SharedOption<T> = Arc<Mutex<Option<T>>>;
@@ -205,7 +206,7 @@ pub struct Scope<'env> {
     _marker: PhantomData<&'env mut &'env ()>,
 }
 
-unsafe impl<'env> Sync for Scope<'env> {}
+unsafe impl Sync for Scope<'_> {}
 
 impl<'env> Scope<'env> {
     /// Spawns a scoped thread.
@@ -268,8 +269,8 @@ impl<'env> Scope<'env> {
     }
 }
 
-impl<'env> fmt::Debug for Scope<'env> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl fmt::Debug for Scope<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("Scope { .. }")
     }
 }
@@ -308,7 +309,7 @@ impl<'env> fmt::Debug for Scope<'env> {
 /// [naming-threads]: https://doc.rust-lang.org/std/thread/index.html#naming-threads
 /// [stack-size]: https://doc.rust-lang.org/std/thread/index.html#stack-size
 #[derive(Debug)]
-pub struct ScopedThreadBuilder<'scope, 'env: 'scope> {
+pub struct ScopedThreadBuilder<'scope, 'env> {
     scope: &'scope Scope<'env>,
     builder: thread::Builder,
 }
@@ -448,8 +449,8 @@ impl<'scope, 'env> ScopedThreadBuilder<'scope, 'env> {
     }
 }
 
-unsafe impl<'scope, T> Send for ScopedJoinHandle<'scope, T> {}
-unsafe impl<'scope, T> Sync for ScopedJoinHandle<'scope, T> {}
+unsafe impl<T> Send for ScopedJoinHandle<'_, T> {}
+unsafe impl<T> Sync for ScopedJoinHandle<'_, T> {}
 
 /// A handle that can be used to join its scoped thread.
 pub struct ScopedJoinHandle<'scope, T> {
@@ -466,7 +467,7 @@ pub struct ScopedJoinHandle<'scope, T> {
     _marker: PhantomData<&'scope ()>,
 }
 
-impl<'scope, T> ScopedJoinHandle<'scope, T> {
+impl<T> ScopedJoinHandle<'_, T> {
     /// Waits for the thread to finish and returns its result.
     ///
     /// If the child thread panics, an error is returned.
@@ -526,7 +527,7 @@ cfg_if! {
     if #[cfg(unix)] {
         use std::os::unix::thread::{JoinHandleExt, RawPthread};
 
-        impl<'scope, T> JoinHandleExt for ScopedJoinHandle<'scope, T> {
+        impl<T> JoinHandleExt for ScopedJoinHandle<'_, T> {
             fn as_pthread_t(&self) -> RawPthread {
                 // Borrow the handle. The handle will surely be available because the root scope waits
                 // for nested scopes before joining remaining threads.
@@ -540,7 +541,7 @@ cfg_if! {
     } else if #[cfg(windows)] {
         use std::os::windows::io::{AsRawHandle, IntoRawHandle, RawHandle};
 
-        impl<'scope, T> AsRawHandle for ScopedJoinHandle<'scope, T> {
+        impl<T> AsRawHandle for ScopedJoinHandle<'_, T> {
             fn as_raw_handle(&self) -> RawHandle {
                 // Borrow the handle. The handle will surely be available because the root scope waits
                 // for nested scopes before joining remaining threads.
@@ -550,7 +551,7 @@ cfg_if! {
         }
 
         #[cfg(windows)]
-        impl<'scope, T> IntoRawHandle for ScopedJoinHandle<'scope, T> {
+        impl<T> IntoRawHandle for ScopedJoinHandle<'_, T> {
             fn into_raw_handle(self) -> RawHandle {
                 self.as_raw_handle()
             }
@@ -558,8 +559,8 @@ cfg_if! {
     }
 }
 
-impl<'scope, T> fmt::Debug for ScopedJoinHandle<'scope, T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl<T> fmt::Debug for ScopedJoinHandle<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("ScopedJoinHandle { .. }")
     }
 }

--- a/crossbeam-utils/tests/atomic_cell.rs
+++ b/crossbeam-utils/tests/atomic_cell.rs
@@ -1,5 +1,3 @@
-extern crate crossbeam_utils;
-
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::SeqCst;
 

--- a/crossbeam-utils/tests/cache_padded.rs
+++ b/crossbeam-utils/tests/cache_padded.rs
@@ -1,5 +1,3 @@
-extern crate crossbeam_utils;
-
 use std::cell::Cell;
 use std::mem;
 

--- a/crossbeam-utils/tests/parker.rs
+++ b/crossbeam-utils/tests/parker.rs
@@ -1,5 +1,3 @@
-extern crate crossbeam_utils;
-
 use std::thread::sleep;
 use std::time::Duration;
 use std::u32;

--- a/crossbeam-utils/tests/sharded_lock.rs
+++ b/crossbeam-utils/tests/sharded_lock.rs
@@ -1,6 +1,3 @@
-extern crate crossbeam_utils;
-extern crate rand;
-
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc::channel;
 use std::sync::{Arc, TryLockError};

--- a/crossbeam-utils/tests/thread.rs
+++ b/crossbeam-utils/tests/thread.rs
@@ -1,5 +1,3 @@
-extern crate crossbeam_utils;
-
 use std::any::Any;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread::sleep;

--- a/crossbeam-utils/tests/wait_group.rs
+++ b/crossbeam-utils/tests/wait_group.rs
@@ -1,5 +1,3 @@
-extern crate crossbeam_utils;
-
 use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,19 +42,9 @@
 //! [`CachePadded`]: utils/struct.CachePadded.html
 //! [`scope`]: fn.scope.html
 
-#![warn(missing_docs)]
-#![warn(missing_debug_implementations)]
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]
-
-#[macro_use]
-extern crate cfg_if;
-#[cfg(feature = "alloc")]
-extern crate alloc;
-#[cfg(feature = "std")]
-extern crate core;
-
-extern crate crossbeam_utils;
 
 #[cfg_attr(feature = "nightly", cfg(target_has_atomic = "ptr"))]
 pub use crossbeam_utils::atomic;
@@ -65,16 +55,18 @@ pub mod utils {
     pub use crossbeam_utils::CachePadded;
 }
 
+use cfg_if::cfg_if;
+
 cfg_if! {
     if #[cfg(feature = "alloc")] {
         mod _epoch {
-            pub extern crate crossbeam_epoch;
+            pub use crossbeam_epoch;
         }
         #[doc(inline)]
-        pub use _epoch::crossbeam_epoch as epoch;
+        pub use crate::_epoch::crossbeam_epoch as epoch;
 
         mod _queue {
-            pub extern crate crossbeam_queue;
+            pub use crossbeam_queue;
         }
         #[doc(inline)]
         pub use crate::_queue::crossbeam_queue as queue;
@@ -84,21 +76,18 @@ cfg_if! {
 cfg_if! {
     if #[cfg(feature = "std")] {
         mod _deque {
-            pub extern crate crossbeam_deque;
+            pub use crossbeam_deque;
         }
         #[doc(inline)]
         pub use crate::_deque::crossbeam_deque as deque;
 
         mod _channel {
-            pub extern crate crossbeam_channel;
-            pub use self::crossbeam_channel::*;
+            pub use crossbeam_channel;
         }
         #[doc(inline)]
         pub use crate::_channel::crossbeam_channel as channel;
 
-        // HACK(stjepang): This is the only way to reexport `select!` in Rust older than 1.30.0
-        #[doc(hidden)]
-        pub use crate::_channel::*;
+        pub use crossbeam_channel::select;
 
         pub use crossbeam_utils::sync;
         pub use crossbeam_utils::thread;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ cfg_if! {
             pub extern crate crossbeam_queue;
         }
         #[doc(inline)]
-        pub use _queue::crossbeam_queue as queue;
+        pub use crate::_queue::crossbeam_queue as queue;
     }
 }
 
@@ -87,18 +87,18 @@ cfg_if! {
             pub extern crate crossbeam_deque;
         }
         #[doc(inline)]
-        pub use _deque::crossbeam_deque as deque;
+        pub use crate::_deque::crossbeam_deque as deque;
 
         mod _channel {
             pub extern crate crossbeam_channel;
             pub use self::crossbeam_channel::*;
         }
         #[doc(inline)]
-        pub use _channel::crossbeam_channel as channel;
+        pub use crate::_channel::crossbeam_channel as channel;
 
         // HACK(stjepang): This is the only way to reexport `select!` in Rust older than 1.30.0
         #[doc(hidden)]
-        pub use _channel::*;
+        pub use crate::_channel::*;
 
         pub use crossbeam_utils::sync;
         pub use crossbeam_utils::thread;

--- a/tests/subcrates.rs
+++ b/tests/subcrates.rs
@@ -1,7 +1,6 @@
 //! Makes sure subcrates are properly re-exported.
 
-#[macro_use]
-extern crate crossbeam;
+use crossbeam::select;
 
 #[test]
 fn channel() {


### PR DESCRIPTION
This migrates all crates to Rust 2018.

The first commit contains the minimal changes needed for the migration. This was mainly done by `cargo fix --editon`.
The second commit migrates the code to be the Rust 2018 idiomatic style. This mainly based on suggestions from `rust_2018_idioms` lint.