### PR TITLE
Prepare for the next release

### DIFF
--- a/crossbeam-deque/CHANGELOG.md
+++ b/crossbeam-deque/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 0.8.1
+
+- Fix deque steal race condition. (#726)
+- Add `Stealer::len` method. (#708)
+
 # Version 0.8.0
 
 - Bump the minimum supported Rust version to 1.36.

--- a/crossbeam-deque/Cargo.toml
+++ b/crossbeam-deque/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-deque"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-deque-X.Y.Z" git tag
-version = "0.8.0"
+version = "0.8.1"
 authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
- crossbeam-deque 0.8.0 -> 0.8.1