### PR TITLE
Add `Sender::try_send_cow`

### DIFF
--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -408,15 +408,17 @@ impl<T> Sender<T> {
     /// # Examples
     ///
     /// ```
+    /// use std::borrow::Cow;
     /// use crossbeam_channel::{bounded, TrySendError};
     ///
     /// let (s, r) = bounded(1);
     ///
-    /// assert_eq!(s.try_send(1), Ok(()));
-    /// assert_eq!(s.try_send(2), Err(TrySendError::Full(2)));
+    /// assert_eq!(s.try_send_cow(Cow::Borrowed(&1)), Ok(())); // Clone occurs
+    /// assert_eq!(s.try_send_cow(Cow::Owned(1)), Ok(())); // Clone does not occur
+    /// assert_eq!(s.try_send_cow(Cow::Borrowed(&2)), Err(TrySendError::Full(Cow::Borrowed(&2)))); // Clone does not occur
     ///
     /// drop(r);
-    /// assert_eq!(s.try_send(3), Err(TrySendError::Disconnected(3)));
+    /// assert_eq!(s.try_send_cow(Cow::Borrowed(&3)), Err(TrySendError::Disconnected(Cow::Borrowed(&3)))); // Clone does not occur
     /// ```
     pub fn try_send_cow<'a>(&self, msg: Cow<'a, T>) -> Result<(), TrySendError<Cow<'a, T>>>
     where

--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -422,7 +422,7 @@ impl<T> Sender<T> {
     /// ```
     pub fn try_send_cow<'a>(&self, msg: Cow<'a, T>) -> Result<(), TrySendError<Cow<'a, T>>>
     where
-        T: Clone
+        T: ToOwned<Owned = T>
     {
         match &self.flavor {
             SenderFlavor::Array(chan) => chan.try_send_cow(msg),

--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -6,6 +6,7 @@ use std::mem;
 use std::panic::{RefUnwindSafe, UnwindSafe};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use std::borrow::Cow;
 
 use crate::context::Context;
 use crate::counter;
@@ -390,6 +391,41 @@ impl<T> Sender<T> {
             SenderFlavor::Array(chan) => chan.try_send(msg),
             SenderFlavor::List(chan) => chan.try_send(msg),
             SenderFlavor::Zero(chan) => chan.try_send(msg),
+        }
+    }
+
+    /// Attempts to send a message into the channel without blocking and without performing any work
+    /// if sending fails. This function uses a [Cow](https://doc.rust-lang.org/std/borrow/enum.Cow.html)
+    /// smart pointer to avoid the need for cloning the message contents if the receiving side is full
+    /// or disconnected.
+    ///
+    /// This method will either send a message into the channel immediately or return an error if
+    /// the channel is full or disconnected. The returned error contains the original Cow.
+    ///
+    /// If called on a zero-capacity channel, this method will send the message only if there
+    /// happens to be a receive operation on the other side of the channel at the same time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_channel::{bounded, TrySendError};
+    ///
+    /// let (s, r) = bounded(1);
+    ///
+    /// assert_eq!(s.try_send(1), Ok(()));
+    /// assert_eq!(s.try_send(2), Err(TrySendError::Full(2)));
+    ///
+    /// drop(r);
+    /// assert_eq!(s.try_send(3), Err(TrySendError::Disconnected(3)));
+    /// ```
+    pub fn try_send_cow<'a>(&self, msg: Cow<'a, T>) -> Result<(), TrySendError<Cow<'a, T>>>
+    where
+        T: Clone
+    {
+        match &self.flavor {
+            SenderFlavor::Array(chan) => chan.try_send_cow(msg),
+            SenderFlavor::List(chan) => chan.try_send_cow(msg),
+            SenderFlavor::Zero(chan) => chan.try_send_cow(msg),
         }
     }
 

--- a/crossbeam-channel/src/flavors/array.rs
+++ b/crossbeam-channel/src/flavors/array.rs
@@ -219,13 +219,9 @@ impl<T> Channel<T> {
         }
     }
 
