### PR TITLE
Make loom dependency optional

### DIFF
--- a/ci/crossbeam-epoch-loom.sh
+++ b/ci/crossbeam-epoch-loom.sh
@@ -8,4 +8,4 @@ export RUSTFLAGS="-D warnings --cfg crossbeam_loom --cfg crossbeam_sanitize"
 # With MAX_PREEMPTIONS=2 the loom tests (currently) take around 11m.
 # If we were to run with =3, they would take several times that,
 # which is probably too costly for CI.
-env LOOM_MAX_PREEMPTIONS=2 cargo test --test loom --release -- --nocapture
+env LOOM_MAX_PREEMPTIONS=2 cargo test --test loom --release --features loom -- --nocapture

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -32,6 +32,12 @@ alloc = []
 # of crossbeam may make breaking changes to them at any time.
 nightly = ["crossbeam-utils/nightly", "const_fn"]
 
+# Enable the use of loom for concurrency testing.
+#
+# This configuration option is outside of the normal semver guarantees: minor
+# versions of crossbeam may make breaking changes to it at any time.
+loom = ["loom-crate", "crossbeam-utils/loom"]
+
 [dependencies]
 cfg-if = "1"
 const_fn = { version = "0.4.4", optional = true }
@@ -42,7 +48,7 @@ memoffset = "0.6"
 # This configuration option is outside of the normal semver guarantees: minor
 # versions of crossbeam may make breaking changes to it at any time.
 [target.'cfg(crossbeam_loom)'.dependencies]
-loom = "0.4"
+loom-crate = { package = "loom", version = "0.4", optional = true }
 
 [dependencies.crossbeam-utils]
 version = "0.8"

--- a/crossbeam-epoch/src/lib.rs
+++ b/crossbeam-epoch/src/lib.rs
@@ -65,6 +65,9 @@
 #![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]
 #![cfg_attr(feature = "nightly", feature(const_fn))]
 
+#[cfg(crossbeam_loom)]
+extern crate loom_crate as loom;
+
 use cfg_if::cfg_if;
 
 #[cfg(crossbeam_loom)]

--- a/crossbeam-epoch/tests/loom.rs
+++ b/crossbeam-epoch/tests/loom.rs
@@ -1,6 +1,7 @@
 #![cfg(crossbeam_loom)]
 
 use crossbeam_epoch as epoch;
+use loom_crate as loom;
 
 use epoch::*;
 use epoch::{Atomic, Owned};

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -37,7 +37,7 @@ lazy_static = { version = "1.4.0", optional = true }
 # This configuration option is outside of the normal semver guarantees: minor
 # versions of crossbeam may make breaking changes to it at any time.
 [target.'cfg(crossbeam_loom)'.dependencies]
-loom = "0.4"
+loom = { version = "0.4", optional = true }
 
 [build-dependencies]
 autocfg = "1.0.0"


### PR DESCRIPTION
The loom dependency will never compile unless users enable cfg, but the way cargo and crates.io handle cfg-ed dependencies is not very good and confuses users.

This issue seems to work around by the way proposed by @matklad in https://github.com/crossbeam-rs/crossbeam/pull/487#issuecomment-783385606.
So this PR uses that workaround.

Closes #665

r? @jeehoonkang @jonhoo 