### PR TITLE
Rename cfg(loom_crossbeam) to cfg(crossbeam_loom)

### DIFF
--- a/ci/crossbeam-epoch-loom.sh
+++ b/ci/crossbeam-epoch-loom.sh
@@ -3,7 +3,7 @@
 cd "$(dirname "$0")"/../crossbeam-epoch
 set -ex
 
-export RUSTFLAGS="-D warnings --cfg loom_crossbeam --cfg crossbeam_sanitize"
+export RUSTFLAGS="-D warnings --cfg crossbeam_loom --cfg crossbeam_sanitize"
 
 # With MAX_PREEMPTIONS=2 the loom tests (currently) take around 11m.
 # If we were to run with =3, they would take several times that,

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -41,7 +41,7 @@ memoffset = "0.6"
 #
 # This configuration option is outside of the normal semver guarantees: minor
 # versions of crossbeam may make breaking changes to it at any time.
-[target.'cfg(loom_crossbeam)'.dependencies]
+[target.'cfg(crossbeam_loom)'.dependencies]
 loom = "0.4"
 
 [dependencies.crossbeam-utils]

--- a/crossbeam-epoch/src/atomic.rs
+++ b/crossbeam-epoch/src/atomic.rs
@@ -339,7 +339,7 @@ impl<T: ?Sized + Pointable> Atomic<T> {
     /// let a = Atomic::<i32>::null();
     /// ```
     ///
-    #[cfg_attr(all(feature = "nightly", not(loom_crossbeam)), const_fn::const_fn)]
+    #[cfg_attr(all(feature = "nightly", not(crossbeam_loom)), const_fn::const_fn)]
     pub fn null() -> Atomic<T> {
         Self {
             data: AtomicUsize::new(0),
@@ -794,14 +794,14 @@ impl<T: ?Sized + Pointable> Atomic<T> {
     /// }
     /// ```
     pub unsafe fn into_owned(self) -> Owned<T> {
-        #[cfg(loom_crossbeam)]
+        #[cfg(crossbeam_loom)]
         {
             // FIXME: loom does not yet support into_inner, so we use unsync_load for now,
             // which should have the same synchronization properties:
             // https://github.com/tokio-rs/loom/issues/117
             Owned::from_usize(self.data.unsync_load())
         }
-        #[cfg(not(loom_crossbeam))]
+        #[cfg(not(crossbeam_loom))]
         {
             Owned::from_usize(self.data.into_inner())
         }
@@ -1524,7 +1524,7 @@ impl<T: ?Sized + Pointable> Default for Shared<'_, T> {
     }
 }
 
-#[cfg(all(test, not(loom_crossbeam)))]
+#[cfg(all(test, not(crossbeam_loom)))]
 mod tests {
     use super::Shared;
 

--- a/crossbeam-epoch/src/collector.rs
+++ b/crossbeam-epoch/src/collector.rs
@@ -14,9 +14,9 @@
 /// ```
 use core::fmt;
 
-use crate::primitive::sync::Arc;
 use crate::guard::Guard;
 use crate::internal::{Global, Local};
+use crate::primitive::sync::Arc;
 
 /// An epoch-based garbage collector.
 pub struct Collector {
@@ -109,7 +109,7 @@ impl fmt::Debug for LocalHandle {
     }
 }
 
-#[cfg(all(test, not(loom_crossbeam)))]
+#[cfg(all(test, not(crossbeam_loom)))]
 mod tests {
     use std::mem;
     use std::sync::atomic::{AtomicUsize, Ordering};

--- a/crossbeam-epoch/src/default.rs
+++ b/crossbeam-epoch/src/default.rs
@@ -5,8 +5,8 @@
 //! destructed on thread exit, which in turn unregisters the thread.
 
 use crate::collector::{Collector, LocalHandle};
-use crate::primitive::{lazy_static, thread_local};
 use crate::guard::Guard;
+use crate::primitive::{lazy_static, thread_local};
 
 lazy_static! {
     /// The global data for the default garbage collector.
@@ -45,7 +45,7 @@ where
         .unwrap_or_else(|_| f(&COLLECTOR.register()))
 }
 
-#[cfg(all(test, not(loom_crossbeam)))]
+#[cfg(all(test, not(crossbeam_loom)))]
 mod tests {
     use crossbeam_utils::thread;
 

--- a/crossbeam-epoch/src/deferred.rs
+++ b/crossbeam-epoch/src/deferred.rs
@@ -79,7 +79,7 @@ impl Deferred {
     }
 }
 
-#[cfg(all(test, not(loom_crossbeam)))]
+#[cfg(all(test, not(crossbeam_loom)))]
 mod tests {
     use super::Deferred;
     use std::cell::Cell;

--- a/crossbeam-epoch/src/internal.rs
+++ b/crossbeam-epoch/src/internal.rs
@@ -625,7 +625,7 @@ impl IsElement<Local> for Local {
     }
 }
 
-#[cfg(all(test, not(loom_crossbeam)))]
+#[cfg(all(test, not(crossbeam_loom)))]
 mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 

--- a/crossbeam-epoch/src/lib.rs
+++ b/crossbeam-epoch/src/lib.rs
@@ -67,7 +67,7 @@
 
 use cfg_if::cfg_if;
 
-#[cfg(loom_crossbeam)]
+#[cfg(crossbeam_loom)]
 #[allow(unused_imports, dead_code)]
 mod primitive {
     pub(crate) mod cell {
@@ -102,7 +102,7 @@ mod primitive {
     pub(crate) use loom::lazy_static;
     pub(crate) use loom::thread_local;
 }
-#[cfg(not(loom_crossbeam))]
+#[cfg(not(crossbeam_loom))]
 #[allow(unused_imports, dead_code)]
 mod primitive {
     #[cfg(any(feature = "alloc", feature = "std"))]

--- a/crossbeam-epoch/src/sync/list.rs
+++ b/crossbeam-epoch/src/sync/list.rs
@@ -295,7 +295,7 @@ impl<'g, T: 'g, C: IsElement<T>> Iterator for Iter<'g, T, C> {
     }
 }
 
-#[cfg(all(test, not(loom_crossbeam)))]
+#[cfg(all(test, not(crossbeam_loom)))]
 mod tests {
     use super::*;
     use crate::{Collector, Owned};

--- a/crossbeam-epoch/src/sync/queue.rs
+++ b/crossbeam-epoch/src/sync/queue.rs
@@ -215,7 +215,7 @@ impl<T> Drop for Queue<T> {
     }
 }
 
-#[cfg(all(test, not(loom_crossbeam)))]
+#[cfg(all(test, not(crossbeam_loom)))]
 mod test {
     use super::*;
     use crate::pin;

--- a/crossbeam-epoch/tests/loom.rs
+++ b/crossbeam-epoch/tests/loom.rs
@@ -1,4 +1,4 @@
-#![cfg(loom_crossbeam)]
+#![cfg(crossbeam_loom)]
 
 use crossbeam_epoch as epoch;
 

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -36,7 +36,7 @@ lazy_static = { version = "1.4.0", optional = true }
 #
 # This configuration option is outside of the normal semver guarantees: minor
 # versions of crossbeam may make breaking changes to it at any time.
-[target.'cfg(loom_crossbeam)'.dependencies]
+[target.'cfg(crossbeam_loom)'.dependencies]
 loom = "0.4"
 
 [build-dependencies]

--- a/crossbeam-utils/src/atomic/atomic_cell.rs
+++ b/crossbeam-utils/src/atomic/atomic_cell.rs
@@ -8,13 +8,13 @@ use core::fmt;
 use core::mem;
 use core::sync::atomic::Ordering;
 
-#[cfg(not(loom_crossbeam))]
+#[cfg(not(crossbeam_loom))]
 use core::ptr;
 
 #[cfg(feature = "std")]
 use std::panic::{RefUnwindSafe, UnwindSafe};
 
-#[cfg(not(loom_crossbeam))]
+#[cfg(not(crossbeam_loom))]
 use super::seq_lock::SeqLock;
 
 /// A thread-safe mutable memory location.
@@ -499,23 +499,23 @@ macro_rules! impl_arithmetic {
 
 #[cfg(has_atomic_u8)]
 impl_arithmetic!(u8, atomic::AtomicU8, "let a = AtomicCell::new(7u8);");
-#[cfg(all(has_atomic_u8, not(loom_crossbeam)))]
+#[cfg(all(has_atomic_u8, not(crossbeam_loom)))]
 impl_arithmetic!(i8, atomic::AtomicI8, "let a = AtomicCell::new(7i8);");
 #[cfg(has_atomic_u16)]
 impl_arithmetic!(u16, atomic::AtomicU16, "let a = AtomicCell::new(7u16);");
-#[cfg(all(has_atomic_u16, not(loom_crossbeam)))]
+#[cfg(all(has_atomic_u16, not(crossbeam_loom)))]
 impl_arithmetic!(i16, atomic::AtomicI16, "let a = AtomicCell::new(7i16);");
 #[cfg(has_atomic_u32)]
 impl_arithmetic!(u32, atomic::AtomicU32, "let a = AtomicCell::new(7u32);");
-#[cfg(all(has_atomic_u32, not(loom_crossbeam)))]
+#[cfg(all(has_atomic_u32, not(crossbeam_loom)))]
 impl_arithmetic!(i32, atomic::AtomicI32, "let a = AtomicCell::new(7i32);");
 #[cfg(has_atomic_u64)]
 impl_arithmetic!(u64, atomic::AtomicU64, "let a = AtomicCell::new(7u64);");
-#[cfg(all(has_atomic_u64, not(loom_crossbeam)))]
+#[cfg(all(has_atomic_u64, not(crossbeam_loom)))]
 impl_arithmetic!(i64, atomic::AtomicI64, "let a = AtomicCell::new(7i64);");
-#[cfg(all(has_atomic_u128, not(loom_crossbeam)))]
+#[cfg(all(has_atomic_u128, not(crossbeam_loom)))]
 impl_arithmetic!(u128, atomic::AtomicU128, "let a = AtomicCell::new(7u128);");
-#[cfg(all(has_atomic_u128, not(loom_crossbeam)))]
+#[cfg(all(has_atomic_u128, not(crossbeam_loom)))]
 impl_arithmetic!(i128, atomic::AtomicI128, "let  a = AtomicCell::new(7i128);");
 
 impl_arithmetic!(
@@ -523,7 +523,7 @@ impl_arithmetic!(
     atomic::AtomicUsize,
     "let a = AtomicCell::new(7usize);"
 );
-#[cfg(not(loom_crossbeam))]
+#[cfg(not(crossbeam_loom))]
 impl_arithmetic!(
     isize,
     atomic::AtomicIsize,
@@ -632,7 +632,7 @@ const fn can_transmute<A, B>() -> bool {
 /// scalability.
 #[inline]
 #[must_use]
-#[cfg(not(loom_crossbeam))]
+#[cfg(not(crossbeam_loom))]
 fn lock(addr: usize) -> &'static SeqLock {
     // The number of locks is a prime number because we want to make sure `addr % LEN` gets
     // dispersed across all locks.
@@ -820,9 +820,9 @@ macro_rules! atomic {
             #[cfg(has_atomic_u128)]
             atomic!(@check, $t, atomic::AtomicU128, $a, $atomic_op);
 
-            #[cfg(loom_crossbeam)]
+            #[cfg(crossbeam_loom)]
             unimplemented!("loom does not support non-atomic atomic ops");
-            #[cfg(not(loom_crossbeam))]
+            #[cfg(not(crossbeam_loom))]
             break $fallback_op;
         }
     };

--- a/crossbeam-utils/src/atomic/consume.rs
+++ b/crossbeam-utils/src/atomic/consume.rs
@@ -53,7 +53,7 @@ macro_rules! impl_atomic {
             type Val = $val;
             impl_consume!();
         }
-        #[cfg(loom_crossbeam)]
+        #[cfg(crossbeam_loom)]
         impl AtomicConsume for ::loom::sync::atomic::$atomic {
             type Val = $val;
             impl_consume!();
@@ -63,7 +63,7 @@ macro_rules! impl_atomic {
 
 impl_atomic!(AtomicBool, bool);
 impl_atomic!(AtomicUsize, usize);
-#[cfg(not(loom_crossbeam))]
+#[cfg(not(crossbeam_loom))]
 impl_atomic!(AtomicIsize, isize);
 #[cfg(has_atomic_u8)]
 impl_atomic!(AtomicU8, u8);
@@ -87,7 +87,7 @@ impl<T> AtomicConsume for ::core::sync::atomic::AtomicPtr<T> {
     impl_consume!();
 }
 
-#[cfg(loom_crossbeam)]
+#[cfg(crossbeam_loom)]
 impl<T> AtomicConsume for ::loom::sync::atomic::AtomicPtr<T> {
     type Val = *mut T;
     impl_consume!();

--- a/crossbeam-utils/src/atomic/mod.rs
+++ b/crossbeam-utils/src/atomic/mod.rs
@@ -3,10 +3,10 @@
 //! * [`AtomicCell`], a thread-safe mutable memory location.
 //! * [`AtomicConsume`], for reading from primitive atomic types with "consume" ordering.
 
-#[cfg(not(loom_crossbeam))]
+#[cfg(not(crossbeam_loom))]
 use cfg_if::cfg_if;
 
-#[cfg(not(loom_crossbeam))]
+#[cfg(not(crossbeam_loom))]
 cfg_if! {
     // Use "wide" sequence lock if the pointer width <= 32 for preventing its counter against wrap
     // around.

--- a/crossbeam-utils/src/lib.rs
+++ b/crossbeam-utils/src/lib.rs
@@ -40,7 +40,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]
 
-#[cfg(loom_crossbeam)]
+#[cfg(crossbeam_loom)]
 #[allow(unused_imports)]
 mod primitive {
     pub(crate) mod sync {
@@ -60,7 +60,7 @@ mod primitive {
         pub(crate) use loom::sync::{Arc, Condvar, Mutex};
     }
 }
-#[cfg(not(loom_crossbeam))]
+#[cfg(not(crossbeam_loom))]
 #[allow(unused_imports)]
 mod primitive {
     pub(crate) mod sync {
@@ -109,7 +109,7 @@ cfg_if! {
     if #[cfg(feature = "std")] {
         pub mod sync;
 
-        #[cfg(not(loom_crossbeam))]
+        #[cfg(not(crossbeam_loom))]
         pub mod thread;
     }
 }

--- a/crossbeam-utils/src/sync/mod.rs
+++ b/crossbeam-utils/src/sync/mod.rs
@@ -5,11 +5,11 @@
 //! * [`WaitGroup`], for synchronizing the beginning or end of some computation.
 
 mod parker;
-#[cfg(not(loom_crossbeam))]
+#[cfg(not(crossbeam_loom))]
 mod sharded_lock;
 mod wait_group;
 
 pub use self::parker::{Parker, Unparker};
-#[cfg(not(loom_crossbeam))]
+#[cfg(not(crossbeam_loom))]
 pub use self::sharded_lock::{ShardedLock, ShardedLockReadGuard, ShardedLockWriteGuard};
 pub use self::wait_group::WaitGroup;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,9 +90,9 @@ cfg_if! {
 
         pub use crossbeam_utils::sync;
 
-        #[cfg(not(loom_crossbeam))]
+        #[cfg(not(crossbeam_loom))]
         pub use crossbeam_utils::thread;
-        #[cfg(not(loom_crossbeam))]
+        #[cfg(not(crossbeam_loom))]
         pub use crossbeam_utils::thread::scope;
     }
 }


### PR DESCRIPTION
It matches with the convention that *will* be documented in `loom`. See https://github.com/crossbeam-rs/crossbeam/pull/487#issuecomment-753800120 for more.

r? @jeehoonkang @jonhoo 