-    /// Writes a message into the channel.
-    pub(crate) unsafe fn write(&self, token: &mut Token, msg: T) -> Result<(), T> {
-        // If there is no slot, the channel is disconnected.
-        if token.array.slot.is_null() {
-            return Err(msg);
-        }
-
+    /// Writes a message into the channel. **Assumes the channel is NOT disconnected.**
+    #[inline]
+    unsafe fn write_unchecked(&self, token: &mut Token, msg: T) {
         let slot: &Slot<T> = &*(token.array.slot as *const Slot<T>);
 
         // Write the message into the slot and update the stamp.
@@ -234,6 +230,16 @@ impl<T> Channel<T> {
 
         // Wake a sleeping receiver.
         self.receivers.notify();
+    }
+
+    /// Writes a message into the channel.
+    pub(crate) unsafe fn write(&self, token: &mut Token, msg: T) -> Result<(), T> {
+        // If there is no slot, the channel is disconnected.
+        if token.array.slot.is_null() {
+            return Err(msg);
+        }
+
+        self.write_unchecked(token, msg);
         Ok(())
     }
 
@@ -249,15 +255,8 @@ impl<T> Channel<T> {
 
         // Take ownership of/clone the underlying message.
         let msg = msg.into_owned();
-
-        let slot: &Slot<T> = &*(token.array.slot as *const Slot<T>);
-
-        // Write the message into the slot and update the stamp.
-        slot.msg.get().write(MaybeUninit::new(msg));
-        slot.stamp.store(token.array.stamp, Ordering::Release);
-
-        // Wake a sleeping receiver.
-        self.receivers.notify();
+        
+        self.write_unchecked(token, msg);
         Ok(())
     }
 

--- a/crossbeam-channel/src/flavors/list.rs
+++ b/crossbeam-channel/src/flavors/list.rs
@@ -301,23 +301,6 @@ impl<T> Channel<T> {
         Ok(())
     }
 
-    /// Writes a message into the channel without cloning if writing fails.
-    pub(crate) unsafe fn write_cow<'a>(&self, token: &mut Token, msg: Cow<'a, T>) -> Result<(), Cow<'a, T>>
-    where
-        T: Clone
-    {
-        // If there is no slot, the channel is disconnected.
-        if token.list.block.is_null() {
-            return Err(msg);
-        }
-
-        // Take ownership of/clone the underlying message.
-        let msg = msg.into_owned();
-
-        self.write_unchecked(token, msg);
-        Ok(())
-    }
-
     /// Attempts to reserve a slot for receiving a message.
     fn start_recv(&self, token: &mut Token) -> bool {
         let backoff = Backoff::new();
@@ -436,17 +419,6 @@ impl<T> Channel<T> {
         })
     }
 
-    /// Attempts to send a message into the channel without performing work if sending fails.
-    pub(crate) fn try_send_cow<'a>(&self, msg: Cow<'a, T>) -> Result<(), TrySendError<Cow<'a, T>>>
-    where
-        T: Clone
-    {
-        self.send_cow(msg, None).map_err(|err| match err {
-            SendTimeoutError::Disconnected(msg) => TrySendError::Disconnected(msg),
-            SendTimeoutError::Timeout(_) => unreachable!(),
-        })
-    }
-
     /// Sends a message into the channel.
     pub(crate) fn send(
         &self,
@@ -457,23 +429,6 @@ impl<T> Channel<T> {
         assert!(self.start_send(token));
         unsafe {
             self.write(token, msg)
-                .map_err(SendTimeoutError::Disconnected)
-        }
-    }
-
-    /// Sends a message into the channel without performing work if sending fails.
-    pub(crate) fn send_cow<'a>(
-        &self,
-        msg: Cow<'a, T>,
-        _deadline: Option<Instant>,
-    ) -> Result<(), SendTimeoutError<Cow<'a, T>>>
-    where
-        T: Clone
-    {
-        let token = &mut Token::default();
-        assert!(self.start_send(token));
-        unsafe {
-            self.write_cow(token, msg)
                 .map_err(SendTimeoutError::Disconnected)
         }
     }
@@ -718,6 +673,44 @@ impl<T> Drop for Channel<T> {
             if !block.is_null() {
                 drop(Box::from_raw(block));
             }
+        }
+    }
+}
+
+impl<T: ToOwned<Owned = T>> Channel<T> {
+    /// Writes a message into the channel without cloning if writing fails.
+    pub(crate) unsafe fn write_cow<'a>(&self, token: &mut Token, msg: Cow<'a, T>) -> Result<(), Cow<'a, T>> {
+        // If there is no slot, the channel is disconnected.
+        if token.list.block.is_null() {
+            return Err(msg);
+        }
+
+        // Take ownership of/clone the underlying message.
+        let msg = msg.into_owned();
+
+        self.write_unchecked(token, msg);
+        Ok(())
+    }
+
+    /// Attempts to send a message into the channel without performing work if sending fails.
+    pub(crate) fn try_send_cow<'a>(&self, msg: Cow<'a, T>) -> Result<(), TrySendError<Cow<'a, T>>> {
+        self.send_cow(msg, None).map_err(|err| match err {
+            SendTimeoutError::Disconnected(msg) => TrySendError::Disconnected(msg),
+            SendTimeoutError::Timeout(_) => unreachable!(),
+        })
+    }
+
+    /// Sends a message into the channel without performing work if sending fails.
+    pub(crate) fn send_cow<'a>(
+        &self,
+        msg: Cow<'a, T>,
+        _deadline: Option<Instant>,
+    ) -> Result<(), SendTimeoutError<Cow<'a, T>>> {
+        let token = &mut Token::default();
+        assert!(self.start_send(token));
+        unsafe {
+            self.write_cow(token, msg)
+                .map_err(SendTimeoutError::Disconnected)
         }
     }
 }

