### PR TITLE
fixed go.go to properly select over channels during the put operation in select_both

### DIFF
--- a/crossbeam-channel/benchmarks/go.go
+++ b/crossbeam-channel/benchmarks/go.go
@@ -139,10 +139,10 @@ func select_both(cap int) {
     var producer = func(c0 chan Message, c1 chan Message, c2 chan Message, c3 chan Message) {
         for i := 0; i < MESSAGES / THREADS; i++ {
             select {
-            case c0 <- Message(i);
-            case c1 <- Message(i);
-            case c2 <- Message(i);
-            case c3 <- Message(i);
+            case c0 <- Message(i):
+            case c1 <- Message(i):
+            case c2 <- Message(i):
+            case c3 <- Message(i):
             }
         }
         done <- true

--- a/crossbeam-channel/benchmarks/go.go
+++ b/crossbeam-channel/benchmarks/go.go
@@ -136,16 +136,21 @@ func select_both(cap int) {
     var c3 = make(chan Message, cap)
     var done = make(chan bool)
 
-    var producer = func(c chan Message) {
+    var producer = func(c0 chan Message, c1 chan Message, c2 chan Message, c3 chan Message) {
         for i := 0; i < MESSAGES / THREADS; i++ {
-            c <- Message(i)
+            select {
+            case c0 <- Message(i);
+            case c1 <- Message(i);
+            case c2 <- Message(i);
+            case c3 <- Message(i);
+            }
         }
         done <- true
     }
-    go producer(c0)
-    go producer(c1)
-    go producer(c2)
-    go producer(c3)
+    go producer(c0,c1,c2,c3)
+    go producer(c0,c1,c2,c3)
+    go producer(c0,c1,c2,c3)
+    go producer(c0,c1,c2,c3)
 
     for t := 0; t < THREADS; t++ {
         go func() {


### PR DESCRIPTION
Per the [crossbeam benchmark configuration](https://github.com/crossbeam-rs/crossbeam/blob/master/crossbeam-channel/benchmarks/README.md) the `select_both` function is defined as: 

> select_both: T threads send N / T messages each by selecting over T channels. T other threads receive N / T messages each by selecting over the T channels.

Previously, the `select_both` function in [go.go](https://github.com/crossbeam-rs/crossbeam/blob/3e83987f258ab85a6573704ba538f2efdfe587c1/crossbeam-channel/benchmarks/go.go#L128) did not utilize the `select` statement while sending messages. Added the use of the select statement. 