### PR TITLE
ci: Do not install cargo-tree from crates.io

### DIFF
--- a/ci/dependencies.sh
+++ b/ci/dependencies.sh
@@ -3,10 +3,6 @@
 cd "$(dirname "$0")"/..
 set -ex
 
-if [[ ! -x "$(command -v cargo-tree)" ]]; then
-    cargo install --debug cargo-tree || exit 1
-fi
-
 cargo tree
 cargo tree --duplicate
 cargo tree --duplicate || exit 1


### PR DESCRIPTION
`cargo tree` subcommand is available by default since Rust 1.44.