### PR TITLE
Prepare for the next release

### DIFF
--- a/crossbeam-epoch/CHANGELOG.md
+++ b/crossbeam-epoch/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.9.3
+
+- Make `loom` dependency optional. (#666)
+
 # Version 0.9.2
 
 - Add `Atomic::compare_exchange` and `Atomic::compare_exchange_weak`. (#628)

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-epoch"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-epoch-X.Y.Z" git tag
-version = "0.9.2"
+version = "0.9.3"
 authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -51,7 +51,7 @@ memoffset = "0.6"
 loom-crate = { package = "loom", version = "0.4", optional = true }
 
 [dependencies.crossbeam-utils]
-version = "0.8"
+version = "0.8.3"
 path = "../crossbeam-utils"
 default-features = false
 

--- a/crossbeam-utils/CHANGELOG.md
+++ b/crossbeam-utils/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.8.3
+
+- Make `loom` dependency optional. (#666)
+
 # Version 0.8.2
 
 - Deprecate `AtomicCell::compare_and_swap`. Use `AtomicCell::compare_exchange` instead. (#619)

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-utils"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-utils-X.Y.Z" git tag
-version = "0.8.2"
+version = "0.8.3"
 authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Changes:

- crossbeam-epoch 0.9.2 -> 0.9.3
  - Make `loom` dependency optional. (#666)
- crossbeam-utils 0.8.2 -> 0.8.3
  - Make `loom` dependency optional. (#666)