### PR TITLE
Make const_fn crate optional dependency

### DIFF
--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -31,14 +31,14 @@ alloc = []
 # This is disabled by default and requires recent nightly compiler.
 # Note that this is outside of the normal semver guarantees and minor versions
 # of crossbeam may make breaking changes to them at any time.
-nightly = ["crossbeam-utils/nightly"]
+nightly = ["crossbeam-utils/nightly", "const_fn"]
 
 # TODO: docs
 sanitize = [] # Makes it more likely to trigger any potential data races.
 
 [dependencies]
 cfg-if = "1"
-const_fn = "0.4"
+const_fn = { version = "0.4.4", optional = true }
 memoffset = "0.6"
 
 [dependencies.crossbeam-utils]

--- a/crossbeam-epoch/src/atomic.rs
+++ b/crossbeam-epoch/src/atomic.rs
@@ -10,7 +10,6 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 use crate::alloc::alloc;
 use crate::alloc::boxed::Box;
 use crate::guard::Guard;
-use const_fn::const_fn;
 use crossbeam_utils::atomic::AtomicConsume;
 
 /// Given ordering for the success case in a compare-exchange operation, returns the strongest
@@ -327,8 +326,8 @@ impl<T: ?Sized + Pointable> Atomic<T> {
     /// let a = Atomic::<i32>::null();
     /// ```
     ///
-    #[const_fn(feature = "nightly")]
-    pub const fn null() -> Atomic<T> {
+    #[cfg_attr(feature = "nightly", const_fn::const_fn)]
+    pub fn null() -> Atomic<T> {
         Self {
             data: AtomicUsize::new(0),
             _marker: PhantomData,
@@ -1370,5 +1369,12 @@ mod tests {
     #[test]
     fn valid_tag_i64() {
         Shared::<i64>::null().with_tag(7);
+    }
+
+    #[cfg(feature = "nightly")]
+    #[test]
+    fn const_atomic_null() {
+        use super::Atomic;
+        const _: Atomic<u8> = Atomic::<u8>::null();
     }
 }


### PR DESCRIPTION
This dependency is only actually used for the nightly feature.