### PR TITLE
Add `Receiver::new_sender` to channels

### DIFF
--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -1561,3 +1561,78 @@ pub(crate) unsafe fn read<T>(r: &Receiver<T>, token: &mut Token) -> Result<T, ()
         }
     }
 }
+
+/// Channel flavors that are reconnectable, ie, may survive
+/// without senders.
+///
+pub mod reconnectable {
+    // note: we need separate types because the At/Tick/Never
+    // channel types do not support this, but they all use the
+    // same exact Receiver type as array and list flavours.
+
+    // The intended usage of this module is just to replace any `use crossbeam_channel::...`
+    // with `use crossbeam_channel::reconnectable::...` and have everything work out of the box.
+
+    // note: these re-exports omit
+    // at, tick, never: cannot be supported
+    // bounded: may be added later in this module
+    use std::ops::Deref;
+
+    use super::{Receiver as NormalReceiver, ReceiverFlavor, SenderFlavor};
+    pub use crate::{
+        Sender,
+        channel::{IntoIter, Iter, TryIter},
+        err::{
+            ReadyTimeoutError, RecvError, RecvTimeoutError, SelectTimeoutError, SendError,
+            SendTimeoutError, TryReadyError, TryRecvError, TrySelectError, TrySendError,
+        },
+        select::{Select, SelectedOperation},
+    };
+
+    /// An [unbounded](super::unbounded) channel whose receiver
+    /// also is reconnectable.
+    pub fn unbounded<T>() -> (Sender<T>, Receiver<T>) {
+        let (s, r) = super::unbounded();
+        (s, Receiver(r))
+    }
+
+    /// A [receiver](super::Receiver) that can survive periods
+    /// of time where no [Sender]s are alive. New senders may
+    /// be created from the receiver directly ([Self::new_sender]).
+    /// The channel is only deallocated when the last receiver dies.
+    /// If there are live senders at that point, they start producing
+    /// [SendError]s as usual.
+    #[derive(Debug)]
+    pub struct Receiver<T>(NormalReceiver<T>);
+
+    impl<T> Receiver<T> {
+        /// Returns a new sender that communicates with this
+        /// receiver.
+        pub fn new_sender(&self) -> Sender<T> {
+            match &self.0.flavor {
+                ReceiverFlavor::Array(chan) => Sender {
+                    flavor: SenderFlavor::Array(
+                        chan.new_sender(|_| unimplemented!("but unreachable")),
+                    ),
+                },
+                ReceiverFlavor::List(chan) => Sender {
+                    flavor: SenderFlavor::List(chan.new_sender(|c| c.reconnect_senders())),
+                },
+                ReceiverFlavor::Zero(chan) => Sender {
+                    flavor: SenderFlavor::Zero(
+                        chan.new_sender(|_| unimplemented!("but unreachable")),
+                    ),
+                },
+                _ => unreachable!("This type cannot be built with at/never/tick"),
+            }
+        }
+    }
+
+    impl<T> Deref for self::Receiver<T> {
+        type Target = NormalReceiver<T>;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+}

--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -1202,19 +1202,19 @@ impl<T> Receiver<T> {
     ///
     /// # Panics
     ///
-    /// If this receiver was created from [tick], [at], or [never].
+    /// If this receiver was created from [tick], [at], or [never()].
     /// Those channel flavors do not support explicit receivers.
     #[track_caller]
     pub fn new_sender(&self) -> Sender<T> {
         match &self.flavor {
             ReceiverFlavor::Array(chan) => Sender {
-                flavor: SenderFlavor::Array(chan.new_sender(|_| unimplemented!("but unreachable"))),
+                flavor: SenderFlavor::Array(chan.new_sender(|c| c.reconnect_senders())),
             },
             ReceiverFlavor::List(chan) => Sender {
                 flavor: SenderFlavor::List(chan.new_sender(|c| c.reconnect_senders())),
             },
             ReceiverFlavor::Zero(chan) => Sender {
-                flavor: SenderFlavor::Zero(chan.new_sender(|_| unimplemented!("but unreachable"))),
+                flavor: SenderFlavor::Zero(chan.new_sender(|c| c.reconnect_senders())),
             },
             _ => panic!("new_sender cannot be called with a Receiver created by at/never/tick"),
         }

--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -1177,6 +1177,48 @@ impl<T> Receiver<T> {
             ReceiverFlavor::Never(_chan) => 0,
         }
     }
+
+    /// Returns a new sender that communicates with this
+    /// receiver. This can be used to revive a receiver
+    /// even when there are no senders currently alive.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use crossbeam_channel::{unbounded, RecvError};
+    /// let (s, r) = unbounded::<i32>();
+    /// s.send(1).unwrap();
+    /// drop(s); // After this point no sender is alive
+    /// assert_eq!(r.recv(), Ok(1));
+    /// // Here the channel is empty, but the rcv call doesn't block
+    /// // as there are no live senders capable of sending messages.
+    /// assert_eq!(r.recv(), Err(RecvError));
+    /// // We can spawn a new sender
+    /// let s = r.new_sender();
+    /// s.send(1).unwrap();
+    /// assert_eq!(r.recv(), Ok(1));
+    /// // Another recv call here would block as there exists a live sender.
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// If this receiver was created from [tick], [at], or [never].
+    /// Those channel flavors do not support explicit receivers.
+    #[track_caller]
+    pub fn new_sender(&self) -> Sender<T> {
+        match &self.flavor {
+            ReceiverFlavor::Array(chan) => Sender {
+                flavor: SenderFlavor::Array(chan.new_sender(|_| unimplemented!("but unreachable"))),
+            },
+            ReceiverFlavor::List(chan) => Sender {
+                flavor: SenderFlavor::List(chan.new_sender(|c| c.reconnect_senders())),
+            },
+            ReceiverFlavor::Zero(chan) => Sender {
+                flavor: SenderFlavor::Zero(chan.new_sender(|_| unimplemented!("but unreachable"))),
+            },
+            _ => panic!("new_sender cannot be called with a Receiver created by at/never/tick"),
+        }
+    }
 }
 
 impl<T> Drop for Receiver<T> {
@@ -1558,81 +1600,6 @@ pub(crate) unsafe fn read<T>(r: &Receiver<T>, token: &mut Token) -> Result<T, ()
                 mem::transmute_copy::<Result<Instant, ()>, Result<T, ()>>(&chan.read(token))
             }
             ReceiverFlavor::Never(chan) => chan.read(token),
-        }
-    }
-}
-
-/// Channel flavors that are reconnectable, ie, may survive
-/// without senders.
-///
-pub mod reconnectable {
-    // note: we need separate types because the At/Tick/Never
-    // channel types do not support this, but they all use the
-    // same exact Receiver type as array and list flavours.
-
-    // The intended usage of this module is just to replace any `use crossbeam_channel::...`
-    // with `use crossbeam_channel::reconnectable::...` and have everything work out of the box.
-
-    // note: these re-exports omit
-    // at, tick, never: cannot be supported
-    // bounded: may be added later in this module
-    use std::ops::Deref;
-
-    use super::{Receiver as NormalReceiver, ReceiverFlavor, SenderFlavor};
-    pub use crate::{
-        Sender,
-        channel::{IntoIter, Iter, TryIter},
-        err::{
-            ReadyTimeoutError, RecvError, RecvTimeoutError, SelectTimeoutError, SendError,
-            SendTimeoutError, TryReadyError, TryRecvError, TrySelectError, TrySendError,
-        },
-        select::{Select, SelectedOperation},
-    };
-
-    /// An [unbounded](super::unbounded) channel whose receiver
-    /// also is reconnectable.
-    pub fn unbounded<T>() -> (Sender<T>, Receiver<T>) {
-        let (s, r) = super::unbounded();
-        (s, Receiver(r))
-    }
-
-    /// A [receiver](super::Receiver) that can survive periods
-    /// of time where no [Sender]s are alive. New senders may
-    /// be created from the receiver directly ([Self::new_sender]).
-    /// The channel is only deallocated when the last receiver dies.
-    /// If there are live senders at that point, they start producing
-    /// [SendError]s as usual.
-    #[derive(Debug)]
-    pub struct Receiver<T>(NormalReceiver<T>);
-
-    impl<T> Receiver<T> {
-        /// Returns a new sender that communicates with this
-        /// receiver.
-        pub fn new_sender(&self) -> Sender<T> {
-            match &self.0.flavor {
-                ReceiverFlavor::Array(chan) => Sender {
-                    flavor: SenderFlavor::Array(
-                        chan.new_sender(|_| unimplemented!("but unreachable")),
-                    ),
-                },
-                ReceiverFlavor::List(chan) => Sender {
-                    flavor: SenderFlavor::List(chan.new_sender(|c| c.reconnect_senders())),
-                },
-                ReceiverFlavor::Zero(chan) => Sender {
-                    flavor: SenderFlavor::Zero(
-                        chan.new_sender(|_| unimplemented!("but unreachable")),
-                    ),
-                },
-                _ => unreachable!("This type cannot be built with at/never/tick"),
-            }
-        }
-    }
-
-    impl<T> Deref for self::Receiver<T> {
-        type Target = NormalReceiver<T>;
-
-        fn deref(&self) -> &Self::Target {
-            &self.0
         }
     }
 }

