### PR TITLE
Deprecate AtomicCell::compare_and_swap

### DIFF
--- a/crossbeam-utils/benches/atomic_cell.rs
+++ b/crossbeam-utils/benches/atomic_cell.rs
@@ -28,11 +28,11 @@ fn fetch_add_u8(b: &mut test::Bencher) {
 }
 
 #[bench]
-fn compare_and_swap_u8(b: &mut test::Bencher) {
+fn compare_exchange_u8(b: &mut test::Bencher) {
     let a = AtomicCell::new(0u8);
     let mut i = 0;
     b.iter(|| {
-        a.compare_and_swap(i, i.wrapping_add(1));
+        let _ = a.compare_exchange(i, i.wrapping_add(1));
         i = i.wrapping_add(1);
     });
 }
@@ -102,11 +102,11 @@ fn fetch_add_usize(b: &mut test::Bencher) {
 }
 
 #[bench]
-fn compare_and_swap_usize(b: &mut test::Bencher) {
+fn compare_exchange_usize(b: &mut test::Bencher) {
     let a = AtomicCell::new(0usize);
     let mut i = 0;
     b.iter(|| {
-        a.compare_and_swap(i, i.wrapping_add(1));
+        let _ = a.compare_exchange(i, i.wrapping_add(1));
         i = i.wrapping_add(1);
     });
 }

--- a/crossbeam-utils/src/atomic/atomic_cell.rs
+++ b/crossbeam-utils/src/atomic/atomic_cell.rs
@@ -213,6 +213,7 @@ impl<T: Copy + Eq> AtomicCell<T> {
     /// # Examples
     ///
     /// ```
+    /// # #![allow(deprecated)]
     /// use crossbeam_utils::atomic::AtomicCell;
     ///
     /// let a = AtomicCell::new(1);
@@ -223,6 +224,7 @@ impl<T: Copy + Eq> AtomicCell<T> {
     /// assert_eq!(a.compare_and_swap(1, 2), 1);
     /// assert_eq!(a.load(), 2);
     /// ```
+    #[deprecated(note = "Use `compare_exchange` instead")]
     pub fn compare_and_swap(&self, current: T, new: T) -> T {
         match self.compare_exchange(current, new) {
             Ok(v) => v,


### PR DESCRIPTION
The standard library deprecated `compare_and_swap` in favor of `compare_exchange(_weak)` in 1.50. (rust-lang/rust#79261)

Given why std `compare_and_swap` was deprecated, it probably makes sense to do the same with `AtomicCell::compare_and_swap`.

Closes #618