### PR TITLE
Add {Atomic, Shared}::try_into_owned

### DIFF
--- a/crossbeam-epoch/src/atomic.rs
+++ b/crossbeam-epoch/src/atomic.rs
@@ -836,7 +836,7 @@ impl<T: ?Sized + Pointable> Atomic<T> {
     ///         // any Shared or & to it ourselves, but it may be null, so we have to be careful.
     ///         let old = mem::replace(&mut self.ptr, Atomic::null());
     ///         unsafe {
-    ///             if let Option::Some(x) = old.try_into_owned() {
+    ///             if let Some(x) = old.try_into_owned() {
     ///                 drop(x)
     ///             }
     ///         }
@@ -850,9 +850,9 @@ impl<T: ?Sized + Pointable> Atomic<T> {
         #[cfg(not(crossbeam_loom))]
         let data = self.data.into_inner();
         if decompose_tag::<T>(data).0 == 0 {
-            Option::None
+            None
         } else {
-            Option::Some(Owned::from_usize(data))
+            Some(Owned::from_usize(data))
         }
     }
 }
@@ -1482,16 +1482,16 @@ impl<'g, T: ?Sized + Pointable> Shared<'g, T> {
     /// unsafe {
     ///     let guard = &epoch::unprotected();
     ///     let p = a.load(SeqCst, guard);
-    ///     if let Option::Some(x) = p.try_into_owned() {
+    ///     if let Some(x) = p.try_into_owned() {
     ///         drop(x);
     ///     }
     /// }
     /// ```
     pub unsafe fn try_into_owned(self) -> Option<Owned<T>> {
         if self.is_null() {
-            Option::None
+            None
         } else {
-            Option::Some(Owned::from_usize(self.data))
+            Some(Owned::from_usize(self.data))
         }
     }
 

--- a/crossbeam-epoch/src/atomic.rs
+++ b/crossbeam-epoch/src/atomic.rs
@@ -819,7 +819,7 @@ impl<T: ?Sized + Pointable> Atomic<T> {
     /// # Safety
     ///
     /// This method may be called only if the pointer is valid and nobody else is holding a
-    /// reference to the same object, or the pointer is null..
+    /// reference to the same object, or the pointer is null.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Sometimes, I have run into times when I have had an `Atomic` which I know to be either null or valid, and I want to convert it into an `Owned`. As far as I can tell, there is no way to do this without converting through a `Shared`, which comes at the const of an additional atomic load. This pull request also adds the same method to `Shared` for symmetry.

This pull request adds the following methods:
```rust
impl<T: ?Sized + Pointable> Owned<T> {
	pub unsafe fn try_into_owned(self) -> Option<Owned<T>>;
}

impl<T: ?Sized + Pointable> Shared<'_, T> {
	pub unsafe fn try_into_owned(self) -> Option<Owned<T>>;
}
```