### PR TITLE
Use feature(const_fn_trait_bound) instead of feature(const_fn)

### DIFF
--- a/crossbeam-epoch/src/lib.rs
+++ b/crossbeam-epoch/src/lib.rs
@@ -63,7 +63,7 @@
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]
-#![cfg_attr(feature = "nightly", feature(const_fn))]
+#![cfg_attr(feature = "nightly", feature(const_fn_trait_bound))]
 
 #[cfg(crossbeam_loom)]
 extern crate loom_crate as loom;


### PR DESCRIPTION
    error[E0658]: trait bounds other than `Sized` on const fn parameters are unstable
       --> crossbeam-epoch/src/atomic.rs:313:6
        |
    313 | impl<T: ?Sized + Pointable> Atomic<T> {
        |      ^
        |
        = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
        = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable