### PR TITLE
Fix memory leak in iterator of skiplist

### DIFF
--- a/crossbeam-skiplist/src/base.rs
+++ b/crossbeam-skiplist/src/base.rs
@@ -1725,8 +1725,12 @@ where
             }
         }
         if finished {
-            self.head = None;
-            self.tail = None;
+            if let Some(e) = mem::replace(&mut self.head, None) {
+                e.release(guard);
+            }
+            if let Some(e) = mem::replace(&mut self.tail, None) {
+                e.release(guard);
+            }
         }
         self.head.clone()
     }
@@ -1751,8 +1755,12 @@ where
             }
         }
         if finished {
-            self.head = None;
-            self.tail = None;
+            if let Some(e) = mem::replace(&mut self.head, None) {
+                e.release(guard);
+            }
+            if let Some(e) = mem::replace(&mut self.tail, None) {
+                e.release(guard);
+            }
         }
         self.tail.clone()
     }

--- a/crossbeam-skiplist/tests/map.rs
+++ b/crossbeam-skiplist/tests/map.rs
@@ -124,6 +124,30 @@ fn concurrent_remove() {
 }
 
 #[test]
+fn next_memory_leak() {
+    let map: SkipMap<i32, i32> = iter::once((1, 1)).collect();
+    let mut iter = map.iter();
+    let e = iter.next_back();
+    assert!(e.is_some());
+    let e = iter.next();
+    assert!(e.is_none());
+    map.remove(&1);
+}
+
+
+#[test]
+fn next_back_memory_leak() {
+    let map: SkipMap<i32, i32> = iter::once((1, 1)).collect();
+    map.insert(1, 1);
+    let mut iter = map.iter();
+    let e = iter.next();
+    assert!(e.is_some());
+    let e = iter.next_back();
+    assert!(e.is_none());
+    map.remove(&1);
+}
+
+#[test]
 fn entry() {
     let s = SkipMap::new();
 


### PR DESCRIPTION
SkipMap's iterator may leak memory when it reads the value that gets removed from the SkipMap later:

```rust
{
    let map: SkipMap<i32, i32> = iter::once((1, 1)).collect();
    let mut iter = map.iter();
    let e = iter.next_back();
    let e = iter.next();
    map.remove(&1);
} // iter leaks memory
```

The leak happens because the implementation of next and next_back does not call release when replacing head and tail to None (see the diff).

Note that the Drop impl of SkipMap will reclaim all the values in the skiplist when it's dropped; thus, only values that are removed before dropping the skiplist get leaked.

This PR fixed the leak by decreasing the reference count when needed.