### PR TITLE
bors: set delete_merged_branches = true

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,1 +1,2 @@
+delete_merged_branches = true
 status = ["ci"]


### PR DESCRIPTION
https://bors.tech/documentation

> If set to true, and if the PR branch is on the same repository that bors-ng itself is on, the branch will be deleted.