### PR TITLE
Fix CachePadded test

### DIFF
--- a/crossbeam-utils/tests/cache_padded.rs
+++ b/crossbeam-utils/tests/cache_padded.rs
@@ -27,7 +27,9 @@ fn distance() {
     let arr = [CachePadded::new(17u8), CachePadded::new(37u8)];
     let a = &*arr[0] as *const u8;
     let b = &*arr[1] as *const u8;
-    assert!(unsafe { a.offset(64) } <= b);
+    let align = mem::align_of::<CachePadded<()>>();
+    assert!(align >= 32);
+    assert_eq!(unsafe { a.add(align) }, b);
 }
 
 #[test]


### PR DESCRIPTION
This test fails on architectures that use 32-byte alignment as assuming the alignment of `CachePadded` is 64+.

https://github.com/crossbeam-rs/crossbeam/blob/a66fe72b224e0864f66360778d611a06c7234771/crossbeam-utils/tests/cache_padded.rs#L25-L31