### PR TITLE
impl From<T> for AtomicCell<T>

### DIFF
--- a/crossbeam-utils/src/atomic/atomic_cell.rs
+++ b/crossbeam-utils/src/atomic/atomic_cell.rs
@@ -595,6 +595,13 @@ impl<T: Default> Default for AtomicCell<T> {
     }
 }
 
+impl<T> From<T> for AtomicCell<T> {
+    #[inline]
+    fn from(val: T) -> AtomicCell<T> {
+        AtomicCell::new(val)
+    }
+}
+
 impl<T: Copy + fmt::Debug> fmt::Debug for AtomicCell<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("AtomicCell")


### PR DESCRIPTION
std atomic types also have similar `From` impls: e.g., [`AtomicBool`](https://doc.rust-lang.org/nightly/std/sync/atomic/struct.AtomicBool.html#impl-From%3Cbool%3E), [`AtomicUsize`](https://doc.rust-lang.org/nightly/std/sync/atomic/struct.AtomicUsize.html#impl-From%3Cusize%3E)