### PR TITLE
epoch: Correct handling of null ptr returned from alloc::alloc

### DIFF
--- a/crossbeam-epoch/src/atomic.rs
+++ b/crossbeam-epoch/src/atomic.rs
@@ -252,6 +252,9 @@ impl<T> Pointable for [MaybeUninit<T>] {
         let align = mem::align_of::<Array<T>>();
         let layout = alloc::Layout::from_size_align(size, align).unwrap();
         let ptr = alloc::alloc(layout) as *mut Array<T>;
+        if ptr.is_null() {
+            alloc::handle_alloc_error(layout);
+        }
         (*ptr).size = size;
         ptr as usize
     }


### PR DESCRIPTION
Fixes #689 