### PR TITLE
Remove obsolete FnMut conversion

### DIFF
--- a/crossbeam-utils/src/thread.rs
+++ b/crossbeam-utils/src/thread.rs
@@ -415,16 +415,12 @@ impl<'scope, 'env> ScopedThreadBuilder<'scope, 'env> {
                     *result.lock().unwrap() = Some(res);
                 };
 
-                // Change the type of `closure` from `FnOnce() -> T` to `FnMut() -> T`.
-                let mut closure = Some(closure);
-                let closure = move || closure.take().unwrap()();
-
                 // Allocate `clsoure` on the heap and erase the `'env` bound.
-                let closure: Box<dyn FnMut() + Send + 'env> = Box::new(closure);
-                let closure: Box<dyn FnMut() + Send + 'static> = unsafe { mem::transmute(closure) };
+                let closure: Box<dyn FnOnce() + Send + 'env> = Box::new(closure);
+                let closure: Box<dyn FnOnce() + Send + 'static> =
+                    unsafe { mem::transmute(closure) };
 
                 // Finally, spawn the closure.
-                let mut closure = closure;
                 self.builder.spawn(move || closure())?
             };
 

--- a/crossbeam-utils/tests/thread.rs
+++ b/crossbeam-utils/tests/thread.rs
@@ -178,6 +178,12 @@ fn join_nested() {
     .unwrap();
 }
 
+#[test]
+fn scope_returns_ok() {
+    let result = thread::scope(|scope| scope.spawn(|_| 1234).join().unwrap()).unwrap();
+    assert_eq!(result, 1234);
+}
+
 #[cfg(unix)]
 #[test]
 fn as_pthread_t() {


### PR DESCRIPTION
Currently we convert the FnOnce closure to a FnMut closure. This is not
needed and there is no comment explaining why this is done. I suspect
this might have been required originally because the api or compiler was
different.