### PR TITLE
Relaxed size constrait of Local (closes #597)

### DIFF
--- a/crossbeam-epoch/src/internal.rs
+++ b/crossbeam-epoch/src/internal.rs
@@ -376,7 +376,7 @@ pub struct Local {
 // https://github.com/crossbeam-rs/crossbeam/issues/551
 #[test]
 fn local_size() {
-    assert_eq!(2040, core::mem::size_of::<Local>());
+    assert!(core::mem::size_of::<Local>() <= 2040, "An allocation of `Local` should be <= 2048 bytes.");
 }
 
 impl Local {

--- a/crossbeam-epoch/src/internal.rs
+++ b/crossbeam-epoch/src/internal.rs
@@ -376,7 +376,7 @@ pub struct Local {
 // https://github.com/crossbeam-rs/crossbeam/issues/551
 #[test]
 fn local_size() {
-    assert!(core::mem::size_of::<Local>() <= 2040, "An allocation of `Local` should be <= 2048 bytes.");
+    assert!(core::mem::size_of::<Local>() <= 2048, "An allocation of `Local` should be <= 2048 bytes.");
 }
 
 impl Local {


### PR DESCRIPTION
@decathorpe Thank you for reporting this.  It's also kinda hotfix.  As @taiki-e said, we really need CI for i686 and other 32-bit architectures... (#598).

r? @taiki-e 