### PR TITLE
Make AtomicCell::is_lock_free always const fn

### DIFF
--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -31,7 +31,6 @@ nightly = []
 
 [dependencies]
 cfg-if = "1"
-const_fn = "0.4"
 lazy_static = { version = "1.4.0", optional = true }
 
 [build-dependencies]
@@ -39,4 +38,3 @@ autocfg = "1.0.0"
 
 [dev-dependencies]
 rand = "0.7.3"
-rustversion = "1.0"

--- a/crossbeam-utils/tests/atomic_cell.rs
+++ b/crossbeam-utils/tests/atomic_cell.rs
@@ -22,11 +22,10 @@ fn is_lock_free() {
     assert_eq!(AtomicCell::<u128>::is_lock_free(), cfg!(has_atomic_u128));
 }
 
-#[rustversion::since(1.46)]
 #[test]
 fn const_is_lock_free() {
-    const _: bool = AtomicCell::<usize>::is_lock_free();
-    const _: bool = AtomicCell::<isize>::is_lock_free();
+    const _U: bool = AtomicCell::<usize>::is_lock_free();
+    const _I: bool = AtomicCell::<isize>::is_lock_free();
 }
 
 #[test]


### PR DESCRIPTION
`if` expression can only be used in const fn since Rust 1.46, so const `is_lock_free` was require Rust 1.46 (context: #531, #546).
However, when we replace uses of `if` expression with `|` and `&` operators, it seems `is_lock_free` can be used as const fn even in Rust 1.36.

r? @jeehoonkang or @Vtec234 