### PR TITLE
Prepare for the next release

### DIFF
--- a/crossbeam-epoch/CHANGELOG.md
+++ b/crossbeam-epoch/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Version 0.9.2
+
+- Add `Atomic::compare_exchange` and `Atomic::compare_exchange_weak`. (#628)
+- Deprecate `Atomic::compare_and_set` and `Atomic::compare_and_set_weak`. Use `Atomic::compare_exchange` or `Atomic::compare_exchange_weak` instead. (#628)
+- Make `const_fn` dependency optional. (#611)
+- Add unstable support for `loom`. (#487)
+
 # Version 0.9.1
 
 - Bump `memoffset` dependency to version 0.6. (#592)

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-epoch"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-epoch-X.Y.Z" git tag
-version = "0.9.1"
+version = "0.9.2"
 authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-skiplist/Cargo.toml
+++ b/crossbeam-skiplist/Cargo.toml
@@ -36,7 +36,7 @@ nightly = ["crossbeam-epoch/nightly", "crossbeam-utils/nightly"]
 cfg-if = "1"
 
 [dependencies.crossbeam-epoch]
-version = "0.9"
+version = "0.9.2"
 path = "../crossbeam-epoch"
 default-features = false
 optional = true

--- a/crossbeam-utils/CHANGELOG.md
+++ b/crossbeam-utils/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Version 0.8.2
+
+- Deprecate `AtomicCell::compare_and_swap`. Use `AtomicCell::compare_exchange` instead. (#619)
+- Add `Parker::park_deadline`. (#563)
+- Improve implementation of `CachePadded`. (#636)
+- Add unstable support for `loom`. (#487)
+
 # Version 0.8.1
 
 - Make `AtomicCell::is_lock_free` always const fn. (#600)
@@ -8,7 +15,7 @@
 # Version 0.8.0
 
 - Bump the minimum supported Rust version to 1.36.
-- Remove deprecated `AtomicCell::get_mut()` and `Backoff::is_complete()` methods
+- Remove deprecated `AtomicCell::get_mut()` and `Backoff::is_complete()` methods.
 - Remove `alloc` feature.
 - Make `CachePadded::new()` const function.
 - Make `AtomicCell::is_lock_free()` const function at 1.46+.

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-utils"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-utils-X.Y.Z" git tag
-version = "0.8.1"
+version = "0.8.2"
 authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
It's been over two months since the previous release. There are some improvements and deprecations in the master branch, and it would be nice to release them. Also, there is no breaking change that needs a major version bump.

Changes:

- crossbeam-epoch 0.9.1 -> 0.9.2
  - Add `Atomic::compare_exchange` and `Atomic::compare_exchange_weak`. (#628)
  - Deprecate `Atomic::compare_and_set` and `Atomic::compare_and_set_weak`. (#628)
  - Make `const_fn` dependency optional. (#611)
  - Add unstable support for `loom`. (#487)
- crossbeam-utils 0.8.1 -> 0.8.2
  - Deprecate `AtomicCell::compare_and_swap`. (#619)
  - Add `Parker::park_deadline`. (#563)
  - Improve implementation of `CachePadded`. (#636)
  - Add unstable support for `loom`. (#487)
