### PR TITLE
Add block cache to SegQueue-alikes

### DIFF
--- a/crossbeam-channel/benchmarks/Cargo.toml
+++ b/crossbeam-channel/benchmarks/Cargo.toml
@@ -75,3 +75,8 @@ doc = false
 name = "mpmc"
 path = "mpmc.rs"
 doc = false
+
+[[bin]]
+name = "send-latency"
+path = "send-latency.rs"
+doc = false

--- a/crossbeam-channel/benchmarks/Cargo.toml
+++ b/crossbeam-channel/benchmarks/Cargo.toml
@@ -13,6 +13,7 @@ crossbeam-channel = { path = ".." }
 crossbeam-deque = { path = "../../crossbeam-deque" }
 flume = "0.10"
 futures = { version = "0.3", features = ["thread-pool"] }
+libc = "0.2"
 lockfree = "0.5.1"
 mpmc = "0.1.5"
 
@@ -79,4 +80,9 @@ doc = false
 [[bin]]
 name = "send-latency"
 path = "send-latency.rs"
+doc = false
+
+[[bin]]
+name = "unbounded-alloc"
+path = "unbounded-alloc.rs"
 doc = false

--- a/crossbeam-channel/benchmarks/send-latency.rs
+++ b/crossbeam-channel/benchmarks/send-latency.rs
@@ -1,0 +1,163 @@
+use crossbeam::channel::unbounded;
+
+mod message;
+
+const MESSAGES: usize = 5_000_000;
+const THREADS: usize = 4;
+
+struct Stats {
+    min: f64,
+    max: f64,
+    mean: f64,
+    _s: f64,
+}
+
+impl Stats {
+    fn new() -> Self {
+        Self { min: f64::MAX, max: f64::MIN, mean: 0.0, _s: 0.0 }
+    }
+
+    fn update(&mut self, x: f64, i: usize) {
+        self.min = self.min.min(x);
+        self.max = self.max.max(x);
+        let mean_prev = self.mean;
+        self.mean = self.mean + ((x - self.mean) / ((i + 1) as f64));
+        self._s = self._s + ((x - mean_prev) * (x - self.mean));
+    }
+
+    fn stddev(&self, i: usize) -> f64 {
+        (self._s / (i as f64)).sqrt()
+    }
+}
+
+fn spsc() -> (f64, f64, f64, f64) {
+    let (tx, rx) = unbounded();
+    let mut stats = Stats::new();
+    crossbeam::scope(|scope| {
+        scope.spawn(|_| {
+            for i in 0..MESSAGES / 1000 {
+                let before = std::time::Instant::now();
+                for i in 0..1000 {
+                    tx.send(message::new(i)).unwrap();
+                }
+                let elapsed = (std::time::Instant::now() - before).as_secs_f64();
+                stats.update(elapsed, i)
+            }
+        });
+
+        for _ in 0..MESSAGES {
+            rx.recv().unwrap();
+        }
+    })
+    .unwrap();
+    (stats.min, stats.max, stats.mean, stats.stddev(MESSAGES - 1))
+}
+
+fn mpsc() -> (f64, f64, f64, f64) {
+    let (tx, rx) = unbounded();
+    let mut stats = Stats::new();
+    crossbeam::scope(|scope| {
+        for _ in 0..THREADS - 1 {
+            scope.spawn(|_| {
+                for i in 0..MESSAGES / THREADS {
+                    tx.send(message::new(i)).unwrap();
+                }
+            });
+        }
+        scope.spawn(|_| {
+            for i in 0..MESSAGES / THREADS / 1000 {
+                let before = std::time::Instant::now();
+                for i in 0..1000 {
+                    tx.send(message::new(i)).unwrap();
+                }
+                let elapsed = (std::time::Instant::now() - before).as_secs_f64();
+                stats.update(elapsed, i)
+            }
+        });
+
+        for _ in 0..MESSAGES {
+            rx.recv().unwrap();
+        }
+    })
+    .unwrap();
+    (stats.min, stats.max, stats.mean, stats.stddev(MESSAGES - 1))
+}
+
+fn spmc() -> (f64, f64, f64, f64) {
+    let (tx, rx) = unbounded();
+    let mut stats = Stats::new();
+    crossbeam::scope(|scope| {
+        scope.spawn(|_| {
+            for i in 0..MESSAGES / 1000 {
+                let before = std::time::Instant::now();
+                for i in 0..1000 {
+                    tx.send(message::new(i)).unwrap();
+                }
+                let elapsed = (std::time::Instant::now() - before).as_secs_f64();
+                stats.update(elapsed, i)
+            }
+        });
+
+        for _ in 0..THREADS {
+            scope.spawn(|_| {
+                for _ in 0..MESSAGES / THREADS {
+                    rx.recv().unwrap();
+                }
+            });
+        }
+    })
+    .unwrap();
+    (stats.min, stats.max, stats.mean, stats.stddev(MESSAGES - 1))
+}
+
+fn mpmc() -> (f64, f64, f64, f64) {
+    let (tx, rx) = unbounded();
+    let mut stats = Stats::new();
+    crossbeam::scope(|scope| {
+        for _ in 0..THREADS - 1 {
+            scope.spawn(|_| {
+                for i in 0..MESSAGES / THREADS {
+                    tx.send(message::new(i)).unwrap();
+                }
+            });
+        }
+        scope.spawn(|_| {
+            for i in 0..MESSAGES / THREADS / 1000 {
+                let before = std::time::Instant::now();
+                for i in 0..1000 {
+                    tx.send(message::new(i)).unwrap();
+                }
+                let elapsed = (std::time::Instant::now() - before).as_secs_f64();
+                stats.update(elapsed, i)
+            }
+        });
+
+        for _ in 0..THREADS {
+            scope.spawn(|_| {
+                for _ in 0..MESSAGES / THREADS {
+                    rx.recv().unwrap();
+                }
+            });
+        }
+    })
+    .unwrap();
+    (stats.min, stats.max, stats.mean, stats.stddev(MESSAGES - 1))
+}
+
+fn run(name: &str, (min, max, mean, stddev): (f64, f64, f64, f64)) {
+    println!(
+        "{} | min: {:.9}, max: {:.9}, mean: {:.9}, stddev: {:.9}",
+        name, min, max, mean, stddev
+    );
+}
+
+fn main() {
+    run("spsc", spsc());
+    run("spsc", spsc());
+    run("mpsc", mpsc());
+    run("mpsc", mpsc());
+    run("spmc", spmc());
+    run("spmc", spmc());
+    run("mpmc", mpmc());
+    run("mpmc", mpmc());
+}

