### PR TITLE
Correct minimal versions check

### DIFF
--- a/ci/dependencies.sh
+++ b/ci/dependencies.sh
@@ -3,13 +3,19 @@
 cd "$(dirname "$0")"/..
 set -ex
 
+cargo install cargo-hack
+
 cargo tree
 cargo tree --duplicate
 cargo tree --duplicate || exit 1
 
 # Check minimal versions.
+# Remove dev-dependencies from Cargo.toml to prevent the next `cargo update`
+# from determining minimal versions based on dev-dependencies.
+cargo hack --remove-dev-deps --workspace
+# Update Cargo.lock to minimal version dependencies.
 cargo update -Zminimal-versions
 cargo tree
-cargo check --all --all-features --exclude benchmarks
+cargo hack check --all --all-features --exclude benchmarks
 
 exit 0


### PR DESCRIPTION
dev-dependencies may raise version requirements. Ideally, remove them before run `cargo update -Z mimimal-version`.

See also https://github.com/tokio-rs/tokio/pull/3131#discussion_r521621961.