### PR TITLE
Fix cargo doc failure

### DIFF
--- a/crossbeam-channel/benchmarks/Cargo.toml
+++ b/crossbeam-channel/benchmarks/Cargo.toml
@@ -19,47 +19,59 @@ mpmc = "0.1.5"
 [[bin]]
 name = "atomicring"
 path = "atomicring.rs"
+doc = false
 
 [[bin]]
 name = "atomicringqueue"
 path = "atomicringqueue.rs"
+doc = false
 
 [[bin]]
 name = "bus"
 path = "bus.rs"
+doc = false
 
 [[bin]]
 name = "chan"
 path = "chan.rs"
+doc = false
 
 [[bin]]
 name = "crossbeam-channel"
 path = "crossbeam-channel.rs"
+doc = false
 
 [[bin]]
 name = "crossbeam-deque"
 path = "crossbeam-deque.rs"
+doc = false
 
 [[bin]]
 name = "flume"
 path = "flume.rs"
+doc = false
 
 [[bin]]
 name = "futures-channel"
 path = "futures-channel.rs"
+doc = false
 
 [[bin]]
 name = "lockfree"
 path = "lockfree.rs"
+doc = false
 
 [[bin]]
 name = "mpsc"
 path = "mpsc.rs"
+doc = false
 
 [[bin]]
 name = "segqueue"
 path = "segqueue.rs"
+doc = false
 
 [[bin]]
 name = "mpmc"
 path = "mpmc.rs"
+doc = false


### PR DESCRIPTION
https://github.com/crossbeam-rs/crossbeam/runs/2755265709?check_suite_focus=true
```
error: document output filename collision
The lib `crossbeam-channel` in package `crossbeam-channel v0.5.1 (/home/runner/work/crossbeam/crossbeam/crossbeam-channel)` has the same name as the bin `crossbeam-channel` in package `benchmarks v0.1.0 (/home/runner/work/crossbeam/crossbeam/crossbeam-channel/benchmarks)`.
Only one may be documented at once since they output to the same path.
Consider documenting only one, renaming one, or marking one with `doc = false` in Cargo.toml.
```