### PR TITLE
v0.7: Bump crossbeam-channel to v0.4.4

### DIFF
--- a/crossbeam-channel/CHANGELOG.md
+++ b/crossbeam-channel/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.4.3
+
+- Change license to "MIT OR Apache-2.0".
+
 # Version 0.4.2
 
 - Fix bug in release (yanking 0.4.1)

--- a/crossbeam-channel/CHANGELOG.md
+++ b/crossbeam-channel/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 0.4.4
+
+- Fix bug in release (yanking 0.4.3)
+- Fix UB and breaking change introduced in 0.4.3
+
 # Version 0.4.3
 
 - Change license to "MIT OR Apache-2.0".

--- a/crossbeam-channel/Cargo.toml
+++ b/crossbeam-channel/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-channel"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-channel-X.Y.Z" git tag
-version = "0.4.3"
+version = "0.4.4"
 authors = ["The Crossbeam Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/crossbeam-channel/Cargo.toml
+++ b/crossbeam-channel/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-channel"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-channel-X.Y.Z" git tag
-version = "0.4.2"
+version = "0.4.3"
 authors = ["The Crossbeam Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/crossbeam-channel/Cargo.toml
+++ b/crossbeam-channel/Cargo.toml
@@ -6,7 +6,7 @@ name = "crossbeam-channel"
 # - Create "crossbeam-channel-X.Y.Z" git tag
 version = "0.4.2"
 authors = ["The Crossbeam Project Developers"]
-license = "MIT/Apache-2.0 AND BSD-2-Clause"
+license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/crossbeam-rs/crossbeam"
 homepage = "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-channel"


### PR DESCRIPTION
See https://github.com/crossbeam-rs/crossbeam/pull/537#issuecomment-687755200 for details.
(The `v0.7` branch itself is based on the commits we made when I released crossbeam-queue v0.2.3 in https://github.com/crossbeam-rs/crossbeam/issues/523#issuecomment-642347864.)

Backports:
* #537 
* https://github.com/crossbeam-rs/crossbeam/commit/5a68889cbc490f71fce5e615572e586cf15668a6