### PR TITLE
Prepare for the next release

### DIFF
--- a/crossbeam-channel/CHANGELOG.md
+++ b/crossbeam-channel/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.5.1
+
+- Fix memory leak in unbounded channel. (#669)
+
 # Version 0.5.0
 
 - Bump the minimum supported Rust version to 1.36.

--- a/crossbeam-channel/Cargo.toml
+++ b/crossbeam-channel/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-channel"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-channel-X.Y.Z" git tag
-version = "0.5.0"
+version = "0.5.1"
 authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Changes:

- crossbeam-channel 0.5.0 -> 0.5.1
  - Fix memory leak in unbounded channel. (#669)