--- a/crossbeam-channel/benchmarks/send-latency.rs
+++ b/crossbeam-channel/benchmarks/send-latency.rs
@@ -14,7 +14,12 @@ struct Stats {
 
 impl Stats {
     fn new() -> Self {
-        Self { min: f64::MAX, max: f64::MIN, mean: 0.0, _s: 0.0 }
+        Self {
+            min: f64::MAX,
+            max: f64::MIN,
+            mean: 0.0,
+            _s: 0.0,
+        }
     }
 
     fn update(&mut self, x: f64, i: usize) {

--- a/crossbeam-channel/benchmarks/unbounded-alloc.rs
+++ b/crossbeam-channel/benchmarks/unbounded-alloc.rs
@@ -1,0 +1,138 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use crossbeam::channel::unbounded;
+
+mod message;
+
+const MESSAGES: usize = 31 * 160_000;
+const THREADS: usize = 4;
+
+struct Counter;
+
+static NUM_ALLOCS: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for Counter {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        NUM_ALLOCS.fetch_add(1, Ordering::Relaxed);
+        System.alloc(layout)
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout);
+    }
+}
+
+#[global_allocator]
+static A: Counter = Counter;
+
+fn spsc() -> usize {
+    let (tx, rx) = unbounded();
+    let before = NUM_ALLOCS.load(Ordering::Relaxed);
+    crossbeam::scope(|scope| {
+        scope.spawn(|_| {
+            for i in 0..MESSAGES / 31 {
+                for _ in 0..31 {
+                    tx.send(message::new(i)).unwrap();
+                }
+                std::thread::yield_now();
+            }
+        });
+
+        for _ in 0..MESSAGES {
+            rx.recv().unwrap();
+        }
+    })
+    .unwrap();
+    NUM_ALLOCS.load(Ordering::Relaxed) - before
+}
+
+fn mpsc() -> usize {
+    let (tx, rx) = unbounded();
+    let before = NUM_ALLOCS.load(Ordering::Relaxed);
+    crossbeam::scope(|scope| {
+        for _ in 0..THREADS {
+            scope.spawn(|_| {
+                for i in 0..MESSAGES / THREADS / 31 {
+                    for _ in 0..31 {
+                        tx.send(message::new(i)).unwrap();
+                    }
+                    std::thread::yield_now();
+                }
+            });
+        }
+
+        for _ in 0..MESSAGES {
+            rx.recv().unwrap();
+        }
+    })
+    .unwrap();
+    NUM_ALLOCS.load(Ordering::Relaxed) - before
+}
+
+fn spmc() -> usize {
+    let (tx, rx) = unbounded();
+    let before = NUM_ALLOCS.load(Ordering::Relaxed);
+    crossbeam::scope(|scope| {
+        scope.spawn(|_| {
+            for i in 0..MESSAGES / 31 {
+                for _ in 0..31 {
+                    tx.send(message::new(i)).unwrap();
+                }
+                std::thread::yield_now();
+            }
+        });
+
+        for _ in 0..THREADS {
+            scope.spawn(|_| {
+                for _ in 0..MESSAGES / THREADS {
+                    rx.recv().unwrap();
+                }
+            });
+        }
+    })
+    .unwrap();
+    NUM_ALLOCS.load(Ordering::Relaxed) - before
+}
+
+fn mpmc() -> usize {
+    let (tx, rx) = unbounded();
+    let before = NUM_ALLOCS.load(Ordering::Relaxed);
+    crossbeam::scope(|scope| {
+        for _ in 0..THREADS {
+            scope.spawn(|_| {
+                for i in 0..MESSAGES / THREADS / 31 {
+                    for _ in 0..31 {
+                        tx.send(message::new(i)).unwrap();
+                    }
+                    std::thread::yield_now();
+                }
+            });
+        }
+
+        for _ in 0..THREADS {
+            scope.spawn(|_| {
+                for _ in 0..MESSAGES / THREADS {
+                    rx.recv().unwrap();
+                }
+            });
+        }
+    })
+    .unwrap();
+    NUM_ALLOCS.load(Ordering::Relaxed) - before
+}
+
+fn run(name: &str, n_allocs: usize) {
+    println!("{} | allocs: {}", name, n_allocs);
+}
+
+fn main() {
+    run("spsc", spsc());
+    run("spsc", spsc());
+    run("mpsc", mpsc());
+    run("mpsc", mpsc());
+    run("spmc", spmc());
+    run("spmc", spmc());
+    run("mpmc", mpmc());
+    run("mpmc", mpmc());
+}

--- a/crossbeam-channel/src/flavors/list.rs
+++ b/crossbeam-channel/src/flavors/list.rs
@@ -151,20 +151,17 @@ pub(crate) struct Channel<T> {
 impl<T> Channel<T> {
     /// Creates a new unbounded channel.
     pub(crate) fn new() -> Self {
-        let first = Box::into_raw(Box::new(Block::<T>::new()));
         Channel {
             head: CachePadded::new(Position {
-                block: AtomicPtr::new(first),
+                block: AtomicPtr::new(ptr::null_mut()),
                 index: AtomicUsize::new(0),
             }),
             tail: CachePadded::new(Position {
-                block: AtomicPtr::new(first),
+                block: AtomicPtr::new(ptr::null_mut()),
                 index: AtomicUsize::new(0),
             }),
             receivers: SyncWaker::new(),
-            cached_block: CachePadded::new(AtomicPtr::new(Box::into_raw(Box::new(
-                Block::<T>::new(),
-            )))),
+            cached_block: CachePadded::new(AtomicPtr::new(ptr::null_mut())),
             _marker: PhantomData,
         }
     }
@@ -217,6 +214,27 @@ impl<T> Channel<T> {
                     } else {
                         Some(unsafe { Box::from_raw(cached) })
                     };
+                }
+            }
+
+            // If this is the first message to be sent into the channel, we need to allocate the
+            // first block and install it.
+            if block.is_null() {
+                let new = Box::into_raw(Box::new(Block::<T>::new()));
+
+                if self
+                    .tail
+                    .block
+                    .compare_exchange(block, new, Ordering::Release, Ordering::Relaxed)
+                    .is_ok()
+                {
+                    self.head.block.store(new, Ordering::Release);
+                    block = new;
+                } else {
+                    next_block = unsafe { Some(Box::from_raw(new)) };
+                    tail = self.tail.index.load(Ordering::Acquire);
+                    block = self.tail.block.load(Ordering::Acquire);
+                    continue;
                 }
             }
 

--- a/crossbeam-channel/src/flavors/list.rs
+++ b/crossbeam-channel/src/flavors/list.rs
@@ -103,6 +103,7 @@ struct BlockCacheSplitIndices {
     tail: AtomicU32,
 }
 
+#[repr(C)]
 #[cfg(target_endian = "big")]
 struct BlockCacheSplitIndices {
     tail: AtomicU32,

--- a/crossbeam-channel/src/flavors/list.rs
+++ b/crossbeam-channel/src/flavors/list.rs
@@ -2,7 +2,7 @@
 
 use std::cell::UnsafeCell;
 use std::marker::PhantomData;
-use std::mem::{ManuallyDrop, MaybeUninit};
+use std::mem::{self, ManuallyDrop, MaybeUninit};
 use std::ptr;
 use std::sync::atomic::{self, AtomicPtr, AtomicUsize, Ordering};
 use std::time::Instant;
@@ -148,7 +148,7 @@ impl<T> BlockCache<T> {
         loop {
             let both = self.indices.both.load(Ordering::Relaxed);
             let head = both as Uhalf;
-            let tail = (both >> std::mem::size_of::<Uhalf>()) as Uhalf;
+            let tail = (both >> (mem::size_of::<Uhalf>() * 8)) as Uhalf;
 
             if head == tail {
                 return ptr::null_mut();
@@ -170,7 +170,7 @@ impl<T> BlockCache<T> {
     unsafe fn try_put(&self, block: *mut Block<T>) -> *mut Block<T> {
         let both = self.indices.both.load(Ordering::Relaxed);
         let head = both as Uhalf;
-        let tail = (both >> std::mem::size_of::<Uhalf>()) as Uhalf;
+        let tail = (both >> (mem::size_of::<Uhalf>() * 8)) as Uhalf;
 
         if tail - head == BLOCK_CACHE_SIZE as Uhalf {
             return block;

--- a/crossbeam-channel/src/flavors/list.rs
+++ b/crossbeam-channel/src/flavors/list.rs
@@ -206,11 +206,11 @@ impl<T> Channel<T> {
             // short as possible.
             if offset + 1 == BLOCK_CAP && next_block.is_none() {
                 if self.cached_block.load(Ordering::Relaxed).is_null() {
-                    next_block = Some(Box::new(Block::<T>::new()));
+                    next_block = Some(Box::new(Block::new()));
                 } else {
                     let cached = self.cached_block.swap(ptr::null_mut(), Ordering::Acquire);
                     next_block = if cached.is_null() {
-                        Some(Box::new(Block::<T>::new()))
+                        Some(Box::new(Block::new()))
                     } else {
                         Some(unsafe { Box::from_raw(cached) })
                     };
@@ -220,7 +220,7 @@ impl<T> Channel<T> {
             // If this is the first message to be sent into the channel, we need to allocate the
             // first block and install it.
             if block.is_null() {
-                let new = Box::into_raw(Box::new(Block::<T>::new()));
+                let new = Box::into_raw(Box::new(Block::new()));
 
                 if self
                     .tail

--- a/crossbeam-channel/src/flavors/list.rs
+++ b/crossbeam-channel/src/flavors/list.rs
@@ -397,12 +397,9 @@ impl<T> Channel<T> {
             drop(Box::from_raw(this));
         } else {
             *this = MaybeUninit::zeroed().assume_init();
-            if self
-                .cached_block
-                .compare_exchange(cached, this, Ordering::Release, Ordering::Relaxed)
-                .is_err()
-            {
-                drop(Box::from_raw(this));
+            let prev = self.cached_block.swap(this, Ordering::Release);
+            if !prev.is_null() {
+                drop(Box::from_raw(prev));
             }
         }
     }

--- a/crossbeam-channel/src/flavors/list.rs
+++ b/crossbeam-channel/src/flavors/list.rs
@@ -159,10 +159,9 @@ impl<T> BlockCache<T> {
         }
 
         *block = MaybeUninit::zeroed().assume_init();
-        let prev = self.blocks[tail as usize & (BLOCK_CACHE_SIZE - 1)]
-                .swap(block, Ordering::Release);
-        self
-            .indices
+        let prev =
+            self.blocks[tail as usize & (BLOCK_CACHE_SIZE - 1)].swap(block, Ordering::Release);
+        self.indices
             .split
             .tail
             .compare_exchange_weak(tail, tail + 1, Ordering::Relaxed, Ordering::Relaxed)

--- a/crossbeam-channel/src/flavors/list.rs
+++ b/crossbeam-channel/src/flavors/list.rs
@@ -755,15 +755,12 @@ impl<T> Drop for Channel<T> {
             if !block.is_null() {
                 drop(Box::from_raw(block));
             }
-            self.block_cache
-                .blocks
-                .iter()
-                .map(|b| b.load(Ordering::Relaxed))
-                .for_each(|p| {
-                    if !p.is_null() {
-                        drop(Box::from_raw(p));
-                    }
-                });
+            for b in &self.block_cache.blocks {
+                let p = b.load(Ordering::Relaxed);
+                if !p.is_null() {
+                    drop(Box::from_raw(p));
+                }
+            }
         }
     }
 }

--- a/crossbeam-channel/src/flavors/list.rs
+++ b/crossbeam-channel/src/flavors/list.rs
@@ -179,11 +179,12 @@ impl<T> BlockCache<T> {
         *block = MaybeUninit::zeroed().assume_init();
         let prev =
             self.blocks[tail as usize & (BLOCK_CACHE_SIZE - 1)].swap(block, Ordering::Release);
-        self.indices
-            .split
-            .tail
-            .compare_exchange_weak(tail, tail + 1, Ordering::Relaxed, Ordering::Relaxed)
-            .ok();
+        let _ = self.indices.split.tail.compare_exchange_weak(
+            tail,
+            tail + 1,
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+        );
         prev
     }
 }

--- a/crossbeam-channel/tests/alloc.rs
+++ b/crossbeam-channel/tests/alloc.rs
@@ -1,11 +1,13 @@
 //! Tests which require a global allocator that counts allocations.
 
 use std::alloc::{GlobalAlloc, Layout, System};
-use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crossbeam_channel::{bounded, unbounded};
 use crossbeam_utils::thread::scope;
+use rand::{thread_rng, Rng};
+
+const BLOCK_CAP: usize = 31;
 
 struct Counter;
 
@@ -13,11 +15,8 @@ static NUM_ALLOCS: AtomicUsize = AtomicUsize::new(0);
 
 unsafe impl GlobalAlloc for Counter {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        let ret = System.alloc(layout);
-        if !ret.is_null() {
-            NUM_ALLOCS.fetch_add(1, Ordering::SeqCst);
-        }
-        return ret;
+        NUM_ALLOCS.fetch_add(1, Ordering::Relaxed);
+        System.alloc(layout)
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
@@ -32,54 +31,68 @@ static A: Counter = Counter;
 fn allocs() {
     let (s, r) = unbounded();
 
-    // We expect to see the first (and only) additional allocation after exactly
-    // BLOCK_CAP sends and receives.
-    let before = NUM_ALLOCS.load(Ordering::SeqCst);
-    for i in 0..30 {
+    // We expect to see the first additional allocation after exactly BLOCK_CAP sends and receives.
+    let before = NUM_ALLOCS.load(Ordering::Relaxed);
+    for i in 0..BLOCK_CAP - 1 {
         s.send(i as i32).unwrap();
         r.recv().unwrap();
     }
-    let after = NUM_ALLOCS.load(Ordering::SeqCst);
-    assert_eq!(after, before);
-    s.send(1).unwrap();
+    let after = NUM_ALLOCS.load(Ordering::Relaxed);
+    assert_eq!(before, after);
+    s.send((BLOCK_CAP - 1) as i32).unwrap();
     r.recv().unwrap();
-    let after = NUM_ALLOCS.load(Ordering::SeqCst);
-    assert_eq!(after, before + 1);
+    let after = NUM_ALLOCS.load(Ordering::Relaxed);
+    assert_eq!(before + 1, after);
 
-    // Now we can send up to BLOCK_CAP messages before incurring an allocation.
-    for _ in 0..100 {
-        let before = NUM_ALLOCS.load(Ordering::SeqCst);
-        for i in 0..31 {
-            s.send(i as i32).unwrap();
-        }
-        for _ in 0..31 {
-            r.recv().unwrap();
-        }
-        let after = NUM_ALLOCS.load(Ordering::SeqCst);
-        assert_eq!(before, after);
+    // Warm up the cache by sending BLOCK_CAP * 4  more messages.
+    let before = after;
+    for i in 0..BLOCK_CAP * 4 {
+        s.send(i as i32).unwrap();
     }
+    for _ in 0..BLOCK_CAP * 4 {
+        r.recv().unwrap();
+    }
+    let after = NUM_ALLOCS.load(Ordering::Relaxed);
+    assert_eq!(before + 3, after);
 
-    let (ready_s, ready_r) = bounded(1);
-    let before = NUM_ALLOCS.load(Ordering::SeqCst);
+    // Now we can send up to BLOCK_CAP * 4 messages before incurring an allocation.
+    let mut rng = thread_rng();
+    let (count_s, count_r) = bounded(1);
     scope(|scope| {
         scope.spawn(|_| {
+            // Get the waker allocations out of the way before starting the test.
+            for _ in 0..8 {
+                count_r.recv().unwrap();
+            }
+
+            let before = NUM_ALLOCS.load(Ordering::Relaxed);
             for i in 0..100_000 {
-                for _ in 0..31 {
+                let count = count_r.recv().unwrap();
+                for _ in 0..count {
                     s.send(i as i32).unwrap();
                 }
-                ready_r.recv().unwrap();
             }
+            let after = NUM_ALLOCS.load(Ordering::Relaxed);
+            assert_eq!(before, after);
         });
-        for _ in 0..100_000 {
-            for _ in 0..31 {
+
+        // Get the waker allocations out of the way before starting the test.
+        let _ = r.recv_timeout(std::time::Duration::from_millis(10));
+        for i in 0..8 {
+            count_s.send(i).unwrap();
+        }
+
+        for i in 0..100_000 {
+            let count = if i % 2 == 0 {
+                BLOCK_CAP * 4
+            } else {
+                rng.gen_range(1..BLOCK_CAP * 4)
+            };
+            count_s.send(count).unwrap();
+            for _ in 0..count {
                 r.recv().unwrap();
             }
-            ready_s.send(()).unwrap();
         }
     })
     .unwrap();
-    let after = NUM_ALLOCS.load(Ordering::SeqCst);
-    // Exactly 19 allocations are made every time on my box. Let's say 50 to be
-    // safe.
-    assert!(before + 50 > after);
 }

--- a/crossbeam-channel/tests/alloc.rs
+++ b/crossbeam-channel/tests/alloc.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
 use crossbeam_channel::unbounded;
+use crossbeam_utils::thread::scope;
 
 struct Counter;
 
@@ -21,7 +22,6 @@ unsafe impl GlobalAlloc for Counter {
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         System.dealloc(ptr, layout);
-        NUM_ALLOCS.fetch_sub(1, Ordering::SeqCst);
     }
 }
 
@@ -35,8 +35,8 @@ fn allocs() {
     // We expect to see the first (and only) additional allocation after exactly
     // BLOCK_CAP sends and receives.
     let before = NUM_ALLOCS.load(Ordering::SeqCst);
-    for _ in 0..30 {
-        s.send(1).unwrap();
+    for i in 0..30 {
+        s.send(i as i32).unwrap();
         r.recv().unwrap();
     }
     let after = NUM_ALLOCS.load(Ordering::SeqCst);
@@ -49,8 +49,8 @@ fn allocs() {
     // Now we can send up to BLOCK_CAP messages before incurring an allocation.
     for _ in 0..100 {
         let before = NUM_ALLOCS.load(Ordering::SeqCst);
-        for _ in 0..31 {
-            s.send(1).unwrap();
+        for i in 0..31 {
+            s.send(i as i32).unwrap();
         }
         for _ in 0..31 {
             r.recv().unwrap();
@@ -58,4 +58,40 @@ fn allocs() {
         let after = NUM_ALLOCS.load(Ordering::SeqCst);
         assert_eq!(before, after);
     }
+
+    let before = NUM_ALLOCS.load(Ordering::SeqCst);
+    scope(|scope| {
+        scope.spawn(|_| {
+            for i in 0..31 * 1_000_000 {
+                s.send(i as i32).unwrap();
+            }
+        });
+        for _ in 0..31 * 1_000_000 {
+            r.recv().unwrap();
+        }
+    })
+    .unwrap();
+    let after = NUM_ALLOCS.load(Ordering::SeqCst);
+    assert!(after < before + 500_000);
+
+    let threads = num_cpus::get();
+    let before = NUM_ALLOCS.load(Ordering::SeqCst);
+    scope(|scope| {
+        for _ in 0..threads / 2 {
+            scope.spawn(|_| {
+                for i in 0..31 * 100_000 {
+                    s.send(i as i32).unwrap();
+                }
+            });
+        }
+        std::thread::sleep(std::time::Duration::from_millis(1000));
+        for _ in 0..threads / 2 {
+            for _ in 0..31 * 100_000 {
+                r.recv().unwrap();
+            }
+        }
+    })
+    .unwrap();
+    let after = NUM_ALLOCS.load(Ordering::SeqCst);
+    assert!(after < before + ((threads / 4) * 100_000));
 }

--- a/crossbeam-channel/tests/alloc.rs
+++ b/crossbeam-channel/tests/alloc.rs
@@ -1,0 +1,61 @@
+//! Tests which require a global allocator that counts allocations.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+
+use crossbeam_channel::unbounded;
+
+struct Counter;
+
+static NUM_ALLOCS: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for Counter {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ret = System.alloc(layout);
+        if !ret.is_null() {
+            NUM_ALLOCS.fetch_add(1, Ordering::SeqCst);
+        }
+        return ret;
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout);
+        NUM_ALLOCS.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+#[global_allocator]
+static A: Counter = Counter;
+
+#[test]
+fn allocs() {
+    let (s, r) = unbounded();
+
+    // We expect to see the first (and only) additional allocation after exactly
+    // BLOCK_CAP sends and receives.
+    let before = NUM_ALLOCS.load(Ordering::SeqCst);
+    for _ in 0..30 {
+        s.send(1).unwrap();
+        r.recv().unwrap();
+    }
+    let after = NUM_ALLOCS.load(Ordering::SeqCst);
+    assert_eq!(after, before);
+    s.send(1).unwrap();
+    r.recv().unwrap();
+    let after = NUM_ALLOCS.load(Ordering::SeqCst);
+    assert_eq!(after, before + 1);
+
+    // Now we can send up to BLOCK_CAP messages before incurring an allocation.
+    for _ in 0..100 {
+        let before = NUM_ALLOCS.load(Ordering::SeqCst);
+        for _ in 0..31 {
+            s.send(1).unwrap();
+        }
+        for _ in 0..31 {
+            r.recv().unwrap();
+        }
+        let after = NUM_ALLOCS.load(Ordering::SeqCst);
+        assert_eq!(before, after);
+    }
+}

--- a/crossbeam-deque/src/deque.rs
+++ b/crossbeam-deque/src/deque.rs
@@ -1960,15 +1960,12 @@ impl<T> Drop for Injector<T> {
             if !block.is_null() {
                 drop(Box::from_raw(block));
             }
-            self.block_cache
-                .blocks
-                .iter()
-                .map(|b| b.load(Ordering::Relaxed))
-                .for_each(|p| {
-                    if !p.is_null() {
-                        drop(Box::from_raw(p));
-                    }
-                });
+            for b in &self.block_cache.blocks {
+                let p = b.load(Ordering::Relaxed);
+                if !p.is_null() {
+                    drop(Box::from_raw(p));
+                }
+            }
         }
     }
 }

--- a/crossbeam-deque/src/deque.rs
+++ b/crossbeam-deque/src/deque.rs
@@ -3,7 +3,7 @@ use std::cmp;
 use std::fmt;
 use std::iter::FromIterator;
 use std::marker::PhantomData;
-use std::mem::{self, MaybeUninit};
+use std::mem::{self, ManuallyDrop, MaybeUninit};
 use std::ptr;
 use std::sync::atomic::{self, AtomicIsize, AtomicPtr, AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -1108,6 +1108,8 @@ const DESTROY: usize = 4;
 const LAP: usize = 64;
 // The maximum number of values a block can hold.
 const BLOCK_CAP: usize = LAP - 1;
+// The maximum number of blocks to retain in the block cache. Must be a power of two.
+const BLOCK_CACHE_SIZE: usize = 4;
 // How many lower bits are reserved for metadata.
 const SHIFT: usize = 1;
 // Indicates that the block is not the last one.
@@ -1166,25 +1168,97 @@ impl<T> Block<T> {
             backoff.snooze();
         }
     }
+}
 
-    /// Sets the `DESTROY` bit in slots starting from `start` and destroys the block.
-    unsafe fn destroy(this: *mut Block<T>, count: usize) {
-        // It is not necessary to set the `DESTROY` bit in the last slot because that slot has
-        // begun destruction of the block.
-        for i in (0..count).rev() {
-            let slot = (*this).slots.get_unchecked(i);
+#[cfg(target_pointer_width = "16")]
+type Uhalf = u8;
+#[cfg(target_pointer_width = "16")]
+type AtomicUhalf = std::sync::atomic::AtomicU8;
 
-            // Mark the `DESTROY` bit if a thread is still using the slot.
-            if slot.state.load(Ordering::Acquire) & READ == 0
-                && slot.state.fetch_or(DESTROY, Ordering::AcqRel) & READ == 0
+#[cfg(target_pointer_width = "32")]
+type Uhalf = u16;
+#[cfg(target_pointer_width = "32")]
+type AtomicUhalf = std::sync::atomic::AtomicU16;
+
+#[cfg(target_pointer_width = "64")]
+type Uhalf = u32;
+#[cfg(target_pointer_width = "64")]
+type AtomicUhalf = std::sync::atomic::AtomicU32;
+
+#[repr(C)]
+#[cfg(target_endian = "little")]
+struct BlockCacheSplitIndices {
+    head: AtomicUhalf,
+    tail: AtomicUhalf,
+}
+
+#[repr(C)]
+#[cfg(target_endian = "big")]
+struct BlockCacheSplitIndices {
+    tail: AtomicUhalf,
+    head: AtomicUhalf,
+}
+
+#[repr(C)]
+union BlockCacheIndices {
+    both: ManuallyDrop<AtomicUsize>,
+    split: ManuallyDrop<BlockCacheSplitIndices>,
+}
+
+struct BlockCache<T> {
+    indices: BlockCacheIndices,
+    blocks: [AtomicPtr<Block<T>>; BLOCK_CACHE_SIZE],
+}
+
+impl<T> BlockCache<T> {
+    fn new() -> Self {
+        // SAFETY: This is safe because:
+        //  [1] `BlockCache::indices` (BlockCacheIndices) may be safely zero initialized.
+        //  [2] `BlockCache::blocks` (AtomicPtr array) may be safely zero initialized.
+        unsafe { MaybeUninit::zeroed().assume_init() }
+    }
+
+    unsafe fn try_get(&self) -> *mut Block<T> {
+        loop {
+            let both = self.indices.both.load(Ordering::Relaxed);
+            let head = both as Uhalf;
+            let tail = (both >> std::mem::size_of::<Uhalf>()) as Uhalf;
+
+            if head == tail {
+                return ptr::null_mut();
+            }
+
+            if self
+                .indices
+                .split
+                .head
+                .compare_exchange_weak(head, head + 1, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
             {
-                // If a thread is still using the slot, it will continue destruction of the block.
-                return;
+                return self.blocks[head as usize & (BLOCK_CACHE_SIZE - 1)]
+                    .swap(ptr::null_mut(), Ordering::Acquire);
             }
         }
+    }
 
-        // No thread is using the block, now it is safe to destroy it.
-        drop(Box::from_raw(this));
+    unsafe fn try_put(&self, block: *mut Block<T>) -> *mut Block<T> {
+        let both = self.indices.both.load(Ordering::Relaxed);
+        let head = both as Uhalf;
+        let tail = (both >> std::mem::size_of::<Uhalf>()) as Uhalf;
+
+        if tail - head == BLOCK_CACHE_SIZE as Uhalf {
+            return block;
+        }
+
+        *block = MaybeUninit::zeroed().assume_init();
+        let prev =
+            self.blocks[tail as usize & (BLOCK_CACHE_SIZE - 1)].swap(block, Ordering::Release);
+        self.indices
+            .split
+            .tail
+            .compare_exchange_weak(tail, tail + 1, Ordering::Relaxed, Ordering::Relaxed)
+            .ok();
+        prev
     }
 }
 
@@ -1222,6 +1296,9 @@ pub struct Injector<T> {
     /// The tail of the queue.
     tail: CachePadded<Position<T>>,
 
+    /// Cache some number of blocks to avoid allocations when possible.
+    block_cache: CachePadded<BlockCache<T>>,
+
     /// Indicates that dropping a `Injector<T>` may drop values of type `T`.
     _marker: PhantomData<T>,
 }
@@ -1241,6 +1318,7 @@ impl<T> Default for Injector<T> {
                 block: AtomicPtr::new(block),
                 index: AtomicUsize::new(0),
             }),
+            block_cache: CachePadded::new(BlockCache::new()),
             _marker: PhantomData,
         }
     }
@@ -1289,12 +1367,17 @@ impl<T> Injector<T> {
                 continue;
             }
 
-            // If we're going to have to install the next block, allocate it in advance in order to
-            // make the wait for other threads as short as possible.
+            // If we're going to have to install the next block, get or allocate
+            // it in advance in order to make the wait for other threads as
+            // short as possible.
             if offset + 1 == BLOCK_CAP && next_block.is_none() {
-                next_block = Some(Box::new(Block::<T>::new()));
+                let p = unsafe { self.block_cache.try_get() };
+                next_block = if p.is_null() {
+                    Some(Box::new(Block::new()))
+                } else {
+                    Some(unsafe { Box::from_raw(p) })
+                };
             }
-
             let new_tail = tail + (1 << SHIFT);
 
             // Try advancing the tail forward.
@@ -1328,6 +1411,31 @@ impl<T> Injector<T> {
                     backoff.spin();
                 }
             }
+        }
+    }
+
+    /// Sets the `DESTROY` bit in slots counting down from `count` and caches or destroys the
+    /// block.
+    unsafe fn cache_or_destroy(&self, this: *mut Block<T>, count: usize) {
+        // It is not necessary to set the `DESTROY` bit in the last slot because that slot has
+        // begun destruction of the block.
+        for i in (0..count).rev() {
+            let slot = (*this).slots.get_unchecked(i);
+
+            // Mark the `DESTROY` bit if a thread is still using the slot.
+            if slot.state.load(Ordering::Acquire) & READ == 0
+                && slot.state.fetch_or(DESTROY, Ordering::AcqRel) & READ == 0
+            {
+                // If a thread is still using the slot, it will continue destruction of the block.
+                return;
+            }
+        }
+
+        // No thread is using the block. Try to cache it for reuse or deallocate
+        // it otherwise.
+        let p = self.block_cache.try_put(this);
+        if !p.is_null() {
+            drop(Box::from_raw(p));
         }
     }
 
@@ -1417,7 +1525,7 @@ impl<T> Injector<T> {
             if (offset + 1 == BLOCK_CAP)
                 || (slot.state.fetch_or(READ, Ordering::AcqRel) & DESTROY != 0)
             {
-                Block::destroy(block, offset);
+                self.cache_or_destroy(block, offset);
             }
 
             Steal::Success(task)
@@ -1568,13 +1676,13 @@ impl<T> Injector<T> {
             // Destroy the block if we've reached the end, or if another thread wanted to destroy
             // but couldn't because we were busy reading from the slot.
             if new_offset == BLOCK_CAP {
-                Block::destroy(block, offset);
+                self.cache_or_destroy(block, offset);
             } else {
                 for i in offset..new_offset {
                     let slot = (*block).slots.get_unchecked(i);
 
                     if slot.state.fetch_or(READ, Ordering::AcqRel) & DESTROY != 0 {
-                        Block::destroy(block, offset);
+                        self.cache_or_destroy(block, offset);
                         break;
                     }
                 }
@@ -1732,13 +1840,13 @@ impl<T> Injector<T> {
             // Destroy the block if we've reached the end, or if another thread wanted to destroy
             // but couldn't because we were busy reading from the slot.
             if new_offset == BLOCK_CAP {
-                Block::destroy(block, offset);
+                self.cache_or_destroy(block, offset);
             } else {
                 for i in offset..new_offset {
                     let slot = (*block).slots.get_unchecked(i);
 
                     if slot.state.fetch_or(READ, Ordering::AcqRel) & DESTROY != 0 {
-                        Block::destroy(block, offset);
+                        self.cache_or_destroy(block, offset);
                         break;
                     }
                 }
@@ -1848,8 +1956,19 @@ impl<T> Drop for Injector<T> {
                 head = head.wrapping_add(1 << SHIFT);
             }
 
-            // Deallocate the last remaining block.
-            drop(Box::from_raw(block));
+            // Deallocate the last remaining block and any cached blocks.
+            if !block.is_null() {
+                drop(Box::from_raw(block));
+            }
+            self.block_cache
+                .blocks
+                .iter()
+                .map(|b| b.load(Ordering::Relaxed))
+                .for_each(|p| {
+                    if !p.is_null() {
+                        drop(Box::from_raw(p));
+                    }
+                });
         }
     }
 }

--- a/crossbeam-deque/src/deque.rs
+++ b/crossbeam-deque/src/deque.rs
@@ -1253,11 +1253,12 @@ impl<T> BlockCache<T> {
         *block = MaybeUninit::zeroed().assume_init();
         let prev =
             self.blocks[tail as usize & (BLOCK_CACHE_SIZE - 1)].swap(block, Ordering::Release);
-        self.indices
-            .split
-            .tail
-            .compare_exchange_weak(tail, tail + 1, Ordering::Relaxed, Ordering::Relaxed)
-            .ok();
+        let _ = self.indices.split.tail.compare_exchange_weak(
+            tail,
+            tail + 1,
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+        );
         prev
     }
 }

--- a/crossbeam-deque/src/deque.rs
+++ b/crossbeam-deque/src/deque.rs
@@ -1222,7 +1222,7 @@ impl<T> BlockCache<T> {
         loop {
             let both = self.indices.both.load(Ordering::Relaxed);
             let head = both as Uhalf;
-            let tail = (both >> std::mem::size_of::<Uhalf>()) as Uhalf;
+            let tail = (both >> (mem::size_of::<Uhalf>() * 8)) as Uhalf;
 
             if head == tail {
                 return ptr::null_mut();
@@ -1244,7 +1244,7 @@ impl<T> BlockCache<T> {
     unsafe fn try_put(&self, block: *mut Block<T>) -> *mut Block<T> {
         let both = self.indices.both.load(Ordering::Relaxed);
         let head = both as Uhalf;
-        let tail = (both >> std::mem::size_of::<Uhalf>()) as Uhalf;
+        let tail = (both >> (mem::size_of::<Uhalf>() * 8)) as Uhalf;
 
         if tail - head == BLOCK_CACHE_SIZE as Uhalf {
             return block;

--- a/crossbeam-epoch/src/internal.rs
+++ b/crossbeam-epoch/src/internal.rs
@@ -101,7 +101,7 @@ impl Bag {
 
     /// Seals the bag with the given epoch.
     fn seal(self, epoch: Epoch) -> SealedBag {
-        SealedBag { epoch, bag: self }
+        SealedBag { epoch, _bag: self }
     }
 }
 
@@ -216,7 +216,7 @@ fn no_op_func() {}
 #[derive(Default, Debug)]
 struct SealedBag {
     epoch: Epoch,
-    bag: Bag,
+    _bag: Bag,
 }
 
 /// It is safe to share `SealedBag` because `is_expired` only inspects the epoch.

--- a/crossbeam-queue/src/seg_queue.rs
+++ b/crossbeam-queue/src/seg_queue.rs
@@ -280,12 +280,9 @@ impl<T> SegQueue<T> {
             drop(Box::from_raw(this));
         } else {
             *this = MaybeUninit::zeroed().assume_init();
-            if self
-                .cached_block
-                .compare_exchange(cached, this, Ordering::Release, Ordering::Relaxed)
-                .is_err()
-            {
-                drop(Box::from_raw(this));
+            let prev = self.cached_block.swap(this, Ordering::Release);
+            if !prev.is_null() {
+                drop(Box::from_raw(prev));
             }
         }
     }

--- a/crossbeam-queue/src/seg_queue.rs
+++ b/crossbeam-queue/src/seg_queue.rs
@@ -587,15 +587,12 @@ impl<T> Drop for SegQueue<T> {
             if !block.is_null() {
                 drop(Box::from_raw(block));
             }
-            self.block_cache
-                .blocks
-                .iter()
-                .map(|b| b.load(Ordering::Relaxed))
-                .for_each(|p| {
-                    if !p.is_null() {
-                        drop(Box::from_raw(p));
-                    }
-                });
+            for b in &self.block_cache.blocks {
+                let p = b.load(Ordering::Relaxed);
+                if !p.is_null() {
+                    drop(Box::from_raw(p));
+                }
+            }
         }
     }
 }

--- a/crossbeam-queue/src/seg_queue.rs
+++ b/crossbeam-queue/src/seg_queue.rs
@@ -189,11 +189,11 @@ impl<T> SegQueue<T> {
             // short as possible.
             if offset + 1 == BLOCK_CAP && next_block.is_none() {
                 if self.cached_block.load(Ordering::Relaxed).is_null() {
-                    next_block = Some(Box::new(Block::<T>::new()));
+                    next_block = Some(Box::new(Block::new()));
                 } else {
                     let cached = self.cached_block.swap(ptr::null_mut(), Ordering::Acquire);
                     next_block = if cached.is_null() {
-                        Some(Box::new(Block::<T>::new()))
+                        Some(Box::new(Block::new()))
                     } else {
                         Some(unsafe { Box::from_raw(cached) })
                     };
@@ -202,7 +202,7 @@ impl<T> SegQueue<T> {
 
             // If this is the first push operation, we need to allocate the first block.
             if block.is_null() {
-                let new = Box::into_raw(Box::new(Block::<T>::new()));
+                let new = Box::into_raw(Box::new(Block::new()));
 
                 if self
                     .tail

--- a/crossbeam-queue/src/seg_queue.rs
+++ b/crossbeam-queue/src/seg_queue.rs
@@ -2,7 +2,7 @@ use alloc::boxed::Box;
 use core::cell::UnsafeCell;
 use core::fmt;
 use core::marker::PhantomData;
-use core::mem::{ManuallyDrop, MaybeUninit};
+use core::mem::{self, ManuallyDrop, MaybeUninit};
 use core::ptr;
 use std::sync::atomic::{self, AtomicPtr, AtomicUsize, Ordering};
 
@@ -143,7 +143,7 @@ impl<T> BlockCache<T> {
         loop {
             let both = self.indices.both.load(Ordering::Relaxed);
             let head = both as Uhalf;
-            let tail = (both >> std::mem::size_of::<Uhalf>()) as Uhalf;
+            let tail = (both >> (mem::size_of::<Uhalf>() * 8)) as Uhalf;
 
             if head == tail {
                 return ptr::null_mut();
@@ -165,7 +165,7 @@ impl<T> BlockCache<T> {
     unsafe fn try_put(&self, block: *mut Block<T>) -> *mut Block<T> {
         let both = self.indices.both.load(Ordering::Relaxed);
         let head = both as Uhalf;
-        let tail = (both >> std::mem::size_of::<Uhalf>()) as Uhalf;
+        let tail = (both >> (mem::size_of::<Uhalf>() * 8)) as Uhalf;
 
         if tail - head == BLOCK_CACHE_SIZE as Uhalf {
             return block;

--- a/crossbeam-queue/src/seg_queue.rs
+++ b/crossbeam-queue/src/seg_queue.rs
@@ -174,11 +174,12 @@ impl<T> BlockCache<T> {
         *block = MaybeUninit::zeroed().assume_init();
         let prev =
             self.blocks[tail as usize & (BLOCK_CACHE_SIZE - 1)].swap(block, Ordering::Release);
-        self.indices
-            .split
-            .tail
-            .compare_exchange_weak(tail, tail + 1, Ordering::Relaxed, Ordering::Relaxed)
-            .ok();
+        let _ = self.indices.split.tail.compare_exchange_weak(
+            tail,
+            tail + 1,
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+        );
         prev
     }
 }


### PR DESCRIPTION
Some early discussion and rough benchmarks can be found in https://github.com/crossbeam-rs/crossbeam/issues/398.

The imprecision of the block cache operations is intentional and seems to be a key part of making this work. As mentioned in https://github.com/crossbeam-rs/crossbeam/issues/398#issuecomment-507741714, it is very easy for a cache/junkyard to be counterproductive in the average case so I prioritized reducing contention over trying to reuse a block in every possible case. All of my attempts to increase the accuracy of the operations, such as by CAS-ing against null in `try_put` rather than blindly swapping, have resulted in worse benchmark performance. I have also not seen a positive effect so far from adjusting the size of the block cache in either direction.

This needs more benchmarking, including on architectures other than x86-64.