--- a/crossbeam-channel/src/flavors/list.rs
+++ b/crossbeam-channel/src/flavors/list.rs
@@ -6,6 +6,7 @@ use std::mem::MaybeUninit;
 use std::ptr;
 use std::sync::atomic::{self, AtomicPtr, AtomicUsize, Ordering};
 use std::time::Instant;
+use std::borrow::Cow;
 
 use crossbeam_utils::{Backoff, CachePadded};
 
@@ -294,6 +295,31 @@ impl<T> Channel<T> {
         Ok(())
     }
 
+    /// Writes a message into the channel without cloning if writing fails.
+    pub(crate) unsafe fn write_cow<'a>(&self, token: &mut Token, msg: Cow<'a, T>) -> Result<(), Cow<'a, T>>
+    where
+        T: Clone
+    {
+        // If there is no slot, the channel is disconnected.
+        if token.list.block.is_null() {
+            return Err(msg);
+        }
+
+        // Take ownership of/clone the underlying message.
+        let msg = msg.into_owned();
+
+        // Write the message into the slot.
+        let block = token.list.block as *mut Block<T>;
+        let offset = token.list.offset;
+        let slot = (*block).slots.get_unchecked(offset);
+        slot.msg.get().write(MaybeUninit::new(msg));
+        slot.state.fetch_or(WRITE, Ordering::Release);
+
+        // Wake a sleeping receiver.
+        self.receivers.notify();
+        Ok(())
+    }
+
     /// Attempts to reserve a slot for receiving a message.
     fn start_recv(&self, token: &mut Token) -> bool {
         let backoff = Backoff::new();
@@ -412,6 +438,17 @@ impl<T> Channel<T> {
         })
     }
 
+    /// Attempts to send a message into the channel without performing work if sending fails.
+    pub(crate) fn try_send_cow<'a>(&self, msg: Cow<'a, T>) -> Result<(), TrySendError<Cow<'a, T>>>
+    where
+        T: Clone
+    {
+        self.send_cow(msg, None).map_err(|err| match err {
+            SendTimeoutError::Disconnected(msg) => TrySendError::Disconnected(msg),
+            SendTimeoutError::Timeout(_) => unreachable!(),
+        })
+    }
+
     /// Sends a message into the channel.
     pub(crate) fn send(
         &self,
@@ -422,6 +459,23 @@ impl<T> Channel<T> {
         assert!(self.start_send(token));
         unsafe {
             self.write(token, msg)
+                .map_err(SendTimeoutError::Disconnected)
+        }
+    }
+
+    /// Sends a message into the channel without performing work if sending fails.
+    pub(crate) fn send_cow<'a>(
+        &self,
+        msg: Cow<'a, T>,
+        _deadline: Option<Instant>,
+    ) -> Result<(), SendTimeoutError<Cow<'a, T>>>
+    where
+        T: Clone
+    {
+        let token = &mut Token::default();
+        assert!(self.start_send(token));
+        unsafe {
+            self.write_cow(token, msg)
                 .map_err(SendTimeoutError::Disconnected)
         }
     }

--- a/crossbeam-channel/src/flavors/zero.rs
+++ b/crossbeam-channel/src/flavors/zero.rs
@@ -147,23 +147,6 @@ impl<T> Channel<T> {
         Ok(())
     }
 
