### PR TITLE
Add `#![doc(html_root_url)]` to all crates

### DIFF
--- a/crossbeam-channel/src/lib.rs
+++ b/crossbeam-channel/src/lib.rs
@@ -328,6 +328,7 @@
         allow(dead_code, unused_assignments, unused_variables)
     )
 ))]
+#![doc(html_root_url = "https://docs.rs/crossbeam-channel/0.5.0")]
 #![warn(
     missing_docs,
     missing_debug_implementations,

--- a/crossbeam-deque/src/lib.rs
+++ b/crossbeam-deque/src/lib.rs
@@ -89,6 +89,7 @@
         allow(dead_code, unused_assignments, unused_variables)
     )
 ))]
+#![doc(html_root_url = "https://docs.rs/crossbeam-deque/0.8.0")]
 #![warn(
     missing_docs,
     missing_debug_implementations,

--- a/crossbeam-epoch/src/lib.rs
+++ b/crossbeam-epoch/src/lib.rs
@@ -55,6 +55,7 @@
         allow(dead_code, unused_assignments, unused_variables)
     )
 ))]
+#![doc(html_root_url = "https://docs.rs/crossbeam-epoch/0.9.1")]
 #![warn(
     missing_docs,
     missing_debug_implementations,

--- a/crossbeam-queue/src/lib.rs
+++ b/crossbeam-queue/src/lib.rs
@@ -12,6 +12,7 @@
         allow(dead_code, unused_assignments, unused_variables)
     )
 ))]
+#![doc(html_root_url = "https://docs.rs/crossbeam-queue/0.3.1")]
 #![warn(
     missing_docs,
     missing_debug_implementations,

--- a/crossbeam-skiplist/src/lib.rs
+++ b/crossbeam-skiplist/src/lib.rs
@@ -7,6 +7,7 @@
         allow(dead_code, unused_assignments, unused_variables)
     )
 ))]
+#![doc(html_root_url = "https://docs.rs/crossbeam-skiplist/0.0.0")]
 #![warn(
     missing_docs,
     missing_debug_implementations,

--- a/crossbeam-utils/src/lib.rs
+++ b/crossbeam-utils/src/lib.rs
@@ -31,6 +31,7 @@
         allow(dead_code, unused_assignments, unused_variables)
     )
 ))]
+#![doc(html_root_url = "https://docs.rs/crossbeam-utils/0.8.1")]
 #![warn(
     missing_docs,
     missing_debug_implementations,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@
         allow(dead_code, unused_assignments, unused_variables)
     )
 ))]
+#![doc(html_root_url = "https://docs.rs/crossbeam/0.8.0")]
 #![warn(
     missing_docs,
     missing_debug_implementations,


### PR DESCRIPTION
It enables external crates' documentation to link to `crossbeam`'s one.