### PR TITLE
Ignore deprecated warnings on spin_loop_hint

### DIFF
--- a/crossbeam-utils/src/backoff.rs
+++ b/crossbeam-utils/src/backoff.rs
@@ -145,6 +145,9 @@ impl Backoff {
     #[inline]
     pub fn spin(&self) {
         for _ in 0..1 << self.step.get().min(SPIN_LIMIT) {
+            // TODO(taiki-e): once we bump the minimum required Rust version to 1.49+,
+            // use [`core::hint::spin_loop`] instead.
+            #[allow(deprecated)]
             atomic::spin_loop_hint();
         }
 
@@ -205,11 +208,17 @@ impl Backoff {
     pub fn snooze(&self) {
         if self.step.get() <= SPIN_LIMIT {
             for _ in 0..1 << self.step.get() {
+                // TODO(taiki-e): once we bump the minimum required Rust version to 1.49+,
+                // use [`core::hint::spin_loop`] instead.
+                #[allow(deprecated)]
                 atomic::spin_loop_hint();
             }
         } else {
             #[cfg(not(feature = "std"))]
             for _ in 0..1 << self.step.get() {
+                // TODO(taiki-e): once we bump the minimum required Rust version to 1.49+,
+                // use [`core::hint::spin_loop`] instead.
+                #[allow(deprecated)]
                 atomic::spin_loop_hint();
             }
 

--- a/crossbeam-utils/src/lib.rs
+++ b/crossbeam-utils/src/lib.rs
@@ -68,6 +68,9 @@ mod primitive {
     pub(crate) mod sync {
         pub(crate) mod atomic {
             pub(crate) use core::sync::atomic::compiler_fence;
+            // TODO(taiki-e): once we bump the minimum required Rust version to 1.49+,
+            // use [`core::hint::spin_loop`] instead.
+            #[allow(deprecated)]
             pub(crate) use core::sync::atomic::spin_loop_hint;
             pub(crate) use core::sync::atomic::{AtomicBool, AtomicIsize, AtomicUsize};
             #[cfg(has_atomic_u16)]


### PR DESCRIPTION
`spin_loop_hint` is deprecated in 1.51. (rust-lang/rust#80966)

However, the alternative (`hint::spin_loop`) requires Rust 1.49+, so ignore deprecated warnings for now.