### PR TITLE
Keep skiplist iterator ordered

### DIFF
--- a/crossbeam-skiplist/src/base.rs
+++ b/crossbeam-skiplist/src/base.rs
@@ -1764,8 +1764,12 @@ impl<'a, K: 'a, V: 'a> RefIter<'a, K, V> {
     /// Decrements the reference count of `RefEntry` owned by the iterator.
     pub fn drop_impl(&mut self, guard: &Guard) {
         self.parent.check_guard(guard);
-        mem::replace(&mut self.head, None).map(|e| unsafe { e.node.decrement(guard) });
-        mem::replace(&mut self.tail, None).map(|e| unsafe { e.node.decrement(guard) });
+        if let Some(e) = mem::replace(&mut self.head, None) {
+            unsafe { e.node.decrement(guard) };
+        }
+        if let Some(e) = mem::replace(&mut self.tail, None) {
+            unsafe { e.node.decrement(guard) };
+        }
     }
 }
 

--- a/crossbeam-skiplist/src/base.rs
+++ b/crossbeam-skiplist/src/base.rs
@@ -1764,8 +1764,8 @@ impl<'a, K: 'a, V: 'a> RefIter<'a, K, V> {
     /// Decrements the reference count of `RefEntry` owned by the iterator.
     pub fn drop_impl(&mut self, guard: &Guard) {
         self.parent.check_guard(guard);
-        self.head.as_ref().map(|e| unsafe { e.node.decrement(guard)} );
-        self.tail.as_ref().map(|e| unsafe { e.node.decrement(guard)} );
+        mem::replace(&mut self.head, None).map(|e| unsafe { e.node.decrement(guard) });
+        mem::replace(&mut self.tail, None).map(|e| unsafe { e.node.decrement(guard) });
     }
 }
 

--- a/crossbeam-skiplist/src/map.rs
+++ b/crossbeam-skiplist/src/map.rs
@@ -682,6 +682,13 @@ impl<K, V> fmt::Debug for Iter<'_, K, V> {
     }
 }
 
+impl<'a, K, V> Drop for Iter<'a, K, V> {
+    fn drop(&mut self) {
+        let guard = &epoch::pin();
+        self.inner.drop_impl(guard);
+    }
+}
+
 /// An iterator over a subset of entries of a `SkipMap`.
 pub struct Range<'a, Q, R, K, V>
 where

--- a/crossbeam-skiplist/tests/map.rs
+++ b/crossbeam-skiplist/tests/map.rs
@@ -134,7 +134,6 @@ fn next_memory_leak() {
     map.remove(&1);
 }
 
-
 #[test]
 fn next_back_memory_leak() {
     let map: SkipMap<i32, i32> = iter::once((1, 1)).collect();

--- a/crossbeam-skiplist/tests/map.rs
+++ b/crossbeam-skiplist/tests/map.rs
@@ -124,6 +124,30 @@ fn concurrent_remove() {
 }
 
 #[test]
+fn next_memory_leak() {
+    let map: SkipMap<i32, i32> = iter::once((1, 1)).collect();
+    let mut iter = map.iter();
+    let e = iter.next_back();
+    assert!(e.is_some());
+    let e = iter.next();
+    assert!(e.is_none());
+    map.remove(&1);
+}
+
+
+#[test]
+fn next_back_memory_leak() {
+    let map: SkipMap<i32, i32> = iter::once((1, 1)).collect();
+    map.insert(1, 1);
+    let mut iter = map.iter();
+    let e = iter.next();
+    assert!(e.is_some());
+    let e = iter.next_back();
+    assert!(e.is_none());
+    map.remove(&1);
+}
+
+#[test]
 fn entry() {
     let s = SkipMap::new();
 
@@ -145,6 +169,33 @@ fn entry() {
     assert!(!e.move_next());
     assert!(e.move_prev());
     assert_eq!(*e.key(), 11);
+}
+
+#[test]
+fn ordered_iter() {
+    let s: SkipMap<i32, i32> = SkipMap::new();
+    s.insert(1, 1);
+
+    let mut iter = s.iter();
+    assert!(iter.next().is_some());
+    assert!(iter.next().is_none());
+    assert!(iter.next().is_none());
+
+    s.insert(2, 2);
+    assert!(iter.next().is_some());
+    assert!(iter.next().is_none());
+    assert!(iter.next().is_none());
+
+    s.insert(3, 3);
+    s.insert(4, 4);
+    s.insert(5, 5);
+    assert_eq!(*iter.next_back().unwrap().key(), 5);
+    assert_eq!(*iter.next().unwrap().key(), 3);
+    assert_eq!(*iter.next_back().unwrap().key(), 4);
+    assert!(iter.next().is_none());
+    assert!(iter.next_back().is_none());
+    assert!(iter.next().is_none());
+    assert!(iter.next_back().is_none());
 }
 
 #[test]


### PR DESCRIPTION
This PR updates the implementation of `RefIter` so that `head` and `tail` always hold the last value returned from `next` and `next_back` respectively. `None` means there has been no invocation.

This PR also tweaks how we handle reference count in RefIter, and adds `Drop` implementation to `Iter` which is a consumer of `RefIter` to avoid leaking memory.

Closes #737.