### PR TITLE
Updates to `Parker`

### DIFF
--- a/crossbeam-utils/src/sync/mod.rs
+++ b/crossbeam-utils/src/sync/mod.rs
@@ -8,6 +8,6 @@ mod parker;
 mod sharded_lock;
 mod wait_group;
 
-pub use self::parker::{Parker, UnparkReason, Unparker};
+pub use self::parker::{Parker, Unparker};
 pub use self::sharded_lock::{ShardedLock, ShardedLockReadGuard, ShardedLockWriteGuard};
 pub use self::wait_group::WaitGroup;

--- a/crossbeam-utils/src/sync/mod.rs
+++ b/crossbeam-utils/src/sync/mod.rs
@@ -8,6 +8,6 @@ mod parker;
 mod sharded_lock;
 mod wait_group;
 
-pub use self::parker::{Parker, Unparker};
+pub use self::parker::{Parker, UnparkReason, Unparker};
 pub use self::sharded_lock::{ShardedLock, ShardedLockReadGuard, ShardedLockWriteGuard};
 pub use self::wait_group::WaitGroup;

--- a/crossbeam-utils/src/sync/parker.rs
+++ b/crossbeam-utils/src/sync/parker.rs
@@ -365,8 +365,9 @@ impl Inner {
             m = match deadline {
                 None => self.cvar.wait(m).unwrap(),
                 Some(deadline) => match deadline.checked_duration_since(Instant::now()) {
-                    // We could check for a timeout here, but in the case that a timeout and an
-                    // unpark arrive simultaneously, we prefer to report the former.
+                    // We could check for a timeout here, in the return value of wait_timeout,
+                    // but in the case that a timeout and an unpark arrive simultaneously, we
+                    // prefer to report the former.
                     Some(duration) if duration > Duration::from_secs(0) => {
                         self.cvar.wait_timeout(m, duration).unwrap().0
                     }

--- a/crossbeam-utils/src/sync/parker.rs
+++ b/crossbeam-utils/src/sync/parker.rs
@@ -1,9 +1,9 @@
+use std::fmt;
 use std::marker::PhantomData;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::SeqCst;
 use std::sync::{Arc, Condvar, Mutex};
-use std::time::Duration;
-use std::{fmt, time::Instant};
+use std::time::{Duration, Instant};
 
 /// A thread parking primitive.
 ///

--- a/crossbeam-utils/tests/parker.rs
+++ b/crossbeam-utils/tests/parker.rs
@@ -2,7 +2,7 @@ use std::thread::sleep;
 use std::time::Duration;
 use std::u32;
 
-use crossbeam_utils::sync::{Parker, UnparkReason};
+use crossbeam_utils::sync::Parker;
 use crossbeam_utils::thread;
 
 #[test]
@@ -10,10 +10,7 @@ fn park_timeout_unpark_before() {
     let p = Parker::new();
     for _ in 0..10 {
         p.unparker().unpark();
-        assert_eq!(
-            p.park_timeout(Duration::from_millis(u32::MAX as u64)),
-            UnparkReason::Unparked,
-        );
+        p.park_timeout(Duration::from_millis(u32::MAX as u64));
     }
 }
 
@@ -21,10 +18,7 @@ fn park_timeout_unpark_before() {
 fn park_timeout_unpark_not_called() {
     let p = Parker::new();
     for _ in 0..10 {
-        assert_eq!(
-            p.park_timeout(Duration::from_millis(10)),
-            UnparkReason::Timeout,
-        );
+        p.park_timeout(Duration::from_millis(10))
     }
 }
 
@@ -40,10 +34,7 @@ fn park_timeout_unpark_called_other_thread() {
                 u.unpark();
             });
 
-            assert_eq!(
-                p.park_timeout(Duration::from_millis(u32::MAX as u64)),
-                UnparkReason::Unparked,
-            );
+            p.park_timeout(Duration::from_millis(u32::MAX as u64))
         })
         .unwrap();
     }


### PR DESCRIPTION
- No longer a possibility for a spurious wake (previously possible if using a timeout), and removed references to spurious wake in the documentation.
- Implementation updates to `park`: now deadline based, and unified the code paths between timeout and no-timeout versions
- **Breaking Change** `park_timeout` and `park_deadline` now report the reason for their return (timeout or `unpark`) in an enum.

If you'd rather not have this breaking change, I'm happy to revert that side of it and just focus on the spurious awakening prevention stuff.

Fixes #482 