### PR TITLE
Port select2.go test to Rust

### DIFF
--- a/crossbeam-channel/tests/golang.rs
+++ b/crossbeam-channel/tests/golang.rs
@@ -9,9 +9,11 @@
 //!   - https://golang.org/LICENSE
 //!   - https://golang.org/PATENTS
 
+use std::alloc::{GlobalAlloc, Layout, System};
 use std::any::Any;
 use std::cell::Cell;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 use std::time::Duration;
@@ -164,6 +166,27 @@ impl<F: FnOnce()> Drop for Defer<F> {
         f();
     }
 }
+
+struct Counter;
+
+static ALLOCATED: AtomicUsize = AtomicUsize::new(0);
+unsafe impl GlobalAlloc for Counter {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ret = System.alloc(layout);
+        if !ret.is_null() {
+            ALLOCATED.fetch_add(layout.size(), SeqCst);
+        }
+        return ret;
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout);
+        ALLOCATED.fetch_sub(layout.size(), SeqCst);
+    }
+}
+
+#[global_allocator]
+static A: Counter = Counter;
 
 macro_rules! defer {
     ($body:expr) => {
@@ -667,29 +690,6 @@ mod select {
 // https://github.com/golang/go/blob/master/test/chan/select2.go
 mod select2 {
     use super::*;
-    use std::alloc::{GlobalAlloc, Layout, System};
-    use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
-
-    struct Counter;
-
-    static ALLOCATED: AtomicUsize = AtomicUsize::new(0);
-    unsafe impl GlobalAlloc for Counter {
-        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-            let ret = System.alloc(layout);
-            if !ret.is_null() {
-                ALLOCATED.fetch_add(layout.size(), SeqCst);
-            }
-            return ret;
-        }
-
-        unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-            System.dealloc(ptr, layout);
-            ALLOCATED.fetch_sub(layout.size(), SeqCst);
-        }
-    }
-
-    #[global_allocator]
-    static A: Counter = Counter;
 
     #[test]
     fn main() {

--- a/crossbeam-channel/tests/golang.rs
+++ b/crossbeam-channel/tests/golang.rs
@@ -16,7 +16,7 @@ use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 use std::time::Duration;
 
-use crossbeam_channel::{bounded, unbounded, select, tick, Receiver, Select, Sender};
+use crossbeam_channel::{bounded, select, tick, unbounded, Receiver, Select, Sender};
 
 fn ms(ms: u64) -> Duration {
     Duration::from_millis(ms)
@@ -667,7 +667,7 @@ mod select {
 // https://github.com/golang/go/blob/master/test/chan/select2.go
 mod select2 {
     use super::*;
-    use std::alloc::{System, GlobalAlloc, Layout};
+    use std::alloc::{GlobalAlloc, Layout, System};
     use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 
     struct Counter;
@@ -679,9 +679,9 @@ mod select2 {
             if !ret.is_null() {
                 ALLOCATED.fetch_add(layout.size(), SeqCst);
             }
-            return ret
+            return ret;
         }
-    
+
         unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
             System.dealloc(ptr, layout);
             ALLOCATED.fetch_sub(layout.size(), SeqCst);
@@ -716,7 +716,7 @@ mod select2 {
         let dummy = make_unbounded::<i32>();
 
         ALLOCATED.store(0, SeqCst);
-        
+
         go!(c, sender(&c, 100000));
         receiver(&c, &dummy, 100000);
 


### PR DESCRIPTION
A port of select2.go to Rust. Select2 tests for excess memory usage by the select statement. The original go test uses memstats.alloc within the "runtime" package  to determine the net number of bytes allocated on the heap. I used a wrapper around alloc::System to achieve a similar behavior for the Rust port.

I also added make_unbounded() to initialize unbounded channels the go way.

#201 