### PR TITLE
Use intra-doc links

### DIFF
--- a/ci/crossbeam-channel.sh
+++ b/ci/crossbeam-channel.sh
@@ -11,4 +11,6 @@ cargo test -- --test-threads=1
 if [[ "$RUST_VERSION" == "nightly"* ]]; then
     cd benchmarks
     cargo check --bins
+
+    RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --all-features
 fi

--- a/ci/crossbeam-deque.sh
+++ b/ci/crossbeam-deque.sh
@@ -7,3 +7,7 @@ export RUSTFLAGS="-D warnings"
 
 cargo check --bins --examples --tests
 cargo test
+
+if [[ "$RUST_VERSION" == "nightly"* ]]; then
+    RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --all-features
+fi

--- a/ci/crossbeam-epoch.sh
+++ b/ci/crossbeam-epoch.sh
@@ -11,6 +11,8 @@ cargo test
 if [[ "$RUST_VERSION" == "nightly"* ]]; then
     cargo test --features nightly
 
+    RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --all-features
+
     if [[ "$OSTYPE" == "linux"* ]]; then
         ASAN_OPTIONS="detect_odr_violation=0 detect_leaks=0" \
         RUSTFLAGS="-Z sanitizer=address" \

--- a/ci/crossbeam-queue.sh
+++ b/ci/crossbeam-queue.sh
@@ -7,3 +7,7 @@ export RUSTFLAGS="-D warnings"
 
 cargo check --bins --examples --tests
 cargo test
+
+if [[ "$RUST_VERSION" == "nightly"* ]]; then
+    RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --all-features
+fi

--- a/ci/crossbeam-skiplist.sh
+++ b/ci/crossbeam-skiplist.sh
@@ -10,4 +10,6 @@ cargo test
 
 if [[ "$RUST_VERSION" == "nightly"* ]]; then
     cargo test --features nightly
+
+    RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --all-features
 fi

--- a/ci/crossbeam-utils.sh
+++ b/ci/crossbeam-utils.sh
@@ -10,4 +10,6 @@ cargo test
 
 if [[ "$RUST_VERSION" == "nightly"* ]]; then
     cargo test --features nightly
+
+    RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --all-features
 fi

--- a/ci/crossbeam.sh
+++ b/ci/crossbeam.sh
@@ -10,4 +10,6 @@ cargo test
 
 if [[ "$RUST_VERSION" == "nightly"* ]]; then
     cargo test --features nightly
+
+    RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --all-features
 fi

