### PR TITLE
Prepare for the next release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.8.1
+
+- Support targets that do not have atomic CAS on stable Rust (#698)
+
 # Version 0.8.0
 
 - Bump the minimum supported Rust version to 1.36.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-X.Y.Z" git tag
-version = "0.8.0"
+version = "0.8.1"
 authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -57,19 +57,19 @@ default-features = false
 optional = true
 
 [dependencies.crossbeam-epoch]
-version = "0.9"
+version = "0.9.5"
 path = "./crossbeam-epoch"
 default-features = false
 optional = true
 
 [dependencies.crossbeam-queue]
-version = "0.3"
+version = "0.3.2"
 path = "./crossbeam-queue"
 default-features = false
 optional = true
 
 [dependencies.crossbeam-utils]
-version = "0.8"
+version = "0.8.5"
 path = "./crossbeam-utils"
 default-features = false
 

--- a/crossbeam-epoch/CHANGELOG.md
+++ b/crossbeam-epoch/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 0.9.5
+
+- Fix UB in `Pointable` impl of `[MaybeUninit<T>]` (#694)
+- Support targets that do not have atomic CAS on stable Rust (#698)
+- Fix breakage with nightly feature due to rust-lang/rust#84510 (#692)
+
 # Version 0.9.4
 
 - Fix UB in `<[MaybeUninit<T>] as Pointable>::init` when global allocator failed allocation (#690)

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-epoch"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-epoch-X.Y.Z" git tag
-version = "0.9.4"
+version = "0.9.5"
 authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -54,7 +54,7 @@ memoffset = "0.6"
 loom-crate = { package = "loom", version = "0.5", optional = true }
 
 [dependencies.crossbeam-utils]
-version = "0.8.4"
+version = "0.8.5"
 path = "../crossbeam-utils"
 default-features = false
 

--- a/crossbeam-queue/CHANGELOG.md
+++ b/crossbeam-queue/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.3.2
+
+- Support targets that do not have atomic CAS on stable Rust (#698)
+
 # Version 0.3.1
 
 - Make `SegQueue::new` const fn. (#584)

--- a/crossbeam-queue/Cargo.toml
+++ b/crossbeam-queue/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-queue"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-queue-X.Y.Z" git tag
-version = "0.3.1"
+version = "0.3.2"
 authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -41,7 +41,7 @@ nightly = ["crossbeam-utils/nightly"]
 cfg-if = "1"
 
 [dependencies.crossbeam-utils]
-version = "0.8"
+version = "0.8.5"
 path = "../crossbeam-utils"
 default-features = false
 

--- a/crossbeam-skiplist/Cargo.toml
+++ b/crossbeam-skiplist/Cargo.toml
@@ -32,13 +32,13 @@ alloc = ["crossbeam-epoch/alloc"]
 cfg-if = "1"
 
 [dependencies.crossbeam-epoch]
-version = "0.9.2"
+version = "0.9.5"
 path = "../crossbeam-epoch"
 default-features = false
 optional = true
 
 [dependencies.crossbeam-utils]
-version = "0.8"
+version = "0.8.5"
 path = "../crossbeam-utils"
 default-features = false
 

--- a/crossbeam-utils/CHANGELOG.md
+++ b/crossbeam-utils/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 0.8.5
+
+- Add `AtomicCell::fetch_update` (#704)
+- Support targets that do not have atomic CAS on stable Rust (#698)
+
 # Version 0.8.4
 
 - Bump `loom` dependency to version 0.5. (#686)

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-utils"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-utils-X.Y.Z" git tag
-version = "0.8.4"
+version = "0.8.5"
 authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
- crossbeam-epoch 0.9.4 -> 0.9.5
  - Fix UB in `Pointable` impl of `[MaybeUninit<T>]` (#694)
  - Support targets that do not have atomic CAS on stable Rust (#698)
  - Fix breakage with nightly feature due to rust-lang/rust#84510 (#692)
- crossbeam-queue 0.3.1 -> 0.3.2
  - Support targets that do not have atomic CAS on stable Rust (#698)
- crossbeam-utils 0.8.4 -> 0.8.5
  - Add `AtomicCell::fetch_update` (#704)
  - Support targets that do not have atomic CAS on stable Rust (#698)
- crossbeam 0.8.0 -> 0.8.1
  - Support targets that do not have atomic CAS on stable Rust (#698)

Closes #702 