### PR TITLE
Prepare for the next release

### DIFF
--- a/crossbeam-epoch/CHANGELOG.md
+++ b/crossbeam-epoch/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 0.9.4
+
+- Fix UB in `<[MaybeUninit<T>] as Pointable>::init` when global allocator failed allocation (#690)
+- Bump `loom` dependency to version 0.5. (#686)
+
 # Version 0.9.3
 
 - Make `loom` dependency optional. (#666)

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-epoch"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-epoch-X.Y.Z" git tag
-version = "0.9.3"
+version = "0.9.4"
 authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -51,7 +51,7 @@ memoffset = "0.6"
 loom-crate = { package = "loom", version = "0.5", optional = true }
 
 [dependencies.crossbeam-utils]
-version = "0.8.3"
+version = "0.8.4"
 path = "../crossbeam-utils"
 default-features = false
 

--- a/crossbeam-utils/CHANGELOG.md
+++ b/crossbeam-utils/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.8.4
+
+- Bump `loom` dependency to version 0.5. (#686)
+
 # Version 0.8.3
 
 - Make `loom` dependency optional. (#666)

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-utils"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-utils-X.Y.Z" git tag
-version = "0.8.3"
+version = "0.8.4"
 authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
- crossbeam-utils 0.8.3 -> 0.8.4
  - Bump `loom` dependency to version 0.5. (#686)
- crossbeam-epoch 0.9.3 -> 0.9.4
  - Fix UB in `<[MaybeUninit<T>] as Pointable>::init` when global allocator failed allocation (#690)
  - Bump `loom` dependency to version 0.5. (#686)
