### PR TITLE
Bump master to 1.0 and mark as 'publish = false'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-X.Y.Z" git tag
-version = "0.7.3"
+version = "1.0.0"
 authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -16,6 +16,7 @@ description = "Tools for concurrent programming"
 keywords = ["atomic", "garbage", "non-blocking", "lock-free", "rcu"]
 categories = ["concurrency", "memory-management", "data-structures", "no-std"]
 exclude = ["/ci/*", "/bors.toml"]
+publish = false # blocked on https://github.com/crossbeam-rs/crossbeam/issues/503
 
 [features]
 default = ["std"]
@@ -45,31 +46,31 @@ nightly = ["crossbeam-epoch/nightly", "crossbeam-utils/nightly", "crossbeam-queu
 cfg-if = "1"
 
 [dependencies.crossbeam-channel]
-version = "0.4"
+version = "1"
 path = "./crossbeam-channel"
 default-features = false
 optional = true
 
 [dependencies.crossbeam-deque]
-version = "0.7.0"
+version = "1"
 path = "./crossbeam-deque"
 default-features = false
 optional = true
 
 [dependencies.crossbeam-epoch]
-version = "0.8"
+version = "1"
 path = "./crossbeam-epoch"
 default-features = false
 optional = true
 
 [dependencies.crossbeam-queue]
-version = "0.2"
+version = "1"
 path = "./crossbeam-queue"
 default-features = false
 optional = true
 
 [dependencies.crossbeam-utils]
-version = "0.7"
+version = "1"
 path = "./crossbeam-utils"
 default-features = false
 

--- a/crossbeam-channel/Cargo.toml
+++ b/crossbeam-channel/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-channel"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-channel-X.Y.Z" git tag
-version = "0.4.3"
+version = "1.0.0"
 authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -15,6 +15,7 @@ documentation = "https://docs.rs/crossbeam-channel"
 description = "Multi-producer multi-consumer channels for message passing"
 keywords = ["channel", "mpmc", "select", "golang", "message"]
 categories = ["algorithms", "concurrency", "data-structures"]
+publish = false # blocked on https://github.com/crossbeam-rs/crossbeam/issues/503
 
 [features]
 default = ["std"]
@@ -27,7 +28,7 @@ std = ["crossbeam-utils/std"]
 cfg-if = "1"
 
 [dependencies.crossbeam-utils]
-version = "0.7"
+version = "1"
 path = "../crossbeam-utils"
 default-features = false
 optional = true

--- a/crossbeam-deque/Cargo.toml
+++ b/crossbeam-deque/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-deque"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-deque-X.Y.Z" git tag
-version = "0.7.3"
+version = "1.0.0"
 authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -15,6 +15,7 @@ documentation = "https://docs.rs/crossbeam-deque"
 description = "Concurrent work-stealing deque"
 keywords = ["chase-lev", "lock-free", "scheduler", "scheduling"]
 categories = ["algorithms", "concurrency", "data-structures"]
+publish = false # blocked on https://github.com/crossbeam-rs/crossbeam/issues/503
 
 [features]
 default = ["std"]
@@ -27,13 +28,13 @@ std = ["crossbeam-epoch/std", "crossbeam-utils/std"]
 cfg-if = "1"
 
 [dependencies.crossbeam-epoch]
-version = "0.8"
+version = "1"
 path = "../crossbeam-epoch"
 default-features = false
 optional = true
 
 [dependencies.crossbeam-utils]
-version = "0.7"
+version = "1"
 path = "../crossbeam-utils"
 default-features = false
 optional = true

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-epoch"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-epoch-X.Y.Z" git tag
-version = "0.8.2"
+version = "1.0.0"
 authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -15,6 +15,7 @@ documentation = "https://docs.rs/crossbeam-epoch"
 description = "Epoch-based garbage collection"
 keywords = ["lock-free", "rcu", "atomic", "garbage"]
 categories = ["concurrency", "memory-management", "no-std"]
+publish = false # blocked on https://github.com/crossbeam-rs/crossbeam/issues/503
 
 [features]
 default = ["std"]
@@ -42,7 +43,7 @@ const_fn = "0.4"
 memoffset = "0.5.4"
 
 [dependencies.crossbeam-utils]
-version = "0.7"
+version = "1"
 path = "../crossbeam-utils"
 default-features = false
 

--- a/crossbeam-queue/Cargo.toml
+++ b/crossbeam-queue/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-queue"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-queue-X.Y.Z" git tag
-version = "0.2.2"
+version = "1.0.0"
 authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT AND BSD-2-Clause OR Apache-2.0 AND BSD-2-Clause"
@@ -15,6 +15,7 @@ documentation = "https://docs.rs/crossbeam-queue"
 description = "Concurrent queues"
 keywords = ["queue", "mpmc", "lock-free", "producer", "consumer"]
 categories = ["concurrency", "data-structures"]
+publish = false # blocked on https://github.com/crossbeam-rs/crossbeam/issues/503
 
 [features]
 default = ["std"]
@@ -37,7 +38,7 @@ nightly = ["crossbeam-utils/nightly"]
 cfg-if = "1"
 
 [dependencies.crossbeam-utils]
-version = "0.7"
+version = "1"
 path = "../crossbeam-utils"
 default-features = false
 

--- a/crossbeam-skiplist/Cargo.toml
+++ b/crossbeam-skiplist/Cargo.toml
@@ -37,13 +37,13 @@ nightly = ["crossbeam-epoch/nightly", "crossbeam-utils/nightly"]
 cfg-if = "1"
 
 [dependencies.crossbeam-epoch]
-version = "0.8"
+version = "1"
 path = "../crossbeam-epoch"
 default-features = false
 optional = true
 
 [dependencies.crossbeam-utils]
-version = "0.7"
+version = "1"
 path = "../crossbeam-utils"
 default-features = false
 

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-utils"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-utils-X.Y.Z" git tag
-version = "0.7.2"
+version = "1.0.0"
 authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -15,6 +15,7 @@ documentation = "https://docs.rs/crossbeam-utils"
 description = "Utilities for concurrent programming"
 keywords = ["scoped", "thread", "atomic", "cache"]
 categories = ["algorithms", "concurrency", "data-structures", "no-std"]
+publish = false # blocked on https://github.com/crossbeam-rs/crossbeam/issues/503
 
 [features]
 default = ["std"]


### PR DESCRIPTION
The current master branch contains breaking changes, but in the past, we've accidentally published a crate from master several times (https://github.com/crossbeam-rs/crossbeam/pull/537#issuecomment-687755200), and I had to yank each time.

This patch prevents releases from being accidentally created from the master branch by marking all crates as 'publish = false'.

Also, this bumps the master branch's version number to 1.0 (that should be the next major version we release). (The actual 1.0 release is blocked on #503.)

