### PR TITLE
remove unnecessary 'move' keyword

### DIFF
--- a/crossbeam-channel/src/context.rs
+++ b/crossbeam-channel/src/context.rs
@@ -45,7 +45,7 @@ impl Context {
         }
 
         let mut f = Some(f);
-        let mut f = move |cx: &Context| -> R {
+        let mut f = |cx: &Context| -> R {
             let f = f.take().unwrap();
             f(cx)
         };


### PR DESCRIPTION
The newer 'f' only captures a mut reference of the former 'f' to make itself becomes a FnMut.So, the 'move' keyword here seems unnecessary.