-    /// Writes a message into the channel without cloning if writing fails.
-    pub(crate) unsafe fn write_cow<'a>(&self, token: &mut Token, msg: Cow<'a, T>) -> Result<(), Cow<'a, T>>
-    where
-        T: Clone
-    {
-        // If there is no packet, the channel is disconnected.
-        if token.zero == 0 {
-            return Err(msg);
-        }
-
-        // Take ownership of/clone the underlying message.
-        let msg = msg.into_owned();
-
-        self.write_unchecked(token, msg);
-        Ok(())
-    }
-
     /// Attempts to pair up with a sender.
     fn start_recv(&self, token: &mut Token) -> bool {
         let mut inner = self.inner.lock();
@@ -217,29 +200,6 @@ impl<T> Channel<T> {
             drop(inner);
             unsafe {
                 self.write(token, msg).ok().unwrap();
-            }
-            Ok(())
-        } else if inner.is_disconnected {
-            Err(TrySendError::Disconnected(msg))
-        } else {
-            Err(TrySendError::Full(msg))
-        }
-    }
-
-    /// Attempts to send a message into the channel without performing work if sending fails.
-    pub(crate) fn try_send_cow<'a>(&self, msg: Cow<'a, T>) -> Result<(), TrySendError<Cow<'a, T>>>
-    where
-        T: Clone
-    {
-        let token = &mut Token::default();
-        let mut inner = self.inner.lock();
-
-        // If there's a waiting receiver, pair up with it.
-        if let Some(operation) = inner.receivers.try_select() {
-            token.zero = operation.packet;
-            drop(inner);
-            unsafe {
-                self.write_cow(token, msg).ok().unwrap();
             }
             Ok(())
         } else if inner.is_disconnected {
@@ -408,6 +368,42 @@ impl<T> Channel<T> {
     /// Returns `true` if the channel is full.
     pub(crate) fn is_full(&self) -> bool {
         true
+    }
+}
+
+impl<T: ToOwned<Owned = T>> Channel<T> {
+    /// Writes a message into the channel without cloning if writing fails.
+    pub(crate) unsafe fn write_cow<'a>(&self, token: &mut Token, msg: Cow<'a, T>) -> Result<(), Cow<'a, T>> {
+        // If there is no packet, the channel is disconnected.
+        if token.zero == 0 {
+            return Err(msg);
+        }
+
+        // Take ownership of/clone the underlying message.
+        let msg = msg.into_owned();
+
+        self.write_unchecked(token, msg);
+        Ok(())
+    }
+
+    /// Attempts to send a message into the channel without performing work if sending fails.
+    pub(crate) fn try_send_cow<'a>(&self, msg: Cow<'a, T>) -> Result<(), TrySendError<Cow<'a, T>>> {
+        let token = &mut Token::default();
+        let mut inner = self.inner.lock();
+
+        // If there's a waiting receiver, pair up with it.
+        if let Some(operation) = inner.receivers.try_select() {
+            token.zero = operation.packet;
+            drop(inner);
+            unsafe {
+                self.write_cow(token, msg).ok().unwrap();
+            }
+            Ok(())
+        } else if inner.is_disconnected {
+            Err(TrySendError::Disconnected(msg))
+        } else {
+            Err(TrySendError::Full(msg))
+        }
     }
 }
 

--- a/crossbeam-channel/tests/mpsc.rs
+++ b/crossbeam-channel/tests/mpsc.rs
@@ -64,7 +64,7 @@ impl<T> SyncSender<T> {
 
     pub fn try_send_cow<'a>(&self, t: Cow<'a, T>) -> Result<(), TrySendError<Cow<'a, T>>>
     where