--- a/crossbeam-channel/src/counter.rs
+++ b/crossbeam-channel/src/counter.rs
@@ -138,6 +138,18 @@ impl<C> Receiver<C> {
     pub(crate) fn addr(&self) -> usize {
         self.counter.as_ptr() as usize
     }
+
+    pub(crate) fn new_sender(&self, reconnect: impl FnOnce(&C) -> bool) -> Sender<C> {
+        if 0 == self.counter().senders.fetch_add(1, Ordering::SeqCst) {
+            // we're the first sender to be created
+            reconnect(&self.counter().chan);
+            self.counter().destroy.store(false, Ordering::Relaxed);
+        }
+
+        Sender {
+            counter: self.counter,
+        }
+    }
 }
 
 impl<C> ops::Deref for Receiver<C> {

--- a/crossbeam-channel/src/flavors/array.rs
+++ b/crossbeam-channel/src/flavors/array.rs
@@ -495,6 +495,17 @@ impl<T> Channel<T> {
         }
     }
 
+    /// Reconnects senders. There is no need to notify threads
+    /// as nobody is currently blocking, since we were in a phase
+    /// where no senders are alive.
+    ///
+    /// Returns `true` if this call reconnected the channel.
+    pub(crate) fn reconnect_senders(&self) -> bool {
+        let tail = self.tail.fetch_and(!self.mark_bit, Ordering::SeqCst);
+
+        tail & self.mark_bit == 0
+    }
+
     /// Returns `true` if the channel is disconnected.
     pub(crate) fn is_disconnected(&self) -> bool {
         self.tail.load(Ordering::SeqCst) & self.mark_bit != 0

--- a/crossbeam-channel/src/flavors/list.rs
+++ b/crossbeam-channel/src/flavors/list.rs
@@ -570,8 +570,8 @@ impl<T> Channel<T> {
     }
 
     /// Reconnects senders. There is no need to notify threads
-    /// as nobody is currently blocking, since we were in an
-    /// idle phase.
+    /// as nobody is currently blocking, since we were in a phase
+    /// where no senders are alive.
     ///
     /// Returns `true` if this call reconnected the channel.
     pub(crate) fn reconnect_senders(&self) -> bool {

--- a/crossbeam-channel/src/flavors/list.rs
+++ b/crossbeam-channel/src/flavors/list.rs
@@ -569,6 +569,17 @@ impl<T> Channel<T> {
         }
     }
 
+    /// Reconnects senders. There is no need to notify threads
+    /// as nobody is currently blocking, since we were in an
+    /// idle phase.
+    ///
+    /// Returns `true` if this call reconnected the channel.
+    pub(crate) fn reconnect_senders(&self) -> bool {
+        let tail = self.tail.index.fetch_and(!MARK_BIT, Ordering::SeqCst);
+
+        tail & MARK_BIT == 0
+    }
+
     /// Disconnects receivers.
     ///
     /// Returns `true` if this call disconnected the channel.

--- a/crossbeam-channel/src/flavors/zero.rs
+++ b/crossbeam-channel/src/flavors/zero.rs
@@ -356,6 +356,21 @@ impl<T> Channel<T> {
         })
     }
 
