### PR TITLE
Get rid of the hack for epoch::unprotected

### DIFF
--- a/crossbeam-epoch/src/guard.rs
+++ b/crossbeam-epoch/src/guard.rs
@@ -502,12 +502,10 @@ impl fmt::Debug for Guard {
 /// [`defer`]: Guard::defer
 #[inline]
 pub unsafe fn unprotected() -> &'static Guard {
-    // HACK(stjepang): An unprotected guard is just a `Guard` with its field `local` set to null.
-    // Since this function returns a `'static` reference to a `Guard`, we must return a reference
-    // to a global guard. However, it's not possible to create a `static` `Guard` because it does
-    // not implement `Sync`. To get around the problem, we create a static `usize` initialized to
-    // zero and then transmute it into a `Guard`. This is safe because `usize` and `Guard`
-    // (consisting of a single pointer) have the same representation in memory.
-    static UNPROTECTED: usize = 0;
-    &*(&UNPROTECTED as *const _ as *const Guard)
+    // An unprotected guard is just a `Guard` with its field `local` set to null.
+    // The static needs to be a `static mut` because `Guard` isn't `Sync`
+    static mut UNPROTECTED: Guard = Guard {
+        local: std::ptr::null(),
+    };
+    &UNPROTECTED
 }


### PR DESCRIPTION
Noticed that this hack isn't necessary (anymore?); originally had a newtype over `Guard` that I implemented `Sync` for, and then I realized that a `static mut` works as well.
