### PR TITLE
Fix UB in destroy_array test

### DIFF
--- a/crossbeam-epoch/src/collector.rs
+++ b/crossbeam-epoch/src/collector.rs
@@ -383,7 +383,7 @@ mod tests {
             let ptr = v.as_mut_ptr() as usize;
             let len = v.len();
             guard.defer_unchecked(move || {
-                drop(Vec::from_raw_parts(ptr as *const u8 as *mut u8, len, len));
+                drop(Vec::from_raw_parts(ptr as *const i32 as *mut i32, len, len));
                 DESTROYS.fetch_add(len, Ordering::Relaxed);
             });
             guard.flush();


### PR DESCRIPTION
Reportrd by Miri in #578 ([log](https://github.com/crossbeam-rs/crossbeam/runs/1232029543?check_suite_focus=true))

https://github.com/crossbeam-rs/crossbeam/blob/e08b21cc086fc42af0e9927a68bc3120bee87af5/crossbeam-epoch/src/collector.rs#L378-L388

`ptr` is a pointer to `Vec<i32>`, but deallocated as `Vec<u8>`.