### PR TITLE
Add Covariance To Some Type Paramaters

### DIFF
--- a/crossbeam-deque/src/deque.rs
+++ b/crossbeam-deque/src/deque.rs
@@ -29,7 +29,7 @@ const FLUSH_THRESHOLD_BYTES: usize = 1 << 10;
 /// *not* deallocate the buffer.
 struct Buffer<T> {
     /// Pointer to the allocated memory.
-    ptr: *mut T,
+    ptr: *const T,
 
     /// Capacity of the buffer. Always a power of two.
     cap: usize,
@@ -51,13 +51,13 @@ impl<T> Buffer<T> {
 
     /// Deallocates the buffer.
     unsafe fn dealloc(self) {
-        drop(Vec::from_raw_parts(self.ptr, 0, self.cap));
+        drop(Vec::from_raw_parts(self.ptr as *mut T, 0, self.cap));
     }
 
     /// Returns a pointer to the task at the specified `index`.
     unsafe fn at(&self, index: isize) -> *mut T {
         // `self.cap` is always a power of two.
-        self.ptr.offset(index & (self.cap - 1) as isize)
+        self.ptr.offset(index & (self.cap - 1) as isize) as *mut _
     }
 
     /// Writes `task` into the specified `index`.

--- a/crossbeam-epoch/src/atomic.rs
+++ b/crossbeam-epoch/src/atomic.rs
@@ -286,7 +286,7 @@ impl<T> Pointable for [MaybeUninit<T>] {
 /// Crossbeam supports dynamically sized types.  See [`Pointable`] for details.
 pub struct Atomic<T: ?Sized + Pointable> {
     data: AtomicUsize,
-    _marker: PhantomData<*mut T>,
+    _marker: PhantomData<*const T>,
 }
 
 unsafe impl<T: ?Sized + Pointable + Send + Sync> Send for Atomic<T> {}


### PR DESCRIPTION
crossbeam_epoc::Atomic<T>, crossbeam_deque::Worker<T> & crossbeam_deque::Stealer<T>: Covariance Over T

At my understanding, covariance is okay because Atomic<T>, Worker<T>, and Stealer<T> all appear to use owning pointers. Owning pointers such as Box<T> can safely be covariant over T. Don't take my word for this though.