### PR TITLE
Add macOS to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,8 @@ jobs:
             os: windows-latest
           - rust: nightly
             os: ubuntu-latest
-          # TODO: https://github.com/crossbeam-rs/crossbeam/pull/518#issuecomment-633342606
-          # - rust: nightly
-          #   os: macos-latest
+          - rust: nightly
+            os: macos-latest
           - rust: nightly
             os: windows-latest
           - rust: nightly

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -13,11 +13,11 @@ fi
 
 # Otherwise, run tests and checks with the host target.
 cargo check --all --bins --examples --tests --exclude benchmarks
-cargo test --all --exclude benchmarks -- --test-threads=1
+cargo test --all --exclude benchmarks --no-fail-fast -- --test-threads=1
 
 if [[ "$RUST_VERSION" == "nightly"* ]]; then
     # Some crates have `nightly` feature, so run tests with --all-features.
-    cargo test --all --all-features --exclude benchmarks -- --test-threads=1
+    cargo test --all --all-features --exclude benchmarks --no-fail-fast -- --test-threads=1
 
     # Benchmarks are only checked on nightly because depending on unstable features.
     cargo check --all --benches


### PR DESCRIPTION
Currently, 1/4~1/3 tests in crossbeam-channel are ignored due to time-related assertions failed due to GitHub Actions' macOS runner is slow.