### PR TITLE
Prepare for the next release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Version 0.8.0
+
+- Bump the minimum supported Rust version to 1.36.
+- Bump `crossbeam-channel` to `0.5`.
+- Bump `crossbeam-deque` to `0.8`.
+- Bump `crossbeam-epoch` to `0.9`.
+- Bump `crossbeam-queue` to `0.3`.
+- Bump `crossbeam-utils` to `0.8`.
+
 # Version 0.7.3
 
 - Fix breakage with nightly feature due to rust-lang/rust#65214.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-X.Y.Z" git tag
-version = "0.7.3"
+version = "0.8.0"
 authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -45,31 +45,31 @@ nightly = ["crossbeam-epoch/nightly", "crossbeam-utils/nightly", "crossbeam-queu
 cfg-if = "1"
 
 [dependencies.crossbeam-channel]
-version = "0.4"
+version = "0.5"
 path = "./crossbeam-channel"
 default-features = false
 optional = true
 
 [dependencies.crossbeam-deque]
-version = "0.7.0"
+version = "0.8"
 path = "./crossbeam-deque"
 default-features = false
 optional = true
 
 [dependencies.crossbeam-epoch]
-version = "0.8"
+version = "0.9"
 path = "./crossbeam-epoch"
 default-features = false
 optional = true
 
 [dependencies.crossbeam-queue]
-version = "0.2"
+version = "0.3"
 path = "./crossbeam-queue"
 default-features = false
 optional = true
 
 [dependencies.crossbeam-utils]
-version = "0.7"
+version = "0.8"
 path = "./crossbeam-utils"
 default-features = false
 

--- a/crossbeam-channel/CHANGELOG.md
+++ b/crossbeam-channel/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Version 0.5.0
+
+- Bump the minimum supported Rust version to 1.36.
+- Add `at()` function.
+- Add `Sender::send_deadline()` and `Receiver::recv_deadline()` methods.
+- Add `Select::select_deadline()` and `Select::ready_deadline()` methods.
+- Add `std` (enabled by default) feature for forward compatibility.
+- Allow `select!` macro compile with `forbid(unsafe_code)`.
+
 # Version 0.4.4
 
 - Fix bug in release (yanking 0.4.3)

--- a/crossbeam-channel/Cargo.toml
+++ b/crossbeam-channel/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-channel"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-channel-X.Y.Z" git tag
-version = "0.4.3"
+version = "0.5.0"
 authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -27,7 +27,7 @@ std = ["crossbeam-utils/std"]
 cfg-if = "1"
 
 [dependencies.crossbeam-utils]
-version = "0.7"
+version = "0.8"
 path = "../crossbeam-utils"
 default-features = false
 optional = true

--- a/crossbeam-deque/CHANGELOG.md
+++ b/crossbeam-deque/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 0.8.0
+
+- Bump the minimum supported Rust version to 1.36.
+- Add `Worker::len()` and `Injector::len()` methods.
+- Add `std` (enabled by default) feature for forward compatibility.
+
 # Version 0.7.3
 
 - Stop stealing from the same deque. (#448)

--- a/crossbeam-deque/Cargo.toml
+++ b/crossbeam-deque/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-deque"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-deque-X.Y.Z" git tag
-version = "0.7.3"
+version = "0.8.0"
 authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -27,13 +27,13 @@ std = ["crossbeam-epoch/std", "crossbeam-utils/std"]
 cfg-if = "1"
 
 [dependencies.crossbeam-epoch]
-version = "0.8"
+version = "0.9"
 path = "../crossbeam-epoch"
 default-features = false
 optional = true
 
 [dependencies.crossbeam-utils]
-version = "0.7"
+version = "0.8"
 path = "../crossbeam-utils"
 default-features = false
 optional = true

--- a/crossbeam-epoch/CHANGELOG.md
+++ b/crossbeam-epoch/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 0.9.0
+
+- Bump the minimum supported Rust version to 1.36.
+- Support dynamically sized types.
+
 # Version 0.8.2
 
 - Fix bug in release (yanking 0.8.1)

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-epoch"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-epoch-X.Y.Z" git tag
-version = "0.8.2"
+version = "0.9.0"
 authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -42,7 +42,7 @@ const_fn = "0.4"
 memoffset = "0.5.4"
 
 [dependencies.crossbeam-utils]
-version = "0.7"
+version = "0.8"
 path = "../crossbeam-utils"
 default-features = false
 

--- a/crossbeam-queue/CHANGELOG.md
+++ b/crossbeam-queue/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 0.3.0
+
+- Bump the minimum supported Rust version to 1.36.
+- Remove `PushError` and `PopError`.
+
 # Version 0.2.3
 
 - Fix bug in release (yanking 0.2.2)

--- a/crossbeam-queue/Cargo.toml
+++ b/crossbeam-queue/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-queue"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-queue-X.Y.Z" git tag
-version = "0.2.2"
+version = "0.3.0"
 authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT AND BSD-2-Clause OR Apache-2.0 AND BSD-2-Clause"
@@ -37,7 +37,7 @@ nightly = ["crossbeam-utils/nightly"]
 cfg-if = "1"
 
 [dependencies.crossbeam-utils]
-version = "0.7"
+version = "0.8"
 path = "../crossbeam-utils"
 default-features = false
 

--- a/crossbeam-skiplist/Cargo.toml
+++ b/crossbeam-skiplist/Cargo.toml
@@ -37,13 +37,13 @@ nightly = ["crossbeam-epoch/nightly", "crossbeam-utils/nightly"]
 cfg-if = "1"
 
 [dependencies.crossbeam-epoch]
-version = "0.8"
+version = "0.9"
 path = "../crossbeam-epoch"
 default-features = false
 optional = true
 
 [dependencies.crossbeam-utils]
-version = "0.7"
+version = "0.8"
 path = "../crossbeam-utils"
 default-features = false
 

--- a/crossbeam-utils/CHANGELOG.md
+++ b/crossbeam-utils/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Version 0.8.0
+
+- Bump the minimum supported Rust version to 1.36.
+- Remove deprecated `AtomicCell::get_mut()` and `Backoff::is_complete()` methods
+- Remove `alloc` feature.
+- Make `CachePadded::new()` const function.
+- Make `AtomicCell::is_lock_free()` const function at 1.46+.
+- Implement `From<T>` for `AtomicCell<T>`.
+
 # Version 0.7.2
 
 - Fix bug in release (yanking 0.7.1)

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-utils"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-utils-X.Y.Z" git tag
-version = "0.7.2"
+version = "0.8.0"
 authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
- crossbeam-channel 0.4.4 -> 0.5.0
- crossbeam-deque 0.7.3 -> 0.8.0
- crossbeam-epoch 0.8.2 -> 0.9.0
- crossbeam-queue 0.2.3 -> 0.3.0
- crossbeam-utils 0.7.2 -> 0.8.0
- crossbeam 0.7.3 -> 0.8.0

Replaces #576

