### PR TITLE
Enable tests on Windows on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,18 @@ on:
       - staging
       - trying
 
+env:
+  RUSTFLAGS: -Dwarnings
+  RUST_BACKTRACE: 1
+
+defaults:
+  run:
+    shell: bash
+
 jobs:
   # Test crates on their minimum Rust versions and nightly Rust.
   test:
     name: test
-    runs-on: ubuntu-latest
     env:
       RUST_VERSION: ${{ matrix.rust }}
     strategy:
@@ -27,6 +34,10 @@ jobs:
         rust:
           - 1.36.0
           - nightly
+        os:
+         - ubuntu
+         - windows
+    runs-on: ${{ matrix.os }}-latest
     steps:
       - uses: actions/checkout@master
       - name: Install Rust
@@ -60,3 +71,32 @@ jobs:
         run: rustup update stable && rustup default stable
       - name: rustfmt
         run: ./ci/rustfmt.sh
+
+  # These jobs don't actually test anything, but they're used to tell bors the
+  # build completed, as there is no practical way to detect when a workflow is
+  # successful listening to webhooks only.
+  #
+  # ALL THE PREVIOUS JOBS NEEDS TO BE ADDED TO THE `needs` SECTION OF THIS JOB!
+
+  ci-success:
+    name: ci
+    if: github.event_name == 'push' && success()
+    needs:
+      - test
+      - dependencies
+      - rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark the job as a success
+        run: exit 0
+  ci-failure:
+    name: ci
+    if: github.event_name == 'push' && !success()
+    needs:
+      - test
+      - dependencies
+      - rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark the job as a failure
+        run: exit 1

--- a/bors.toml
+++ b/bors.toml
@@ -1,18 +1,1 @@
-status = [
-    "test (crossbeam, 1.36.0)",
-    "test (crossbeam, nightly)",
-    "test (crossbeam-channel, 1.36.0)",
-    "test (crossbeam-channel, nightly)",
-    "test (crossbeam-deque, 1.36.0)",
-    "test (crossbeam-deque, nightly)",
-    "test (crossbeam-epoch, 1.36.0)",
-    "test (crossbeam-epoch, nightly)",
-    "test (crossbeam-queue, 1.36.0)",
-    "test (crossbeam-queue, nightly)",
-    "test (crossbeam-skiplist, 1.36.0)",
-    "test (crossbeam-skiplist, nightly)",
-    "test (crossbeam-utils, 1.36.0)",
-    "test (crossbeam-utils, nightly)",
-    "dependencies",
-    "rustfmt",
-]
+status = ["ci"]

--- a/ci/crossbeam-epoch.sh
+++ b/ci/crossbeam-epoch.sh
@@ -13,13 +13,15 @@ if [[ "$RUST_VERSION" == "nightly" ]]; then
     cargo check --no-default-features --features nightly
     cargo test --features nightly
 
-    ASAN_OPTIONS="detect_odr_violation=0 detect_leaks=0" \
-    RUSTFLAGS="-Z sanitizer=address" \
-    cargo run \
-        --release \
-        --target x86_64-unknown-linux-gnu \
-        --features sanitize,nightly \
-        --example sanitize
+    if [[ "$OSTYPE" == "linux"* ]]; then
+        ASAN_OPTIONS="detect_odr_violation=0 detect_leaks=0" \
+        RUSTFLAGS="-Z sanitizer=address" \
+        cargo run \
+            --release \
+            --target x86_64-unknown-linux-gnu \
+            --features sanitize,nightly \
+            --example sanitize
+    fi
 
     # Check for no_std environment.
     cargo check --target thumbv7m-none-eabi --no-default-features

--- a/crossbeam-channel/examples/stopwatch.rs
+++ b/crossbeam-channel/examples/stopwatch.rs
@@ -1,39 +1,45 @@
 //! Prints the elapsed time every 1 second and quits on Ctrl+C.
 
-use std::io;
-use std::thread;
-use std::time::{Duration, Instant};
-
-use crossbeam_channel::{bounded, select, tick, Receiver};
-use signal_hook::iterator::Signals;
-use signal_hook::SIGINT;
-
-// Creates a channel that gets a message every time `SIGINT` is signalled.
-fn sigint_notifier() -> io::Result<Receiver<()>> {
-    let (s, r) = bounded(100);
-    let signals = Signals::new(&[SIGINT])?;
-
-    thread::spawn(move || {
-        for _ in signals.forever() {
-            if s.send(()).is_err() {
-                break;
-            }
-        }
-    });
-
-    Ok(r)
-}
-
-// Prints the elapsed time.
-fn show(dur: Duration) {
-    println!(
-        "Elapsed: {}.{:03} sec",
-        dur.as_secs(),
-        dur.subsec_nanos() / 1_000_000
-    );
-}
-
+#[cfg(windows)] // signal_hook::iterator does not work on windows
 fn main() {
+    println!("This example does not work on Windows");
+}
+
+#[cfg(not(windows))]
+fn main() {
+    use std::io;
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    use crossbeam_channel::{bounded, select, tick, Receiver};
+    use signal_hook::iterator::Signals;
+    use signal_hook::SIGINT;
+
+    // Creates a channel that gets a message every time `SIGINT` is signalled.
+    fn sigint_notifier() -> io::Result<Receiver<()>> {
+        let (s, r) = bounded(100);
+        let signals = Signals::new(&[SIGINT])?;
+
+        thread::spawn(move || {
+            for _ in signals.forever() {
+                if s.send(()).is_err() {
+                    break;
+                }
+            }
+        });
+
+        Ok(r)
+    }
+
+    // Prints the elapsed time.
+    fn show(dur: Duration) {
+        println!(
+            "Elapsed: {}.{:03} sec",
+            dur.as_secs(),
+            dur.subsec_nanos() / 1_000_000
+        );
+    }
+
     let start = Instant::now();
     let update = tick(Duration::from_secs(1));
     let ctrl_c = sigint_notifier().unwrap();


### PR DESCRIPTION
crossbeam has some `cfg(windows)` code, but we don't test on CI. It would be nice to be able to test these with CI.
https://github.com/crossbeam-rs/crossbeam/blob/48790384d49192b928476400b52d81cd008b8869/crossbeam-utils/src/thread.rs#L537
https://github.com/crossbeam-rs/crossbeam/blob/48790384d49192b928476400b52d81cd008b8869/crossbeam-utils/tests/thread.rs#L196

Travis's Windows support was experimental and very slow, but GitHub Actions' Windows support relatively fast. Hopefully we can add this to our CI.
