### PR TITLE
Deny warnings for doc tests

### DIFF
--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -136,7 +136,6 @@ pub fn bounded<T>(cap: usize) -> (Sender<T>, Receiver<T>) {
 /// Using an `after` channel for timeouts:
 ///
 /// ```
-/// # fn main() {
 /// use std::time::Duration;
 /// use crossbeam_channel::{after, select, unbounded};
 ///
@@ -147,7 +146,6 @@ pub fn bounded<T>(cap: usize) -> (Sender<T>, Receiver<T>) {
 ///     recv(r) -> msg => println!("received {:?}", msg),
 ///     recv(after(timeout)) -> _ => println!("timed out"),
 /// }
-/// # }
 /// ```
 ///
 /// When the message gets sent:
@@ -187,9 +185,8 @@ pub fn after(duration: Duration) -> Receiver<Instant> {
 /// Using a `never` channel to optionally add a timeout to [`select!`]:
 ///
 /// ```
-/// # fn main() {
 /// use std::thread;
-/// use std::time::{Duration, Instant};
+/// use std::time::Duration;
 /// use crossbeam_channel::{after, select, never, unbounded};
 ///
 /// let (s, r) = unbounded();
@@ -211,7 +208,6 @@ pub fn after(duration: Duration) -> Receiver<Instant> {
 ///     recv(r) -> msg => assert_eq!(msg, Ok(1)),
 ///     recv(timeout) -> _ => println!("timed out"),
 /// }
-/// # }
 /// ```
 ///
 /// [`select!`]: macro.select.html
@@ -597,9 +593,9 @@ impl<T> fmt::Debug for Sender<T> {
 /// let (s, r) = unbounded();
 ///
 /// thread::spawn(move || {
-///     s.send(1);
+///     let _ = s.send(1);
 ///     thread::sleep(Duration::from_secs(1));
-///     s.send(2);
+///     let _ = s.send(2);
 /// });
 ///
 /// assert_eq!(r.recv(), Ok(1)); // Received immediately.

--- a/crossbeam-channel/src/lib.rs
+++ b/crossbeam-channel/src/lib.rs
@@ -122,8 +122,6 @@
 //! It's also possible to share senders and receivers by reference:
 //!
 //! ```
-//! # fn main() {
-//! use std::thread;
 //! use crossbeam_channel::bounded;
 //! use crossbeam_utils::thread::scope;
 //!
@@ -140,7 +138,6 @@
 //!     s.send(1).unwrap();
 //!     r.recv().unwrap();
 //! }).unwrap();
-//! # }
 //! ```
 //!
 //! # Disconnection
@@ -269,7 +266,6 @@
 //! An example of receiving a message from two channels:
 //!
 //! ```
-//! # fn main() {
 //! use std::thread;
 //! use std::time::Duration;
 //! use crossbeam_channel::{select, unbounded};
@@ -286,7 +282,6 @@
 //!     recv(r2) -> msg => assert_eq!(msg, Ok(20)),
 //!     default(Duration::from_secs(1)) => println!("timed out"),
 //! }
-//! # }
 //! ```
 //!
 //! If you need to select over a dynamically created list of channel operations, use [`Select`]
@@ -306,7 +301,6 @@
 //! An example that prints elapsed time every 50 milliseconds for the duration of 1 second:
 //!
 //! ```
-//! # fn main() {
 //! use std::time::{Duration, Instant};
 //! use crossbeam_channel::{after, select, tick};
 //!
@@ -320,7 +314,6 @@
 //!         recv(timeout) -> _ => break,
 //!     }
 //! }
-//! # }
 //! ```
 //!
 //! [`std::sync::mpsc`]: https://doc.rust-lang.org/std/sync/mpsc/index.html
@@ -338,6 +331,13 @@
 //! [`Sender`]: struct.Sender.html
 //! [`Receiver`]: struct.Receiver.html
 
+#![doc(test(
+    no_crate_inject,
+    attr(
+        deny(warnings, rust_2018_idioms),
+        allow(dead_code, unused_assignments, unused_variables)
+    )
+))]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/crossbeam-channel/src/select.rs
+++ b/crossbeam-channel/src/select.rs
@@ -615,7 +615,6 @@ impl<'a> Select<'a> {
     /// # Examples
     ///
     /// ```
-    /// use std::thread;
     /// use crossbeam_channel::{unbounded, Select};
     ///
     /// let (s, r) = unbounded::<i32>();
@@ -638,7 +637,6 @@ impl<'a> Select<'a> {
     /// # Examples
     ///
     /// ```
-    /// use std::thread;
     /// use crossbeam_channel::{unbounded, Select};
     ///
     /// let (s, r) = unbounded::<i32>();
@@ -669,7 +667,6 @@ impl<'a> Select<'a> {
     /// # Examples
     ///
     /// ```
-    /// use std::thread;
     /// use crossbeam_channel::{unbounded, Select};
     ///
     /// let (s1, r1) = unbounded::<i32>();
@@ -728,7 +725,6 @@ impl<'a> Select<'a> {
     /// # Examples
     ///
     /// ```
-    /// use std::thread;
     /// use crossbeam_channel::{unbounded, Select};
     ///
     /// let (s1, r1) = unbounded();
@@ -874,7 +870,6 @@ impl<'a> Select<'a> {
     /// # Examples
     ///
     /// ```
-    /// use std::thread;
     /// use crossbeam_channel::{unbounded, Select};
     ///
     /// let (s1, r1) = unbounded();

--- a/crossbeam-channel/src/select_macro.rs
+++ b/crossbeam-channel/src/select_macro.rs
@@ -1076,8 +1076,6 @@ macro_rules! crossbeam_channel_internal {
 /// Block until a send or a receive operation is selected:
 ///
 /// ```
-/// # fn main() {
-/// use std::thread;
 /// use crossbeam_channel::{select, unbounded};
 ///
 /// let (s1, r1) = unbounded();
@@ -1092,13 +1090,11 @@ macro_rules! crossbeam_channel_internal {
 ///         assert_eq!(r2.recv(), Ok(20));
 ///     }
 /// }
-/// # }
 /// ```
 ///
 /// Select from a set of operations without blocking:
 ///
 /// ```
-/// # fn main() {
 /// use std::thread;
 /// use std::time::Duration;
 /// use crossbeam_channel::{select, unbounded};
@@ -1121,13 +1117,11 @@ macro_rules! crossbeam_channel_internal {
 ///     recv(r2) -> msg => panic!(),
 ///     default => println!("not ready"),
 /// }
-/// # }
 /// ```
 ///
 /// Select over a set of operations with a timeout:
 ///
 /// ```
-/// # fn main() {
 /// use std::thread;
 /// use std::time::Duration;
 /// use crossbeam_channel::{select, unbounded};
@@ -1150,13 +1144,11 @@ macro_rules! crossbeam_channel_internal {
 ///     recv(r2) -> msg => panic!(),
 ///     default(Duration::from_millis(100)) => println!("timed out"),
 /// }
-/// # }
 /// ```
 ///
 /// Optionally add a receive operation to `select!` using [`never`]:
 ///
 /// ```
-/// # fn main() {
 /// use std::thread;
 /// use std::time::Duration;
 /// use crossbeam_channel::{select, never, unbounded};
@@ -1181,7 +1173,6 @@ macro_rules! crossbeam_channel_internal {
 ///     recv(r1) -> msg => panic!(),
 ///     recv(r2.unwrap_or(&never())) -> msg => assert_eq!(msg, Ok(20)),
 /// }
-/// # }
 /// ```
 ///
 /// To optionally add a timeout to `select!`, see the [example] for [`never`].

--- a/crossbeam-deque/src/deque.rs
+++ b/crossbeam-deque/src/deque.rs
@@ -665,7 +665,7 @@ impl<T> Stealer<T> {
     /// let s = w1.stealer();
     /// let w2 = Worker::new_fifo();
     ///
-    /// s.steal_batch(&w2);
+    /// let _ = s.steal_batch(&w2);
     /// assert_eq!(w2.pop(), Some(1));
     /// assert_eq!(w2.pop(), Some(2));
     /// ```
@@ -1384,7 +1384,7 @@ impl<T> Injector<T> {
     /// q.push(4);
     ///
     /// let w = Worker::new_fifo();
-    /// q.steal_batch(&w);
+    /// let _ = q.steal_batch(&w);
     /// assert_eq!(w.pop(), Some(1));
     /// assert_eq!(w.pop(), Some(2));
     /// ```

--- a/crossbeam-deque/src/lib.rs
+++ b/crossbeam-deque/src/lib.rs
@@ -50,7 +50,7 @@
 //! An implementation of this work-stealing strategy:
 //!
 //! ```
-//! use crossbeam_deque::{Injector, Steal, Stealer, Worker};
+//! use crossbeam_deque::{Injector, Stealer, Worker};
 //! use std::iter;
 //!
 //! fn find_task<T>(
@@ -86,6 +86,13 @@
 //! [`steal_batch()`]: struct.Stealer.html#method.steal_batch
 //! [`steal_batch_and_pop()`]: struct.Stealer.html#method.steal_batch_and_pop
 
+#![doc(test(
+    no_crate_inject,
+    attr(
+        deny(warnings, rust_2018_idioms),
+        allow(dead_code, unused_assignments, unused_variables)
+    )
+))]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/crossbeam-epoch/src/atomic.rs
+++ b/crossbeam-epoch/src/atomic.rs
@@ -225,7 +225,7 @@ impl<T> Atomic<T> {
     /// # Examples
     ///
     /// ```
-    /// use crossbeam_epoch::{self as epoch, Atomic, Owned, Shared};
+    /// use crossbeam_epoch::{Atomic, Owned, Shared};
     /// use std::sync::atomic::Ordering::SeqCst;
     ///
     /// let a = Atomic::new(1234);
@@ -247,7 +247,7 @@ impl<T> Atomic<T> {
     /// # Examples
     ///
     /// ```
-    /// use crossbeam_epoch::{self as epoch, Atomic, Owned, Shared};
+    /// use crossbeam_epoch::{self as epoch, Atomic, Shared};
     /// use std::sync::atomic::Ordering::SeqCst;
     ///
     /// let a = Atomic::new(1234);
@@ -280,7 +280,7 @@ impl<T> Atomic<T> {
     /// let a = Atomic::new(1234);
     ///
     /// let guard = &epoch::pin();
-    /// let mut curr = a.load(SeqCst, guard);
+    /// let curr = a.load(SeqCst, guard);
     /// let res1 = a.compare_and_set(curr, Shared::null(), SeqCst, guard);
     /// let res2 = a.compare_and_set(curr, Owned::new(5678), SeqCst, guard);
     /// ```
@@ -689,7 +689,7 @@ impl<T> Owned<T> {
     /// # Examples
     ///
     /// ```
-    /// use crossbeam_epoch::{self as epoch, Owned};
+    /// use crossbeam_epoch::Owned;
     ///
     /// let o = Owned::new(1234);
     /// let b: Box<i32> = o.into_box();
@@ -1114,7 +1114,7 @@ impl<T> From<*const T> for Shared<'_, T> {
     /// ```
     /// use crossbeam_epoch::Shared;
     ///
-    /// let p = unsafe { Shared::from(Box::into_raw(Box::new(1234)) as *const _) };
+    /// let p = Shared::from(Box::into_raw(Box::new(1234)) as *const _);
     /// assert!(!p.is_null());
     /// ```
     fn from(raw: *const T) -> Self {

--- a/crossbeam-epoch/src/guard.rs
+++ b/crossbeam-epoch/src/guard.rs
@@ -30,7 +30,7 @@ use crate::internal::Local;
 /// For example:
 ///
 /// ```
-/// use crossbeam_epoch::{self as epoch, Atomic, Owned};
+/// use crossbeam_epoch::{self as epoch, Atomic};
 /// use std::sync::atomic::Ordering::SeqCst;
 ///
 /// // Create a heap-allocated number.
@@ -289,11 +289,9 @@ impl Guard {
     /// use crossbeam_epoch as epoch;
     ///
     /// let guard = &epoch::pin();
-    /// unsafe {
-    ///     guard.defer(move || {
-    ///         println!("This better be printed as soon as possible!");
-    ///     });
-    /// }
+    /// guard.defer(move || {
+    ///     println!("This better be printed as soon as possible!");
+    /// });
     /// guard.flush();
     /// ```
     ///
@@ -318,8 +316,6 @@ impl Guard {
     /// ```
     /// use crossbeam_epoch::{self as epoch, Atomic};
     /// use std::sync::atomic::Ordering::SeqCst;
-    /// use std::thread;
-    /// use std::time::Duration;
     ///
     /// let a = Atomic::new(777);
     /// let mut guard = epoch::pin();
@@ -407,8 +403,8 @@ impl Guard {
     /// ```
     /// use crossbeam_epoch as epoch;
     ///
-    /// let mut guard1 = epoch::pin();
-    /// let mut guard2 = epoch::pin();
+    /// let guard1 = epoch::pin();
+    /// let guard2 = epoch::pin();
     /// assert!(guard1.collector() == guard2.collector());
     /// ```
     ///

--- a/crossbeam-epoch/src/lib.rs
+++ b/crossbeam-epoch/src/lib.rs
@@ -54,6 +54,13 @@
 //! [`pin`]: fn.pin.html
 //! [`defer`]: struct.Guard.html#method.defer
 
+#![doc(test(
+    no_crate_inject,
+    attr(
+        deny(warnings, rust_2018_idioms),
+        allow(dead_code, unused_assignments, unused_variables)
+    )
+))]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]

--- a/crossbeam-epoch/src/sync/queue.rs
+++ b/crossbeam-epoch/src/sync/queue.rs
@@ -63,7 +63,12 @@ impl<T> Queue<T> {
     /// Attempts to atomically place `n` into the `next` pointer of `onto`, and returns `true` on
     /// success. The queue's `tail` pointer may be updated.
     #[inline(always)]
-    fn push_internal(&self, onto: Shared<'_, Node<T>>, new: Shared<'_, Node<T>>, guard: &Guard) -> bool {
+    fn push_internal(
+        &self,
+        onto: Shared<'_, Node<T>>,
+        new: Shared<'_, Node<T>>,
+        guard: &Guard,
+    ) -> bool {
         // is `onto` the actual tail?
         let o = unsafe { onto.deref() };
         let next = o.next.load(Acquire, guard);
@@ -205,8 +210,8 @@ impl<T> Drop for Queue<T> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crossbeam_utils::thread;
     use crate::pin;
+    use crossbeam_utils::thread;
 
     struct Queue<T> {
         queue: super::Queue<T>,

--- a/crossbeam-queue/src/array_queue.rs
+++ b/crossbeam-queue/src/array_queue.rs
@@ -299,7 +299,7 @@ impl<T> ArrayQueue<T> {
     /// # Examples
     ///
     /// ```
-    /// use crossbeam_queue::{ArrayQueue, PopError};
+    /// use crossbeam_queue::ArrayQueue;
     ///
     /// let q = ArrayQueue::<i32>::new(100);
     ///
@@ -314,7 +314,7 @@ impl<T> ArrayQueue<T> {
     /// # Examples
     ///
     /// ```
-    /// use crossbeam_queue::{ArrayQueue, PopError};
+    /// use crossbeam_queue::ArrayQueue;
     ///
     /// let q = ArrayQueue::new(100);
     ///
@@ -339,7 +339,7 @@ impl<T> ArrayQueue<T> {
     /// # Examples
     ///
     /// ```
-    /// use crossbeam_queue::{ArrayQueue, PopError};
+    /// use crossbeam_queue::ArrayQueue;
     ///
     /// let q = ArrayQueue::new(1);
     ///
@@ -363,7 +363,7 @@ impl<T> ArrayQueue<T> {
     /// # Examples
     ///
     /// ```
-    /// use crossbeam_queue::{ArrayQueue, PopError};
+    /// use crossbeam_queue::ArrayQueue;
     ///
     /// let q = ArrayQueue::new(100);
     /// assert_eq!(q.len(), 0);

--- a/crossbeam-queue/src/lib.rs
+++ b/crossbeam-queue/src/lib.rs
@@ -8,6 +8,13 @@
 //! [`ArrayQueue`]: struct.ArrayQueue.html
 //! [`SegQueue`]: struct.SegQueue.html
 
+#![doc(test(
+    no_crate_inject,
+    attr(
+        deny(warnings, rust_2018_idioms),
+        allow(dead_code, unused_assignments, unused_variables)
+    )
+))]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]

--- a/crossbeam-queue/src/seg_queue.rs
+++ b/crossbeam-queue/src/seg_queue.rs
@@ -390,7 +390,7 @@ impl<T> SegQueue<T> {
     /// # Examples
     ///
     /// ```
-    /// use crossbeam_queue::{SegQueue, PopError};
+    /// use crossbeam_queue::SegQueue;
     ///
     /// let q = SegQueue::new();
     /// assert_eq!(q.len(), 0);

--- a/crossbeam-skiplist/src/lib.rs
+++ b/crossbeam-skiplist/src/lib.rs
@@ -1,5 +1,12 @@
 //! TODO
 
+#![doc(test(
+    no_crate_inject,
+    attr(
+        deny(warnings, rust_2018_idioms),
+        allow(dead_code, unused_assignments, unused_variables)
+    )
+))]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]

--- a/crossbeam-utils/src/atomic/atomic_cell.rs
+++ b/crossbeam-utils/src/atomic/atomic_cell.rs
@@ -64,7 +64,7 @@ impl<T> AtomicCell<T> {
     /// ```
     /// use crossbeam_utils::atomic::AtomicCell;
     ///
-    /// let mut a = AtomicCell::new(7);
+    /// let a = AtomicCell::new(7);
     /// let v = a.into_inner();
     ///
     /// assert_eq!(v, 7);
@@ -154,7 +154,7 @@ impl<T: ?Sized> AtomicCell<T> {
     /// ```
     /// use crossbeam_utils::atomic::AtomicCell;
     ///
-    /// let mut a = AtomicCell::new(5);
+    /// let a = AtomicCell::new(5);
     ///
     /// let ptr = a.as_ptr();
     /// ```

--- a/crossbeam-utils/src/lib.rs
+++ b/crossbeam-utils/src/lib.rs
@@ -26,6 +26,13 @@
 //! [`CachePadded`]: struct.CachePadded.html
 //! [`scope`]: thread/fn.scope.html
 
+#![doc(test(
+    no_crate_inject,
+    attr(
+        deny(warnings, rust_2018_idioms),
+        allow(dead_code, unused_assignments, unused_variables)
+    )
+))]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]

--- a/crossbeam-utils/src/sync/parker.rs
+++ b/crossbeam-utils/src/sync/parker.rs
@@ -30,7 +30,7 @@ use std::time::Duration;
 /// use std::time::Duration;
 /// use crossbeam_utils::sync::Parker;
 ///
-/// let mut p = Parker::new();
+/// let p = Parker::new();
 /// let u = p.unparker().clone();
 ///
 /// // Make the token available.
@@ -98,7 +98,7 @@ impl Parker {
     /// ```
     /// use crossbeam_utils::sync::Parker;
     ///
-    /// let mut p = Parker::new();
+    /// let p = Parker::new();
     /// let u = p.unparker().clone();
     ///
     /// // Make the token available.
@@ -122,7 +122,7 @@ impl Parker {
     /// use std::time::Duration;
     /// use crossbeam_utils::sync::Parker;
     ///
-    /// let mut p = Parker::new();
+    /// let p = Parker::new();
     ///
     /// // Waits for the token to become available, but will not wait longer than 500 ms.
     /// p.park_timeout(Duration::from_millis(500));
@@ -140,7 +140,7 @@ impl Parker {
     /// ```
     /// use crossbeam_utils::sync::Parker;
     ///
-    /// let mut p = Parker::new();
+    /// let p = Parker::new();
     /// let u = p.unparker().clone();
     ///
     /// // Make the token available.
@@ -225,7 +225,7 @@ impl Unparker {
     /// use std::time::Duration;
     /// use crossbeam_utils::sync::Parker;
     ///
-    /// let mut p = Parker::new();
+    /// let p = Parker::new();
     /// let u = p.unparker().clone();
     ///
     /// thread::spawn(move || {
@@ -352,7 +352,11 @@ impl Inner {
                     // Block the current thread on the conditional variable.
                     m = self.cvar.wait(m).unwrap();
 
-                    if self.state.compare_exchange(NOTIFIED, EMPTY, SeqCst, SeqCst).is_ok() {
+                    if self
+                        .state
+                        .compare_exchange(NOTIFIED, EMPTY, SeqCst, SeqCst)
+                        .is_ok()
+                    {
                         // got a notification
                         return;
                     }

--- a/crossbeam-utils/src/thread.rs
+++ b/crossbeam-utils/src/thread.rs
@@ -108,7 +108,7 @@
 //!         // Yay, this works because we're using a fresh argument `s`! :)
 //!         s.spawn(|_| println!("nested thread"));
 //!     });
-//! });
+//! }).unwrap();
 //! ```
 //!
 //! [`std::thread::spawn`]: https://doc.rust-lang.org/std/thread/fn.spawn.html
@@ -250,7 +250,6 @@ impl<'env> Scope<'env> {
     ///
     /// ```
     /// use crossbeam_utils::thread;
-    /// use std::thread::current;
     ///
     /// thread::scope(|s| {
     ///     s.builder()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,13 @@
 //! [`CachePadded`]: utils/struct.CachePadded.html
 //! [`scope`]: fn.scope.html
 
+#![doc(test(
+    no_crate_inject,
+    attr(
+        deny(warnings, rust_2018_idioms),
+        allow(dead_code, unused_assignments, unused_variables)
+    )
+))]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]


### PR DESCRIPTION
There are some unused imports/`mut`s.

Refs: rust-lang/futures-rs#1672, tokio-rs/tokio#1539

