### PR TITLE
Fix discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ https://crates.io/crates/crossbeam)
 https://docs.rs/crossbeam)
 [![Rust 1.36+](https://img.shields.io/badge/rust-1.36+-lightgray.svg)](
 https://www.rust-lang.org)
-[![chat](https://img.shields.io/discord/569610676205781012.svg?logo=discord)](https://discordapp.com/invite/JXYwgWZ)
+[![chat](https://img.shields.io/discord/569610676205781012.svg?logo=discord)](https://discord.com/invite/JXYwgWZ)
 
 This crate provides a set of tools for concurrent programming:
 

--- a/crossbeam-channel/README.md
+++ b/crossbeam-channel/README.md
@@ -10,7 +10,7 @@ https://crates.io/crates/crossbeam-channel)
 https://docs.rs/crossbeam-channel)
 [![Rust 1.36+](https://img.shields.io/badge/rust-1.36+-lightgray.svg)](
 https://www.rust-lang.org)
-[![chat](https://img.shields.io/discord/569610676205781012.svg?logo=discord)](https://discord.gg/BBYwKq)
+[![chat](https://img.shields.io/discord/569610676205781012.svg?logo=discord)](https://discord.com/invite/JXYwgWZ)
 
 This crate provides multi-producer multi-consumer channels for message passing.
 It is an alternative to [`std::sync::mpsc`] with more features and better performance.

--- a/crossbeam-deque/README.md
+++ b/crossbeam-deque/README.md
@@ -10,7 +10,7 @@ https://crates.io/crates/crossbeam-deque)
 https://docs.rs/crossbeam-deque)
 [![Rust 1.36+](https://img.shields.io/badge/rust-1.36+-lightgray.svg)](
 https://www.rust-lang.org)
-[![chat](https://img.shields.io/discord/569610676205781012.svg?logo=discord)](https://discord.gg/BBYwKq)
+[![chat](https://img.shields.io/discord/569610676205781012.svg?logo=discord)](https://discord.com/invite/JXYwgWZ)
 
 This crate provides work-stealing deques, which are primarily intended for
 building task schedulers.

--- a/crossbeam-epoch/README.md
+++ b/crossbeam-epoch/README.md
@@ -10,7 +10,7 @@ https://crates.io/crates/crossbeam-epoch)
 https://docs.rs/crossbeam-epoch)
 [![Rust 1.36+](https://img.shields.io/badge/rust-1.36+-lightgray.svg)](
 https://www.rust-lang.org)
-[![chat](https://img.shields.io/discord/569610676205781012.svg?logo=discord)](https://discord.gg/BBYwKq)
+[![chat](https://img.shields.io/discord/569610676205781012.svg?logo=discord)](https://discord.com/invite/JXYwgWZ)
 
 This crate provides epoch-based garbage collection for building concurrent data structures.
 

--- a/crossbeam-queue/README.md
+++ b/crossbeam-queue/README.md
@@ -10,7 +10,7 @@ https://crates.io/crates/crossbeam-queue)
 https://docs.rs/crossbeam-queue)
 [![Rust 1.36+](https://img.shields.io/badge/rust-1.36+-lightgray.svg)](
 https://www.rust-lang.org)
-[![chat](https://img.shields.io/discord/569610676205781012.svg?logo=discord)](https://discord.gg/BBYwKq)
+[![chat](https://img.shields.io/discord/569610676205781012.svg?logo=discord)](https://discord.com/invite/JXYwgWZ)
 
 This crate provides concurrent queues that can be shared among threads:
 

--- a/crossbeam-skiplist/README.md
+++ b/crossbeam-skiplist/README.md
@@ -10,7 +10,7 @@ https://crates.io/crates/crossbeam-skiplist)
 https://docs.rs/crossbeam-skiplist)
 [![Rust 1.36+](https://img.shields.io/badge/rust-1.36+-lightgray.svg)](
 https://www.rust-lang.org)
-[![chat](https://img.shields.io/discord/569610676205781012.svg?logo=discord)](https://discord.gg/BBYwKq)
+[![chat](https://img.shields.io/discord/569610676205781012.svg?logo=discord)](https://discord.com/invite/JXYwgWZ)
 
 **Note:** This crate is still a work in progress.
 

--- a/crossbeam-utils/README.md
+++ b/crossbeam-utils/README.md
@@ -10,7 +10,7 @@ https://crates.io/crates/crossbeam-utils)
 https://docs.rs/crossbeam-utils)
 [![Rust 1.36+](https://img.shields.io/badge/rust-1.36+-lightgray.svg)](
 https://www.rust-lang.org)
-[![chat](https://img.shields.io/discord/569610676205781012.svg?logo=discord)](https://discord.gg/BBYwKq)
+[![chat](https://img.shields.io/discord/569610676205781012.svg?logo=discord)](https://discord.com/invite/JXYwgWZ)
 
 This crate provides miscellaneous tools for concurrent programming:
 


### PR DESCRIPTION
Fixes #681 

The correct link is https://discord.com/invite/JXYwgWZ.