### PR TITLE
Revert "bors: set delete_merged_branches = true"

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,2 +1,1 @@
-delete_merged_branches = true
 status = ["ci"]


### PR DESCRIPTION
This reverts commit c9f244573c4d3ab8ba76367156aec1d446c835d8.

If GitHub's "Automatically delete head branches" setting is enabled,
"delete_merged_branches = true" setting is actually not needed.