### PR TITLE
Use stable compiler to installing cargo-hack

### DIFF
--- a/ci/check-features.sh
+++ b/ci/check-features.sh
@@ -4,7 +4,7 @@ cd "$(dirname "$0")"/..
 set -ex
 
 if [[ ! -x "$(command -v cargo-hack)" ]]; then
-    cargo install --debug cargo-hack || exit 1
+    cargo +stable install --debug cargo-hack || exit 1
 fi
 
 if [[ "$RUST_VERSION" != "nightly"* ]]; then


### PR DESCRIPTION
I'm planning to increase the Rust version required for the installation of cargo-hack from 1.36 to 1.40. (cargo-hack is usually runnable with Cargo versions older than the Rust version required for installation. Rust 1.36 will continue to be supported after the increase the Rust version required for the installation of cargo-hack has been increased.)