### PR TITLE
Fix skiplist Range API

### DIFF
--- a/crossbeam-skiplist/src/base.rs
+++ b/crossbeam-skiplist/src/base.rs
@@ -1972,13 +1972,13 @@ where
                 }
                 next_tail
             }
-            None => try_pin_loop(|| self.parent.upper_bound(self.range.start_bound(), guard)),
+            None => try_pin_loop(|| self.parent.upper_bound(self.range.end_bound(), guard)),
         };
         let mut finished = false;
         if let Some(ref t) = self.tail {
             let bound = match self.head {
                 Some(ref h) => Bound::Excluded(h.key().borrow()),
-                None => self.range.end_bound(),
+                None => self.range.start_bound(),
             };
             if !above_lower_bound(&bound, t.key().borrow()) {
                 finished = true;

--- a/crossbeam-skiplist/src/map.rs
+++ b/crossbeam-skiplist/src/map.rs
@@ -740,3 +740,15 @@ where
             .finish()
     }
 }
+
+impl<Q, R, K, V> Drop for Range<'_, Q, R, K, V>
+where
+    K: Ord + Borrow<Q>,
+    R: RangeBounds<Q>,
+    Q: Ord + ?Sized,
+{
+    fn drop(&mut self) {
+        let guard = &epoch::pin();
+        self.inner.drop_impl(guard);
+    }
+}

--- a/crossbeam-skiplist/tests/map.rs
+++ b/crossbeam-skiplist/tests/map.rs
@@ -147,6 +147,17 @@ fn next_back_memory_leak() {
 }
 
 #[test]
+fn range_next_memory_leak() {
+    let map: SkipMap<i32, i32> = iter::once((1, 1)).collect();
+    let mut iter = map.range(0..);
+    let e = iter.next();
+    assert!(e.is_some());
+    let e = iter.next_back();
+    assert!(e.is_none());
+    map.remove(&1);
+}
+
+#[test]
 fn entry() {
     let s = SkipMap::new();
 
@@ -197,6 +208,32 @@ fn ordered_iter() {
     assert!(iter.next_back().is_none());
 }
 
+#[test]
+fn ordered_range() {
+    let s: SkipMap<i32, i32> = SkipMap::new();
+    s.insert(1, 1);
+
+    let mut iter = s.range(0..);
+    assert!(iter.next().is_some());
+    assert!(iter.next().is_none());
+    assert!(iter.next().is_none());
+
+    s.insert(2, 2);
+    assert!(iter.next().is_some());
+    assert!(iter.next().is_none());
+    assert!(iter.next().is_none());
+
+    s.insert(3, 3);
+    s.insert(4, 4);
+    s.insert(5, 5);
+    assert_eq!(*iter.next_back().unwrap().key(), 5);
+    assert_eq!(*iter.next().unwrap().key(), 3);
+    assert_eq!(*iter.next_back().unwrap().key(), 4);
+    assert!(iter.next().is_none());
+    assert!(iter.next_back().is_none());
+    assert!(iter.next().is_none());
+    assert!(iter.next_back().is_none());
+}
 #[test]
 fn entry_remove() {
     let s = SkipMap::new();
@@ -579,6 +616,13 @@ fn iter_range() {
             .map(|x| *x.value())
             .collect::<Vec<_>>(),
         vec![0, 10, 20, 30, 40, 50, 60, 70, 80, 90]
+    );
+    assert_eq!(
+        s.range((Included(&0), Included(&60)))
+            .rev()
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![60, 50, 40, 30, 20, 10, 0]
     );
     assert_eq!(
         s.range((Excluded(&0), Unbounded))


### PR DESCRIPTION
This PR fixes two issues in skiplist Range API.

1. `next_back` does not work as expected
2. Range can leak memory

We fix the first one by using the correct bound when searching for the upper/lower bound (3406d84) and the second one by the same approach used in #738 (a7caaf1).