### PR TITLE
Prepare for the next release

### DIFF
--- a/crossbeam-epoch/CHANGELOG.md
+++ b/crossbeam-epoch/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.9.1
+
+- Bump `memoffset` dependency to version 0.6. (#592)
+
 # Version 0.9.0
 
 - Bump the minimum supported Rust version to 1.36.

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-epoch"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-epoch-X.Y.Z" git tag
-version = "0.9.0"
+version = "0.9.1"
 authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-queue/CHANGELOG.md
+++ b/crossbeam-queue/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 0.3.1
+
+- Make `SegQueue::new` const fn. (#584)
+- Change license to "MIT OR Apache-2.0".
+
 # Version 0.3.0
 
 - Bump the minimum supported Rust version to 1.36.

--- a/crossbeam-queue/Cargo.toml
+++ b/crossbeam-queue/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-queue"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-queue-X.Y.Z" git tag
-version = "0.3.0"
+version = "0.3.1"
 authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-utils/CHANGELOG.md
+++ b/crossbeam-utils/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Version 0.8.1
+
+- Make `AtomicCell::is_lock_free` always const fn. (#600)
+- Fix a bug in `seq_lock_wide`. (#596)
+- Remove `const_fn` dependency. (#600)
+- `crossbeam-utils` no longer fails to compile if unable to determine rustc version. Instead, it now displays a warning. (#604)
+
 # Version 0.8.0
 
 - Bump the minimum supported Rust version to 1.36.

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-utils"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-utils-X.Y.Z" git tag
-version = "0.8.0"
+version = "0.8.1"
 authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
- crossbeam-epoch 0.9.0 -> 0.9.1
- crossbeam-queue 0.3.0 -> 0.3.1
- crossbeam-utils 0.8.0 -> 0.8.1

Since the previous release, there have been some improvements, including bug fixes. I think it makes sense to create new releases.

r? @jeehoonkang @Vtec234 