+    /// Reconnects senders. There is no need to notify threads
+    /// as nobody is currently blocking, since we were in a phase
+    /// where no senders are alive.
+    ///
+    /// Returns `true` if this call reconnected the channel.
+    pub(crate) fn reconnect_senders(&self) -> bool {
+        let mut inner = self.inner.lock().unwrap();
+        if inner.is_disconnected {
+            inner.is_disconnected = false;
+            true
+        } else {
+            false
+        }
+    }
+
     /// Disconnects the channel and wakes up all blocked senders and receivers.
     ///
     /// Returns `true` if this call disconnected the channel.

--- a/crossbeam-channel/src/lib.rs
+++ b/crossbeam-channel/src/lib.rs
@@ -377,7 +377,8 @@ pub mod internal {
 #[cfg(feature = "std")]
 pub use crate::{
     channel::{
-        IntoIter, Iter, Receiver, Sender, TryIter, after, at, bounded, never, tick, unbounded,
+        IntoIter, Iter, Receiver, Sender, TryIter, after, at, bounded, never, reconnectable, tick,
+        unbounded,
     },
     err::{
         ReadyTimeoutError, RecvError, RecvTimeoutError, SelectTimeoutError, SendError,

--- a/crossbeam-channel/src/lib.rs
+++ b/crossbeam-channel/src/lib.rs
@@ -377,8 +377,7 @@ pub mod internal {
 #[cfg(feature = "std")]
 pub use crate::{
     channel::{
-        IntoIter, Iter, Receiver, Sender, TryIter, after, at, bounded, never, reconnectable, tick,
-        unbounded,
+        IntoIter, Iter, Receiver, Sender, TryIter, after, at, bounded, never, tick, unbounded,
     },
     err::{
         ReadyTimeoutError, RecvError, RecvTimeoutError, SelectTimeoutError, SendError,

--- a/crossbeam-channel/tests/after.rs
+++ b/crossbeam-channel/tests/after.rs
@@ -339,3 +339,10 @@ fn fairness_duplicates() {
         assert!(hits.iter().all(|x| *x >= COUNT / hits.len() / 2));
     }
 }
+
+#[test]
+#[should_panic]
+fn new_sender() {
+    let r = after(Duration::from_micros(20));
+    r.new_sender();
+}

--- a/crossbeam-channel/tests/array.rs
+++ b/crossbeam-channel/tests/array.rs
@@ -707,3 +707,20 @@ fn panic_on_drop() {
     // Elements after the panicked element will leak.
     assert!(!b);
 }
+
+#[test]
+fn zero_sender_revival() {
+    let (s, r) = bounded::<i32>(1);
+
+    s.send(1).unwrap();
+
+    drop(s);
+
+    assert_eq!(r.recv(), Ok(1));
+    assert_eq!(r.recv(), Err(RecvError));
+
+    let s = r.new_sender();
+
+    s.send(1).unwrap();
+    assert_eq!(r.recv(), Ok(1));
+}

--- a/crossbeam-channel/tests/list.rs
+++ b/crossbeam-channel/tests/list.rs
@@ -209,7 +209,7 @@ fn recv_after_disconnect() {
 }
 
 #[test]
-fn zero_receiver_revival() {
+fn zero_sender_revival() {
     let (s, r) = unbounded();
 
     s.send(1).unwrap();

--- a/crossbeam-channel/tests/list.rs
+++ b/crossbeam-channel/tests/list.rs
@@ -9,7 +9,7 @@ use std::{
 
 use crossbeam_channel::{
     Receiver, RecvError, RecvTimeoutError, SendError, SendTimeoutError, TryRecvError, TrySendError,
-    reconnectable, select, unbounded,
+    select, unbounded,
 };
 use crossbeam_utils::thread::scope;
 
@@ -210,7 +210,7 @@ fn recv_after_disconnect() {
 
 #[test]
 fn zero_receiver_revival() {
-    let (s, r) = reconnectable::unbounded();
+    let (s, r) = unbounded();
 
     s.send(1).unwrap();
 

--- a/crossbeam-channel/tests/list.rs
+++ b/crossbeam-channel/tests/list.rs
@@ -9,7 +9,7 @@ use std::{
 
 use crossbeam_channel::{
     Receiver, RecvError, RecvTimeoutError, SendError, SendTimeoutError, TryRecvError, TrySendError,
-    select, unbounded,
+    reconnectable, select, unbounded,
 };
 use crossbeam_utils::thread::scope;
 
@@ -206,6 +206,23 @@ fn recv_after_disconnect() {
     assert_eq!(r.recv(), Ok(2));
     assert_eq!(r.recv(), Ok(3));
     assert_eq!(r.recv(), Err(RecvError));
+}
+
+#[test]
+fn zero_receiver_revival() {
+    let (s, r) = reconnectable::unbounded();
+
+    s.send(1).unwrap();
+
+    drop(s);
+
+    assert_eq!(r.recv(), Ok(1));
+    assert_eq!(r.recv(), Err(RecvError));
+
+    let s = r.new_sender();
+
+    s.send(1).unwrap();
+    assert_eq!(r.recv(), Ok(1));
 }
 
 #[test]

--- a/crossbeam-channel/tests/never.rs
+++ b/crossbeam-channel/tests/never.rs
@@ -96,3 +96,10 @@ fn recv_timeout() {
     assert!(now - start >= ms(200));
     assert!(now - start <= ms(250));
 }
+
+#[test]
+#[should_panic]
+fn new_sender() {
+    let r = never::<i32>();
+    r.new_sender();
+}

--- a/crossbeam-channel/tests/tick.rs
+++ b/crossbeam-channel/tests/tick.rs
@@ -358,3 +358,10 @@ fn fairness_duplicates() {
         assert!(hits.iter().all(|x| *x >= COUNT / hits.len() / 2));
     }
 }
+
+#[test]
+#[should_panic]
+fn new_sender() {
+    let r = tick(Duration::from_micros(20));
+    r.new_sender();
+}

--- a/crossbeam-channel/tests/zero.rs
+++ b/crossbeam-channel/tests/zero.rs
@@ -556,3 +556,50 @@ fn channel_through_channel() {
     })
     .unwrap();
 }
+
+#[test]
+fn zero_sender_revival() {
+
+    let (s, r) = bounded::<i32>(0);
+
+    let rref = &r;
+
+    scope(|scope| {
+        scope.spawn(move |_| {
+            let s = s;
+
+            s.send(1).unwrap();
+            // sender is dropped
+        });
+
+        scope.spawn(move |_| {
+            let r = rref;
+
+            assert_eq!(r.recv(), Ok(1));
+            thread::sleep(Duration::from_millis(100));
+            assert_eq!(r.recv(), Err(RecvError)); // non blocking
+
+            let mut msg = r.recv();
+            assert_eq!(msg, Err(RecvError)); // no senders
+
+            while msg == Err(RecvError) {
+                // Yield to the other thread
+                thread::sleep(ms(30));
+                msg = r.recv();
+            }
+
+            assert_eq!(msg, Ok(2)); // received from second sender thread
+        });
+
+        scope.spawn(move |_| {
+            thread::sleep(ms(200)); // start with a delay
+
+            let r = rref;
+
+            let s = r.new_sender();
+
+            s.send(2).unwrap();
+        });
+    })
+    .unwrap();
+}

--- a/crossbeam-channel/tests/zero.rs
+++ b/crossbeam-channel/tests/zero.rs
@@ -559,7 +559,6 @@ fn channel_through_channel() {
 
 #[test]
 fn zero_sender_revival() {
-
     let (s, r) = bounded::<i32>(0);
 
     let rref = &r;


### PR DESCRIPTION
This change gives `channel::Receiver`s the ability to spawn new senders at will. 

Currently, Receivers are disconnected as soon as the Sender count reaches zero, as new Senders can only be created by cloning an existing one. Disconnected receivers do not block on `recv` and such, instead they just fail immediately.

This didn't quite fit my use case, where I need to have the ability to create new Senders when I want to, and also get the non-blocking behavior if there is no Sender alive. With the current API, I have to keep a prototype Sender which is always alive and which I can clone whenever I want. The problem is that since the prototype is always alive, the channel never gets disconnected. That means calls to `recv` stay blocking, even when we know that no message will ever be sent through the Sender prototype, because its only purpose is to produce new Senders.

This change adds support for creating new Sender instances from the Receiver directly. That means, I don't need to keep a Sender prototype anymore, so my Receiver is non-blocking when I know there is no real Sender alive. But even after the channel was disconnected, you can "reconnect" it by spawning new senders.

~~Obviously this method cannot appear in the API of channel flavours like `tick` or `never`, since the point of those is to expose only a receiver. This means, we need two different types for `Receiver`. I put that new API in a separate submodule so that it's easy to import and document. That submodule only supports creating unbounded channels for now, as that was my use case. If you're interested we may be able to add support for bounded and zero channels, but there is AFAIK no risk in keeping an incomplete API here.~~ The new method `Receiver::new_sender` is usable on bounded and unbounded channels; it panics on `tick`, `at` and `never` channels.

Please let me know if there is anything you need from me to get this merged faster, be it documentation, tests, etc. 
Cheers :)