### PR TITLE
Added "deadline" versions of the various "timeout" entry points in crossbeam channel

### DIFF
--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -176,7 +176,7 @@ pub fn after(duration: Duration) -> Receiver<Instant> {
     }
 }
 
-/// Creates a receiver that delivers a message at a certain instant in time
+/// Creates a receiver that delivers a message at a certain instant in time.
 ///
 /// The channel is bounded with capacity of 1 and never gets disconnected. Exactly one message will
 /// be sent into the channel at the moment in time `when`. The message is the instant at which it

--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -185,18 +185,18 @@ pub fn after(duration: Duration) -> Receiver<Instant> {
 ///
 /// # Examples
 ///
-/// Using an `after` channel for timeouts:
+/// Using an `at` channel for timeouts:
 ///
 /// ```
-/// use std::time::Duration;
-/// use crossbeam_channel::{after, select, unbounded};
+/// use std::time::{Instant, Duration};
+/// use crossbeam_channel::{at, select, unbounded};
 ///
 /// let (s, r) = unbounded::<i32>();
-/// let timeout = Duration::from_millis(100);
+/// let deadline = Instant::now() + Duration::from_millis(500);
 ///
 /// select! {
 ///     recv(r) -> msg => println!("received {:?}", msg),
-///     recv(after(timeout)) -> _ => println!("timed out"),
+///     recv(at(deadline)) -> _ => println!("timed out"),
 /// }
 /// ```
 ///

--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -176,11 +176,12 @@ pub fn after(duration: Duration) -> Receiver<Instant> {
     }
 }
 
-/// Creates a receiver that delivers a message after at a certain instant in time
+/// Creates a receiver that delivers a message at a certain instant in time
 ///
 /// The channel is bounded with capacity of 1 and never gets disconnected. Exactly one message will
 /// be sent into the channel at the moment in time `when`. The message is the instant at which it
-/// is sent, which is the same as `when`.
+/// is sent, which is the same as `when`. If `when` is in the past, the message will be delivered
+/// instantly to the receiver.
 ///
 /// # Examples
 ///

--- a/crossbeam-channel/src/flavors/after.rs
+++ b/crossbeam-channel/src/flavors/after.rs
@@ -76,14 +76,13 @@ impl Channel {
         loop {
             let now = Instant::now();
 
-            // Check if we can receive the next message.
-            if now >= self.delivery_time {
-                break;
-            }
-
             let deadline = match deadline {
+                // Check if we can receive the next message.
+                _ if now >= self.delivery_time => break,
                 // Check if the timeout deadline has been reached.
                 Some(d) if now >= d => return Err(RecvTimeoutError::Timeout),
+
+                // Sleep until one of the above happens
                 Some(d) if d < self.delivery_time => d,
                 _ => self.delivery_time,
             };

--- a/crossbeam-channel/src/flavors/at.rs
+++ b/crossbeam-channel/src/flavors/at.rs
@@ -1,4 +1,4 @@
-//! Channel that delivers a message after a certain amount of time.
+//! Channel that delivers a message at a certain moment in time.
 //!
 //! Messages cannot be sent into this kind of channel; they are materialized on demand.
 
@@ -12,9 +12,9 @@ use crate::select::{Operation, SelectHandle, Token};
 use crate::utils;
 
 /// Result of a receive operation.
-pub type AfterToken = Option<Instant>;
+pub type AtToken = Option<Instant>;
 
-/// Channel that delivers a message after a certain amount of time.
+/// Channel that delivers a message at a certain moment in time
 pub struct Channel {
     /// The instant at which the message will be delivered.
     delivery_time: Instant,
@@ -104,7 +104,7 @@ impl Channel {
     /// Reads a message from the channel.
     #[inline]
     pub unsafe fn read(&self, token: &mut Token) -> Result<Instant, ()> {
-        token.after.ok_or(())
+        token.at.ok_or(())
     }
 
     /// Returns `true` if the channel is empty.
@@ -153,11 +153,11 @@ impl SelectHandle for Channel {
     fn try_select(&self, token: &mut Token) -> bool {
         match self.try_recv() {
             Ok(msg) => {
-                token.after = Some(msg);
+                token.at = Some(msg);
                 true
             }
             Err(TryRecvError::Disconnected) => {
-                token.after = None;
+                token.at = None;
                 true
             }
             Err(TryRecvError::Empty) => false,

--- a/crossbeam-channel/src/flavors/mod.rs
+++ b/crossbeam-channel/src/flavors/mod.rs
@@ -2,15 +2,15 @@
 //!
 //! There are six flavors:
 //!
-//! 1. `after` - Channel that delivers a message after a certain amount of time.
+//! 1. `at` - Channel that delivers a message after a certain amount of time.
 //! 2. `array` - Bounded channel based on a preallocated array.
 //! 3. `list` - Unbounded channel implemented as a linked list.
 //! 4. `never` - Channel that never delivers messages.
 //! 5. `tick` - Channel that delivers messages periodically.
 //! 6. `zero` - Zero-capacity channel.
 
-pub mod after;
 pub mod array;
+pub mod at;
 pub mod list;
 pub mod never;
 pub mod tick;

--- a/crossbeam-channel/src/lib.rs
+++ b/crossbeam-channel/src/lib.rs
@@ -362,7 +362,7 @@ cfg_if! {
             pub use crate::select::{select, select_timeout, try_select};
         }
 
-        pub use crate::channel::{after, never, tick};
+        pub use crate::channel::{after, at, never, tick};
         pub use crate::channel::{bounded, unbounded};
         pub use crate::channel::{IntoIter, Iter, TryIter};
         pub use crate::channel::{Receiver, Sender};

--- a/crossbeam-channel/src/select.rs
+++ b/crossbeam-channel/src/select.rs
@@ -21,7 +21,7 @@ use crate::utils;
 /// Each field contains data associated with a specific channel flavor.
 #[derive(Debug, Default)]
 pub struct Token {
-    pub after: flavors::after::AfterToken,
+    pub at: flavors::at::AtToken,
     pub array: flavors::array::ArrayToken,
     pub list: flavors::list::ListToken,
     pub never: flavors::never::NeverToken,

--- a/crossbeam-channel/src/select.rs
+++ b/crossbeam-channel/src/select.rs
@@ -1053,7 +1053,7 @@ impl<'a> Select<'a> {
         self.ready_deadline(Instant::now() + timeout)
     }
 
-    /// Blocks for a until a given deadline, or until one of the operations becomes ready.
+    /// Blocks until a given deadline, or until one of the operations becomes ready.
     ///
     /// If an operation becomes ready, its index is returned. If multiple operations are ready at
     /// the same time, a random one among them is chosen. If none of the operations become ready


### PR DESCRIPTION
Added:

- `Receiver::recv_deadline`
- `Sender::send_deadline`
- `channel::at` (the deadline version of `channel::after`)
- `Select::select_deadline`
- `Select::ready_deadline`

Added associated docs & doctests for these, but in general they share implementations with the existing `timeout` versions, so I didn't add additional unit tests.

Didn't add a deadline version of the select macro for now, since it wasn't clear what the syntax would be or if it's really necessary (since deadline versions of things will be more for low/medium-level abstractions built on top of crossbeam, which would want to minimize abstraction).

Didn't add Parker::park_deadline, since that would have involved a heavier refactor of the `Parker` implementation (probably removing the possibility of a spurious wakeup).

Fixes #553