### PR TITLE
Fix memory leaks in pop_front and pop_back

### DIFF
--- a/crossbeam-skiplist/src/base.rs
+++ b/crossbeam-skiplist/src/base.rs
@@ -1158,6 +1158,8 @@ where
             if let Some(e) = e.pin() {
                 if e.remove(guard) {
                     return Some(e);
+                } else {
+                    e.release(guard);
                 }
             }
         }
@@ -1171,6 +1173,8 @@ where
             if let Some(e) = e.pin() {
                 if e.remove(guard) {
                     return Some(e);
+                } else {
+                    e.release(guard);
                 }
             }
         }


### PR DESCRIPTION
`SkipList` may leak memory when calling `pop_front` (or `pop_back`) concurrently. This is because we forget to decrement the reference count of `RefEntry` when the deletion of an element fails in the `pop_front`/`pop_back`.

This PR fixes it by calling `release` when the removal fails.