--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -911,8 +911,7 @@ impl<T> Receiver<T> {
     /// Each call to [`next`] blocks waiting for the next message and then returns it. However, if
     /// the channel becomes empty and disconnected, it returns [`None`] without blocking.
     ///
-    /// [`next`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#tymethod.next
-    /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
+    /// [`next`]: Iterator::next
     ///
     /// # Examples
     ///
@@ -944,7 +943,7 @@ impl<T> Receiver<T> {
     /// Each call to [`next`] returns a message if there is one ready to be received. The iterator
     /// never blocks waiting for the next message.
     ///
-    /// [`next`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#tymethod.next
+    /// [`next`]: Iterator::next
     ///
     /// # Examples
     ///
@@ -1062,8 +1061,7 @@ impl<T> IntoIterator for Receiver<T> {
 /// Each call to [`next`] blocks waiting for the next message and then returns it. However, if the
 /// channel becomes empty and disconnected, it returns [`None`] without blocking.
 ///
-/// [`next`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#tymethod.next
-/// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
+/// [`next`]: Iterator::next
 ///
 /// # Examples
 ///
@@ -1111,7 +1109,7 @@ impl<T> fmt::Debug for Iter<'_, T> {
 /// Each call to [`next`] returns a message if there is one ready to be received. The iterator
 /// never blocks waiting for the next message.
 ///
-/// [`next`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#tymethod.next
+/// [`next`]: Iterator::next
 ///
 /// # Examples
 ///
@@ -1161,8 +1159,7 @@ impl<T> fmt::Debug for TryIter<'_, T> {
 /// Each call to [`next`] blocks waiting for the next message and then returns it. However, if the
 /// channel becomes empty and disconnected, it returns [`None`] without blocking.
 ///
-/// [`next`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#tymethod.next
-/// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
+/// [`next`]: Iterator::next
 ///
 /// # Examples
 ///

--- a/crossbeam-channel/src/err.rs
+++ b/crossbeam-channel/src/err.rs
@@ -7,7 +7,7 @@ use std::fmt;
 ///
 /// The error contains the message so it can be recovered.
 ///
-/// [`send`]: struct.Sender.html#method.send
+/// [`send`]: super::Sender::send
 #[derive(PartialEq, Eq, Clone, Copy)]
 pub struct SendError<T>(pub T);
 
@@ -15,7 +15,7 @@ pub struct SendError<T>(pub T);
 ///
 /// The error contains the message being sent so it can be recovered.
 ///
-/// [`try_send`]: struct.Sender.html#method.try_send
+/// [`try_send`]: super::Sender::try_send
 #[derive(PartialEq, Eq, Clone, Copy)]
 pub enum TrySendError<T> {
     /// The message could not be sent because the channel is full.
@@ -32,7 +32,7 @@ pub enum TrySendError<T> {
 ///
 /// The error contains the message being sent so it can be recovered.
 ///
-/// [`send_timeout`]: struct.Sender.html#method.send_timeout
+/// [`send_timeout`]: super::Sender::send_timeout
 #[derive(PartialEq, Eq, Clone, Copy)]
 pub enum SendTimeoutError<T> {
     /// The message could not be sent because the channel is full and the operation timed out.
@@ -49,13 +49,13 @@ pub enum SendTimeoutError<T> {
 ///
 /// A message could not be received because the channel is empty and disconnected.
 ///
-/// [`recv`]: struct.Receiver.html#method.recv
+/// [`recv`]: super::Receiver::recv
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub struct RecvError;
 
 /// An error returned from the [`try_recv`] method.
 ///
-/// [`try_recv`]: struct.Receiver.html#method.recv
+/// [`try_recv`]: super::Receiver::try_recv
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum TryRecvError {
     /// A message could not be received because the channel is empty.
@@ -70,7 +70,7 @@ pub enum TryRecvError {
 
 /// An error returned from the [`recv_timeout`] method.
 ///
-/// [`recv_timeout`]: struct.Receiver.html#method.recv_timeout
+/// [`recv_timeout`]: super::Receiver::recv_timeout
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum RecvTimeoutError {
     /// A message could not be received because the channel is empty and the operation timed out.
@@ -87,7 +87,7 @@ pub enum RecvTimeoutError {
 ///
 /// Failed because none of the channel operations were ready.
 ///
-/// [`try_select`]: struct.Select.html#method.try_select
+/// [`try_select`]: super::Select::try_select
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub struct TrySelectError;
 
@@ -95,7 +95,7 @@ pub struct TrySelectError;
 ///
 /// Failed because none of the channel operations became ready before the timeout.
 ///
-/// [`select_timeout`]: struct.Select.html#method.select_timeout
+/// [`select_timeout`]: super::Select::select_timeout
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub struct SelectTimeoutError;
 
@@ -103,7 +103,7 @@ pub struct SelectTimeoutError;
 ///
 /// Failed because none of the channel operations were ready.
 ///
-/// [`try_ready`]: struct.Select.html#method.try_ready
+/// [`try_ready`]: super::Select::try_ready
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub struct TryReadyError;
 
@@ -111,7 +111,7 @@ pub struct TryReadyError;
 ///
 /// Failed because none of the channel operations became ready before the timeout.
 ///
-/// [`ready_timeout`]: struct.Select.html#method.ready_timeout
+/// [`ready_timeout`]: super::Select::ready_timeout
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub struct ReadyTimeoutError;
 

--- a/crossbeam-channel/src/lib.rs
+++ b/crossbeam-channel/src/lib.rs
@@ -316,20 +316,10 @@
 //! }
 //! ```
 //!
-//! [`std::sync::mpsc`]: https://doc.rust-lang.org/std/sync/mpsc/index.html
-//! [`unbounded`]: fn.unbounded.html
-//! [`bounded`]: fn.bounded.html
-//! [`after`]: fn.after.html
-//! [`tick`]: fn.tick.html
-//! [`never`]: fn.never.html
-//! [`send`]: struct.Sender.html#method.send
-//! [`recv`]: struct.Receiver.html#method.recv
-//! [`iter`]: struct.Receiver.html#method.iter
-//! [`try_iter`]: struct.Receiver.html#method.try_iter
-//! [`select!`]: macro.select.html
-//! [`Select`]: struct.Select.html
-//! [`Sender`]: struct.Sender.html
-//! [`Receiver`]: struct.Receiver.html
+//! [`send`]: Sender::send
+//! [`recv`]: Receiver::recv
+//! [`iter`]: Receiver::iter
+//! [`try_iter`]: Receiver::try_iter
 
 #![doc(test(
     no_crate_inject,

--- a/crossbeam-channel/src/select.rs
+++ b/crossbeam-channel/src/select.rs
@@ -570,13 +570,12 @@ pub fn select_timeout<'a>(
 /// }
 /// ```
 ///
-/// [`select!`]: macro.select.html
-/// [`try_select`]: struct.Select.html#method.try_select
-/// [`select`]: struct.Select.html#method.select
-/// [`select_timeout`]: struct.Select.html#method.select_timeout
-/// [`try_ready`]: struct.Select.html#method.try_ready
-/// [`ready`]: struct.Select.html#method.ready
-/// [`ready_timeout`]: struct.Select.html#method.ready_timeout
+/// [`try_select`]: Select::try_select
+/// [`select`]: Select::select
+/// [`select_timeout`]: Select::select_timeout
+/// [`try_ready`]: Select::try_ready
+/// [`ready`]: Select::ready
+/// [`ready_timeout`]: Select::ready_timeout
 pub struct Select<'a> {
     /// A list of senders and receivers participating in selection.
     handles: Vec<(&'a dyn SelectHandle, usize, *const u8)>,
@@ -719,9 +718,6 @@ impl<'a> Select<'a> {
     /// The selected operation must be completed with [`SelectedOperation::send`]
     /// or [`SelectedOperation::recv`].
     ///
-    /// [`SelectedOperation::send`]: struct.SelectedOperation.html#method.send
-    /// [`SelectedOperation::recv`]: struct.SelectedOperation.html#method.recv
-    ///
     /// # Examples
     ///
     /// ```
@@ -762,9 +758,6 @@ impl<'a> Select<'a> {
     ///
     /// The selected operation must be completed with [`SelectedOperation::send`]
     /// or [`SelectedOperation::recv`].
-    ///
-    /// [`SelectedOperation::send`]: struct.SelectedOperation.html#method.send
-    /// [`SelectedOperation::recv`]: struct.SelectedOperation.html#method.recv
     ///
     /// # Panics
     ///
@@ -813,9 +806,6 @@ impl<'a> Select<'a> {
     ///
     /// The selected operation must be completed with [`SelectedOperation::send`]
     /// or [`SelectedOperation::recv`].
-    ///
-    /// [`SelectedOperation::send`]: struct.SelectedOperation.html#method.send
-    /// [`SelectedOperation::recv`]: struct.SelectedOperation.html#method.recv
     ///
     /// # Examples
     ///
@@ -1027,8 +1017,8 @@ impl fmt::Debug for Select<'_> {
 /// Forgetting to complete the operation is an error and might lead to deadlocks. If a
 /// `SelectedOperation` is dropped without completion, a panic occurs.
 ///
-/// [`send`]: struct.SelectedOperation.html#method.send
-/// [`recv`]: struct.SelectedOperation.html#method.recv
+/// [`send`]: SelectedOperation::send
+/// [`recv`]: SelectedOperation::recv
 #[must_use]
 pub struct SelectedOperation<'a> {
     /// Token needed to complete the operation.
@@ -1097,9 +1087,6 @@ impl SelectedOperation<'_> {
     /// assert_eq!(oper.index(), oper1);
     /// assert_eq!(oper.send(&s, 10), Err(SendError(10)));
     /// ```
-    ///
-    /// [`Sender`]: struct.Sender.html
-    /// [`Select::send`]: struct.Select.html#method.send
     pub fn send<T>(mut self, s: &Sender<T>, msg: T) -> Result<(), SendError<T>> {
         assert!(
             s as *const Sender<T> as *const u8 == self.ptr,
@@ -1134,9 +1121,6 @@ impl SelectedOperation<'_> {
     /// assert_eq!(oper.index(), oper1);
     /// assert_eq!(oper.recv(&r), Err(RecvError));
     /// ```
-    ///
-    /// [`Receiver`]: struct.Receiver.html
-    /// [`Select::recv`]: struct.Select.html#method.recv
     pub fn recv<T>(mut self, r: &Receiver<T>) -> Result<T, RecvError> {
         assert!(
             r as *const Receiver<T> as *const u8 == self.ptr,

--- a/crossbeam-channel/src/select_macro.rs
+++ b/crossbeam-channel/src/select_macro.rs
@@ -1046,7 +1046,7 @@ macro_rules! crossbeam_channel_internal {
 /// The `select` macro is a convenience wrapper around [`Select`]. However, it cannot select over a
 /// dynamically created list of channel operations.
 ///
-/// [`Select`]: struct.Select.html
+/// [`Select`]: super::Select
 ///
 /// # Examples
 ///
@@ -1154,8 +1154,8 @@ macro_rules! crossbeam_channel_internal {
 ///
 /// To optionally add a timeout to `select!`, see the [example] for [`never`].
 ///
-/// [`never`]: fn.never.html
-/// [example]: fn.never.html#examples
+/// [`never`]: super::never
+/// [example]: super::never#examples
 #[macro_export]
 macro_rules! select {
     ($($tokens:tt)*) => {

--- a/crossbeam-deque/src/lib.rs
+++ b/crossbeam-deque/src/lib.rs
@@ -75,16 +75,12 @@
 //! }
 //! ```
 //!
-//! [`Worker`]: struct.Worker.html
-//! [`Stealer`]: struct.Stealer.html
-//! [`Injector`]: struct.Injector.html
-//! [`Steal::Retry`]: enum.Steal.html#variant.Retry
-//! [`new_fifo()`]: struct.Worker.html#method.new_fifo
-//! [`new_lifo()`]: struct.Worker.html#method.new_lifo
-//! [`stealer()`]: struct.Worker.html#method.stealer
-//! [`steal()`]: struct.Stealer.html#method.steal
-//! [`steal_batch()`]: struct.Stealer.html#method.steal_batch
-//! [`steal_batch_and_pop()`]: struct.Stealer.html#method.steal_batch_and_pop
+//! [`new_fifo()`]: Worker::new_fifo
+//! [`new_lifo()`]: Worker::new_lifo
+//! [`stealer()`]: Worker::stealer
+//! [`steal()`]: Stealer::steal
+//! [`steal_batch()`]: Stealer::steal_batch
+//! [`steal_batch_and_pop()`]: Stealer::steal_batch_and_pop
 
 #![doc(test(
     no_crate_inject,

--- a/crossbeam-epoch/src/atomic.rs
+++ b/crossbeam-epoch/src/atomic.rs
@@ -135,10 +135,6 @@ fn decompose_tag<T: ?Sized + Pointable>(data: usize) -> (usize, usize) {
 ///
 /// let o = Owned::<[MaybeUninit<i32>]>::init(10); // allocating [i32; 10]
 /// ```
-///
-/// [`Atomic`]: struct.Atomic.html
-/// [`Owned`]: struct.Owned.html
-/// [`Shared`]: struct.Shared.html
 pub trait Pointable {
     /// The alignment of pointer.
     const ALIGN: usize;
@@ -160,10 +156,6 @@ pub trait Pointable {
     /// - The given `ptr` should have been initialized with [`Pointable::init`].
     /// - `ptr` should not have yet been dropped by [`Pointable::drop`].
     /// - `ptr` should not be mutably dereferenced by [`Pointable::deref_mut`] concurrently.
-    ///
-    /// [`Pointable::init`]: trait.Pointable.html#method.init
-    /// [`Pointable::drop`]: trait.Pointable.html#method.drop
-    /// [`Pointable::deref`]: trait.Pointable.html#method.deref
     unsafe fn deref<'a>(ptr: usize) -> &'a Self;
 
     /// Mutably dereferences the given pointer.
@@ -174,11 +166,6 @@ pub trait Pointable {
     /// - `ptr` should not have yet been dropped by [`Pointable::drop`].
     /// - `ptr` should not be dereferenced by [`Pointable::deref`] or [`Pointable::deref_mut`]
     ///   concurrently.
-    ///
-    /// [`Pointable::init`]: trait.Pointable.html#method.init
-    /// [`Pointable::drop`]: trait.Pointable.html#method.drop
-    /// [`Pointable::deref`]: trait.Pointable.html#method.deref
-    /// [`Pointable::deref_mut`]: trait.Pointable.html#method.deref_mut
     unsafe fn deref_mut<'a>(ptr: usize) -> &'a mut Self;
 
     /// Drops the object pointed to by the given pointer.
@@ -189,11 +176,6 @@ pub trait Pointable {
     /// - `ptr` should not have yet been dropped by [`Pointable::drop`].
     /// - `ptr` should not be dereferenced by [`Pointable::deref`] or [`Pointable::deref_mut`]
     ///   concurrently.
-    ///
-    /// [`Pointable::init`]: trait.Pointable.html#method.init
-    /// [`Pointable::drop`]: trait.Pointable.html#method.drop
-    /// [`Pointable::deref`]: trait.Pointable.html#method.deref
-    /// [`Pointable::deref_mut`]: trait.Pointable.html#method.deref_mut
     unsafe fn drop(ptr: usize);
 }
 
@@ -290,9 +272,6 @@ impl<T> Pointable for [MaybeUninit<T>] {
 /// Any method that loads the pointer must be passed a reference to a [`Guard`].
 ///
 /// Crossbeam supports dynamically sized types.  See [`Pointable`] for details.
-///
-/// [`Guard`]: struct.Guard.html
-/// [`Pointable`]: trait.Pointable.html
 pub struct Atomic<T: ?Sized + Pointable> {
     data: AtomicUsize,
     _marker: PhantomData<*mut T>,
@@ -361,8 +340,6 @@ impl<T: ?Sized + Pointable> Atomic<T> {
     /// This method takes an [`Ordering`] argument which describes the memory ordering of this
     /// operation.
     ///
-    /// [`Ordering`]: https://doc.rust-lang.org/std/sync/atomic/enum.Ordering.html
-    ///
     /// # Examples
     ///
     /// ```
@@ -407,8 +384,6 @@ impl<T: ?Sized + Pointable> Atomic<T> {
     /// This method takes an [`Ordering`] argument which describes the memory ordering of this
     /// operation.
     ///
-    /// [`Ordering`]: https://doc.rust-lang.org/std/sync/atomic/enum.Ordering.html
-    ///
     /// # Examples
     ///
     /// ```
@@ -428,8 +403,6 @@ impl<T: ?Sized + Pointable> Atomic<T> {
     ///
     /// This method takes an [`Ordering`] argument which describes the memory ordering of this
     /// operation.
-    ///
-    /// [`Ordering`]: https://doc.rust-lang.org/std/sync/atomic/enum.Ordering.html
     ///
     /// # Examples
     ///
@@ -455,8 +428,6 @@ impl<T: ?Sized + Pointable> Atomic<T> {
     ///
     /// This method takes a [`CompareAndSetOrdering`] argument which describes the memory
     /// ordering of this operation.
-    ///
-    /// [`CompareAndSetOrdering`]: trait.CompareAndSetOrdering.html
     ///
     /// # Examples
     ///
@@ -506,8 +477,7 @@ impl<T: ?Sized + Pointable> Atomic<T> {
     /// This method takes a [`CompareAndSetOrdering`] argument which describes the memory
     /// ordering of this operation.
     ///
-    /// [`compare_and_set`]: struct.Atomic.html#method.compare_and_set
-    /// [`CompareAndSetOrdering`]: trait.CompareAndSetOrdering.html
+    /// [`compare_and_set`]: Atomic::compare_and_set
     ///
     /// # Examples
     ///
@@ -572,8 +542,6 @@ impl<T: ?Sized + Pointable> Atomic<T> {
     /// This method takes an [`Ordering`] argument which describes the memory ordering of this
     /// operation.
     ///
-    /// [`Ordering`]: https://doc.rust-lang.org/std/sync/atomic/enum.Ordering.html
-    ///
     /// # Examples
     ///
     /// ```
@@ -597,8 +565,6 @@ impl<T: ?Sized + Pointable> Atomic<T> {
     /// This method takes an [`Ordering`] argument which describes the memory ordering of this
     /// operation.
     ///
-    /// [`Ordering`]: https://doc.rust-lang.org/std/sync/atomic/enum.Ordering.html
-    ///
     /// # Examples
     ///
     /// ```
@@ -621,8 +587,6 @@ impl<T: ?Sized + Pointable> Atomic<T> {
     ///
     /// This method takes an [`Ordering`] argument which describes the memory ordering of this
     /// operation.
-    ///
-    /// [`Ordering`]: https://doc.rust-lang.org/std/sync/atomic/enum.Ordering.html
     ///
     /// # Examples
     ///
@@ -908,8 +872,6 @@ impl<T: ?Sized + Pointable> Owned<T> {
     /// let guard = &epoch::pin();
     /// let p = o.into_shared(guard);
     /// ```
-    ///
-    /// [`Shared`]: struct.Shared.html
     #[allow(clippy::needless_lifetimes)]
     pub fn into_shared<'g>(self, _: &'g Guard) -> Shared<'g, T> {
         unsafe { Shared::from_usize(self.into_usize()) }

--- a/crossbeam-epoch/src/guard.rs
+++ b/crossbeam-epoch/src/guard.rs
@@ -66,7 +66,7 @@ use crate::internal::Local;
 /// assert!(!epoch::is_pinned());
 /// ```
 ///
-/// [`pin`]: fn.pin.html
+/// [`pin`]: super::pin
 pub struct Guard {
     pub(crate) local: *const Local,
 }
@@ -87,8 +87,6 @@ impl Guard {
     ///
     /// If this method is called from an [`unprotected`] guard, the function will simply be
     /// executed immediately.
-    ///
-    /// [`unprotected`]: fn.unprotected.html
     pub fn defer<F, R>(&self, f: F)
     where
         F: FnOnce() -> R,
@@ -187,8 +185,6 @@ impl Guard {
     ///     }
     /// }
     /// ```
-    ///
-    /// [`unprotected`]: fn.unprotected.html
     pub unsafe fn defer_unchecked<F, R>(&self, f: F)
     where
         F: FnOnce() -> R,
@@ -268,8 +264,6 @@ impl Guard {
     ///     }
     /// }
     /// ```
-    ///
-    /// [`unprotected`]: fn.unprotected.html
     pub unsafe fn defer_destroy<T>(&self, ptr: Shared<'_, T>) {
         self.defer_unchecked(move || ptr.into_owned());
     }
@@ -294,8 +288,6 @@ impl Guard {
     /// });
     /// guard.flush();
     /// ```
-    ///
-    /// [`unprotected`]: fn.unprotected.html
     pub fn flush(&self) {
         if let Some(local) = unsafe { self.local.as_ref() } {
             local.flush(self);
@@ -329,8 +321,6 @@ impl Guard {
     ///     assert_eq!(unsafe { p.as_ref() }, Some(&777));
     /// }
     /// ```
-    ///
-    /// [`unprotected`]: fn.unprotected.html
     pub fn repin(&mut self) {
         if let Some(local) = unsafe { self.local.as_ref() } {
             local.repin();
@@ -367,8 +357,6 @@ impl Guard {
     ///     assert_eq!(unsafe { p.as_ref() }, Some(&777));
     /// }
     /// ```
-    ///
-    /// [`unprotected`]: fn.unprotected.html
     pub fn repin_after<F, R>(&mut self, f: F) -> R
     where
         F: FnOnce() -> R,
@@ -407,8 +395,6 @@ impl Guard {
     /// let guard2 = epoch::pin();
     /// assert!(guard1.collector() == guard2.collector());
     /// ```
-    ///
-    /// [`unprotected`]: fn.unprotected.html
     pub fn collector(&self) -> Option<&Collector> {
         unsafe { self.local.as_ref().map(|local| local.collector()) }
     }
@@ -512,8 +498,8 @@ impl fmt::Debug for Guard {
 /// }
 /// ```
 ///
-/// [`Atomic`]: struct.Atomic.html
-/// [`defer`]: struct.Guard.html#method.defer
+/// [`Atomic`]: super::Atomic
+/// [`defer`]: Guard::defer
 #[inline]
 pub unsafe fn unprotected() -> &'static Guard {
     // HACK(stjepang): An unprotected guard is just a `Guard` with its field `local` set to null.

--- a/crossbeam-epoch/src/lib.rs
+++ b/crossbeam-epoch/src/lib.rs
@@ -39,7 +39,7 @@
 //! pinned participants get unpinned. Such objects can be stored into a thread-local or global
 //! storage, where they are kept until the right time for their destruction comes.
 //!
-//! There is a global shared instance of garbage queue. You can [`defer`] the execution of an
+//! There is a global shared instance of garbage queue. You can [`defer`](Guard::defer) the execution of an
 //! arbitrary function until the global epoch is advanced enough. Most notably, concurrent data
 //! structures may defer the deallocation of an object.
 //!
@@ -47,12 +47,6 @@
 //!
 //! For majority of use cases, just use the default garbage collector by invoking [`pin`]. If you
 //! want to create your own garbage collector, use the [`Collector`] API.
-//!
-//! [`Atomic`]: struct.Atomic.html
-//! [`Collector`]: struct.Collector.html
-//! [`Shared`]: struct.Shared.html
-//! [`pin`]: fn.pin.html
-//! [`defer`]: struct.Guard.html#method.defer
 
 #![doc(test(
     no_crate_inject,

--- a/crossbeam-queue/src/array_queue.rs
+++ b/crossbeam-queue/src/array_queue.rs
@@ -36,7 +36,7 @@ struct Slot<T> {
 /// element into a full queue will fail. Having a buffer allocated upfront makes this queue a bit
 /// faster than [`SegQueue`].
 ///
-/// [`SegQueue`]: struct.SegQueue.html
+/// [`SegQueue`]: super::SegQueue
 ///
 /// # Examples
 ///

--- a/crossbeam-queue/src/lib.rs
+++ b/crossbeam-queue/src/lib.rs
@@ -4,9 +4,6 @@
 //!
 //! * [`ArrayQueue`], a bounded MPMC queue that allocates a fixed-capacity buffer on construction.
 //! * [`SegQueue`], an unbounded MPMC queue that allocates small buffers, segments, on demand.
-//!
-//! [`ArrayQueue`]: struct.ArrayQueue.html
-//! [`SegQueue`]: struct.SegQueue.html
 
 #![doc(test(
     no_crate_inject,

--- a/crossbeam-queue/src/seg_queue.rs
+++ b/crossbeam-queue/src/seg_queue.rs
@@ -116,7 +116,7 @@ struct Position<T> {
 /// at a time. However, since segments need to be dynamically allocated as elements get pushed,
 /// this queue is somewhat slower than [`ArrayQueue`].
 ///
-/// [`ArrayQueue`]: struct.ArrayQueue.html
+/// [`ArrayQueue`]: super::ArrayQueue
 ///
 /// # Examples
 ///

--- a/crossbeam-utils/src/lib.rs
+++ b/crossbeam-utils/src/lib.rs
@@ -17,14 +17,12 @@
 //! * [`CachePadded`], for padding and aligning a value to the length of a cache line.
 //! * [`scope`], for spawning threads that borrow local variables from the stack.
 //!
-//! [`AtomicCell`]: atomic/struct.AtomicCell.html
-//! [`AtomicConsume`]: atomic/trait.AtomicConsume.html
-//! [`Parker`]: sync/struct.Parker.html
-//! [`ShardedLock`]: sync/struct.ShardedLock.html
-//! [`WaitGroup`]: sync/struct.WaitGroup.html
-//! [`Backoff`]: struct.Backoff.html
-//! [`CachePadded`]: struct.CachePadded.html
-//! [`scope`]: thread/fn.scope.html
+//! [`AtomicCell`]: atomic::AtomicCell
+//! [`AtomicConsume`]: atomic::AtomicConsume
+//! [`Parker`]: sync::Parker
+//! [`ShardedLock`]: sync::ShardedLock
+//! [`WaitGroup`]: sync::WaitGroup
+//! [`scope`]: thread::scope
 
 #![doc(test(
     no_crate_inject,

--- a/crossbeam-utils/src/sync/mod.rs
+++ b/crossbeam-utils/src/sync/mod.rs
@@ -3,10 +3,6 @@
 //! * [`Parker`], a thread parking primitive.
 //! * [`ShardedLock`], a sharded reader-writer lock with fast concurrent reads.
 //! * [`WaitGroup`], for synchronizing the beginning or end of some computation.
-//!
-//! [`Parker`]: struct.Parker.html
-//! [`ShardedLock`]: struct.ShardedLock.html
-//! [`WaitGroup`]: struct.WaitGroup.html
 
 mod parker;
 mod sharded_lock;

--- a/crossbeam-utils/src/sync/sharded_lock.rs
+++ b/crossbeam-utils/src/sync/sharded_lock.rs
@@ -481,8 +481,6 @@ impl<T> From<T> for ShardedLock<T> {
 }
 
 /// A guard used to release the shared read access of a [`ShardedLock`] when dropped.
-///
-/// [`ShardedLock`]: struct.ShardedLock.html
 pub struct ShardedLockReadGuard<'a, T: ?Sized> {
     lock: &'a ShardedLock<T>,
     _guard: RwLockReadGuard<'a, ()>,
@@ -514,8 +512,6 @@ impl<T: ?Sized + fmt::Display> fmt::Display for ShardedLockReadGuard<'_, T> {
 }
 
 /// A guard used to release the exclusive write access of a [`ShardedLock`] when dropped.
-///
-/// [`ShardedLock`]: struct.ShardedLock.html
 pub struct ShardedLockWriteGuard<'a, T: ?Sized> {
     lock: &'a ShardedLock<T>,
     _marker: PhantomData<RwLockWriteGuard<'a, T>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,19 +28,15 @@
 //! * [`CachePadded`], for padding and aligning a value to the length of a cache line.
 //! * [`scope`], for spawning threads that borrow local variables from the stack.
 //!
-//! [`AtomicCell`]: atomic/struct.AtomicCell.html
-//! [`AtomicConsume`]: atomic/trait.AtomicConsume.html
-//! [`deque`]: deque/index.html
-//! [`ArrayQueue`]: queue/struct.ArrayQueue.html
-//! [`SegQueue`]: queue/struct.SegQueue.html
-//! [`channel`]: channel/index.html
-//! [`Parker`]: sync/struct.Parker.html
-//! [`ShardedLock`]: sync/struct.ShardedLock.html
-//! [`WaitGroup`]: sync/struct.WaitGroup.html
-//! [`epoch`]: epoch/index.html
-//! [`Backoff`]: utils/struct.Backoff.html
-//! [`CachePadded`]: utils/struct.CachePadded.html
-//! [`scope`]: fn.scope.html
+//! [`AtomicCell`]: atomic::AtomicCell
+//! [`AtomicConsume`]: atomic::AtomicConsume
+//! [`ArrayQueue`]: queue::ArrayQueue
+//! [`SegQueue`]: queue::SegQueue
+//! [`Parker`]: sync::Parker
+//! [`ShardedLock`]: sync::ShardedLock
+//! [`WaitGroup`]: sync::WaitGroup
+//! [`Backoff`]: utils::Backoff
+//! [`CachePadded`]: utils::CachePadded
 
 #![doc(test(
     no_crate_inject,


### PR DESCRIPTION
Switch to use [intra-doc links](https://github.com/rust-lang/rfcs/pull/1946) in all crates. Previously there was a big bug on cross crate re-exports (https://github.com/rust-lang/rust/issues/65983), but it has been fixed, so we can use this in crossbeam.

This also adds checks of the docs to CI.