### PR TITLE
Add list of main items to docs of utils and atomic modules

### DIFF
--- a/crossbeam-utils/src/atomic/mod.rs
+++ b/crossbeam-utils/src/atomic/mod.rs
@@ -1,4 +1,7 @@
 //! Atomic types.
+//!
+//! * [`AtomicCell`], a thread-safe mutable memory location.
+//! * [`AtomicConsume`], for reading from primitive atomic types with "consume" ordering.
 
 #[cfg(not(loom_crossbeam))]
 use cfg_if::cfg_if;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,8 +59,12 @@
 #[cfg_attr(feature = "nightly", cfg(target_has_atomic = "ptr"))]
 pub use crossbeam_utils::atomic;
 
-/// Miscellaneous utilities.
 pub mod utils {
+    //! Miscellaneous utilities.
+    //!
+    //! * [`Backoff`], for exponential backoff in spin loops.
+    //! * [`CachePadded`], for padding and aligning a value to the length of a cache line.
+
     pub use crossbeam_utils::Backoff;
     pub use crossbeam_utils::CachePadded;
 }


### PR DESCRIPTION
Both [`sync`](https://docs.rs/crossbeam/0.8.0/crossbeam/sync/index.html) and [`queue`](https://docs.rs/crossbeam/0.8.0/crossbeam/queue/index.html) modules have similar docs.
