### PR TITLE
Add initial docs to crossbeam-skiplist

### DIFF
--- a/crossbeam-skiplist/src/base.rs
+++ b/crossbeam-skiplist/src/base.rs
@@ -356,7 +356,7 @@ impl<K, V> SkipList<K, V> {
     pub fn len(&self) -> usize {
         let len = self.hot_data.len.load(Ordering::Relaxed);
 
-        // Due to the relaxed  memory ordering, the length counter may sometimes
+        // Due to the relaxed memory ordering, the length counter may sometimes
         // underflow and produce a very large value. We treat such values as 0.
         if len > isize::max_value() as usize {
             0

--- a/crossbeam-skiplist/src/lib.rs
+++ b/crossbeam-skiplist/src/lib.rs
@@ -52,16 +52,17 @@
 //!
 //! let numbers = SkipSet::new();
 //! scope(|s| {
-//!     numbers.insert(5);
-//!
 //!     // Spawn a thread which will remove 5 from the set.
 //!     s.spawn(|_| {
 //!         numbers.remove(&5);
 //!     });
+//!     
+//!     // While the thread above is running, insert a value into the set.
+//!     numbers.insert(5);
 //!
 //!     // This check can fail!
-//!     // The othe thread may remove the value
-//!     // we perform this check.
+//!     // The other thread may remove the value
+//!     // before we perform this check.
 //!     assert!(numbers.contains(&5));
 //! }).unwrap();
 //! ```
@@ -69,7 +70,7 @@
 //! In effect, a _single_ operation on the map, such as [`insert`],
 //! operates atomically: race conditions are impossible. However,
 //! concurrent calls to functions can become interleaved across
-//! threads, introducing non-determinism into your code.
+//! threads, introducing non-determinism.
 //!
 //! To avoid this sort of race condition, never assume that a collection's
 //! state will remain the same across multiple lines of code. For instance,
@@ -102,7 +103,7 @@
 //! A problem faced by many concurrent data structures
 //! is choosing when to free unused memory. Care must be
 //! taken to prevent use-after-frees and double-frees, both
-//! of which cause undefined behvarior.
+//! of which cause undefined behavior.
 //!
 //! Consider the following sequence of events operating on a [`SkipMap`]:
 //! * Thread A calls [`get`] and holds a reference to a value in the map.
@@ -119,7 +120,7 @@
 //! is similar to the garbage collection found in some languages, such as Java, except
 //! it operates solely on the values inside the map.
 //!
-//! This garbage collection scheme operates automatically; users don't have to worry about it.
+//! This garbage collection scheme functions automatically; users don't have to worry about it.
 //! However, keep in mind that holding [`Entry`] handles to entries in the map will prevent
 //! that memory from being freed until at least after the handles are dropped.
 //!

--- a/crossbeam-skiplist/src/lib.rs
+++ b/crossbeam-skiplist/src/lib.rs
@@ -141,6 +141,18 @@
 //! In the end, the best way to choose between [`BTreeMap`] and [`SkipMap`]
 //! is to benchmark them in your own application.
 //!
+//! # Alternatives
+//! This crate implements _ordered_ maps and sets, akin to [`BTreeMap`] and [`BTreeSet`].
+//! In many situations, however, a defined order on elements is not required. For these
+//! purposes, unordered maps will suffice. In addition, unordered maps
+//! often have better performance characteristics than their ordered alternatives.
+//!
+//! Crossbeam [does not currently provide a concurrent unordered map](https://github.com/crossbeam-rs/rfcs/issues/32).
+//! That said, here are some other crates which may suit you:
+//! * [`DashMap`](https://docs.rs/dashmap) implements a novel concurrent hash map
+//! with good performance characteristics.
+//! * [`flurry`](https://docs.rs/flurry) is a Rust port of Java's `ConcurrentHashMap`.
+//!
 //! [`SkipMap`]: struct.SkipMap.html
 //! [`SkipSet`]: struct.SkipSet.html
 //! [`insert`]: struct.SkipMap.html#method.insert


### PR DESCRIPTION
As per https://github.com/crossbeam-rs/crossbeam/issues/503#issuecomment-631679442, I'm writing the docs for `crossbeam-skiplist`. 

Checklist:
* [x] Crate-level docs
* [x] Docs for `SkipMap`
* [ ] Docs for `SkipSet`

I also have some thoughts about the API:
* `Entry`'s name is misleading; it's not the same as the standard library's map entry API. A name like `Ref` might be more suitable, to align with `RefCell`. 
* `set::Entry` could implement `Deref<Target=T>` for convenience. 
* I see the base `SkipList` struct is exposed, though I'm not sure if it belongs in the public API.