-        T: Clone
+        T: ToOwned<Owned = T>
     {
         self.inner.try_send_cow(t).map_err(|err| match err {
             cc::TrySendError::Full(m) => TrySendError::Full(m),

--- a/crossbeam-channel/tests/mpsc.rs
+++ b/crossbeam-channel/tests/mpsc.rs
@@ -24,6 +24,7 @@ use std::sync::mpsc::{RecvError, RecvTimeoutError, TryRecvError};
 use std::sync::mpsc::{SendError, TrySendError};
 use std::thread::JoinHandle;
 use std::time::Duration;
+use std::borrow::Cow;
 
 use crossbeam_channel as cc;
 
@@ -56,6 +57,16 @@ impl<T> SyncSender<T> {
 
     pub fn try_send(&self, t: T) -> Result<(), TrySendError<T>> {
         self.inner.try_send(t).map_err(|err| match err {
+            cc::TrySendError::Full(m) => TrySendError::Full(m),
+            cc::TrySendError::Disconnected(m) => TrySendError::Disconnected(m),
+        })
+    }
+
+    pub fn try_send_cow<'a>(&self, t: Cow<'a, T>) -> Result<(), TrySendError<Cow<'a, T>>>
+    where
+        T: Clone
+    {
+        self.inner.try_send_cow(t).map_err(|err| match err {
             cc::TrySendError::Full(m) => TrySendError::Full(m),
             cc::TrySendError::Disconnected(m) => TrySendError::Disconnected(m),
         })
@@ -958,6 +969,7 @@ mod channel_tests {
 mod sync_channel_tests {
     use super::*;
 
+    use std::borrow::Cow;
     use std::env;
     use std::thread;
     use std::time::Duration;
@@ -1253,6 +1265,26 @@ mod sync_channel_tests {
     fn oneshot_single_thread_try_send_closed2() {
         let (tx, _rx) = sync_channel::<i32>(0);
         assert_eq!(tx.try_send(10), Err(TrySendError::Full(10)));
+    }
+
+    #[test]
+    fn oneshot_single_thread_try_send_cow_open() {
+        let (tx, rx) = sync_channel::<i32>(1);
+        assert_eq!(tx.try_send_cow(Cow::Owned(10)), Ok(()));
+        assert!(rx.recv().unwrap() == 10);
+    }
+
+    #[test]
+    fn oneshot_single_thread_try_send_cow_closed() {
+        let (tx, rx) = sync_channel::<i32>(0);
+        drop(rx);
+        assert_eq!(tx.try_send_cow(Cow::Owned(10)), Err(TrySendError::Disconnected(Cow::Owned(10))));
+    }
+
+    #[test]
+    fn oneshot_single_thread_try_send_cow_closed2() {
+        let (tx, _rx) = sync_channel::<i32>(0);
+        assert_eq!(tx.try_send_cow(Cow::Owned(10)), Err(TrySendError::Full(Cow::Owned(10))));
     }
 
     #[test]
@@ -1649,6 +1681,40 @@ mod sync_channel_tests {
         assert_eq!(tx.try_send(1), Ok(()));
         drop(rx);
         assert_eq!(tx.try_send(1), Err(TrySendError::Disconnected(1)));
+    }
+
+    #[test]
+    fn try_send_cow1() {
+        let (tx, _rx) = sync_channel::<i32>(0);
+        assert_eq!(tx.try_send_cow(Cow::Owned(1)), Err(TrySendError::Full(Cow::Owned(1))));
+
+        let (tx, _rx) = sync_channel::<i32>(0);
+        assert_eq!(tx.try_send_cow(Cow::Borrowed(&1)), Err(TrySendError::Full(Cow::Borrowed(&1))));
+    }
+
+    #[test]
+    fn try_send_cow2() {
+        let (tx, _rx) = sync_channel::<i32>(1);
+        assert_eq!(tx.try_send_cow(Cow::Owned(1)), Ok(()));
+        assert_eq!(tx.try_send_cow(Cow::Owned(1)), Err(TrySendError::Full(Cow::Owned(1))));
+
+        let (tx, _rx) = sync_channel::<i32>(1);
+        assert_eq!(tx.try_send_cow(Cow::Borrowed(&1)), Ok(()));
+        assert_eq!(tx.try_send_cow(Cow::Borrowed(&1)), Err(TrySendError::Full(Cow::Borrowed(&1))));
+    }
+
+    #[test]
+    fn try_send_cow3() {
+        let (tx, rx) = sync_channel::<i32>(1);
+        assert_eq!(tx.try_send_cow(Cow::Owned(1)), Ok(()));
+        drop(rx);
+        assert_eq!(tx.try_send_cow(Cow::Owned(1)), Err(TrySendError::Disconnected(Cow::Owned(1))));
+        drop(tx);
+
+        let (tx, rx) = sync_channel::<i32>(1);
+        assert_eq!(tx.try_send_cow(Cow::Borrowed(&1)), Ok(()));
+        drop(rx);
+        assert_eq!(tx.try_send_cow(Cow::Borrowed(&1)), Err(TrySendError::Disconnected(Cow::Borrowed(&1))));
     }
 
     #[test]


### PR DESCRIPTION
This function's main purpose is to minimize memory allocations whilst using `Sender::try_send` in a loop and to make any code doing this cleaner, simpler and more idiomatic.

The function takes a `Cow<'_, T>` instead of `T` as the message argument. This means you can provide `try_send_cow` with either a borrowed reference to some data, or simply owned data for codepath convenience.

For example, in this snippet, `bytes` will only be cloned and sent to the channel if it is not full and it is not disconnected. If all the channels are disconnected, this will not allocate any unnecessary memory.

```rust
let bytes: Vec<u8> = vec![...];
let data = Cow::Borrowed(&bytes);
let channels: Vec<Sender<T>> = vec![...];
for ch in channels {
    ch.try_send_cow(data.clone());
}
```