### PR TITLE
Fix two memory leaks in crossbeam-skiplist

### DIFF
--- a/crossbeam-skiplist/src/base.rs
+++ b/crossbeam-skiplist/src/base.rs
@@ -1123,9 +1123,8 @@ where
                             break;
                         }
                     }
-
-                    return Some(entry);
                 }
+                return Some(entry);
             }
         }
     }


### PR DESCRIPTION
Closes #671. Closes #672.

The first one is like https://github.com/crossbeam-rs/crossbeam/commit/a6de0ca23b5364d2acc876f6e3d74cb8ab4d7b4a, but the previous commit missed fixing `RefRange`.

The second problem is that `remove` increases the ref count but not returning the entry when the tower is not marked by the current thread. So the leak should be fixed if we always return the entry once the ref count is increased.