### PR TITLE
crossbeam-utils: check only the architecture, not the whole target string

### DIFF
--- a/crossbeam-epoch/build.rs
+++ b/crossbeam-epoch/build.rs
@@ -30,11 +30,16 @@ fn main() {
         }
     };
 
+    let target_arch = target.split('-').next().unwrap_or_default();
+
     // Note that this is `no_*`, not `has_*`. This allows treating
     // `cfg(target_has_atomic = "ptr")` as true when the build script doesn't
     // run. This is needed for compatibility with non-cargo build systems that
     // don't run the build script.
-    if NO_ATOMIC_CAS.contains(&&*target) {
+    if NO_ATOMIC_CAS
+        .iter()
+        .any(|t| t.split('-').next().unwrap_or_default() == target_arch)
+    {
         println!("cargo:rustc-cfg=crossbeam_no_atomic_cas");
     }
 

--- a/crossbeam-queue/build.rs
+++ b/crossbeam-queue/build.rs
@@ -30,11 +30,16 @@ fn main() {
         }
     };
 
+    let target_arch = target.split('-').next().unwrap_or_default();
+
     // Note that this is `no_*`, not `has_*`. This allows treating
     // `cfg(target_has_atomic = "ptr")` as true when the build script doesn't
     // run. This is needed for compatibility with non-cargo build systems that
     // don't run the build script.
-    if NO_ATOMIC_CAS.contains(&&*target) {
+    if NO_ATOMIC_CAS
+        .iter()
+        .any(|t| t.split('-').next().unwrap_or_default() == target_arch)
+    {
         println!("cargo:rustc-cfg=crossbeam_no_atomic_cas");
     }
 

--- a/crossbeam-skiplist/build.rs
+++ b/crossbeam-skiplist/build.rs
@@ -30,11 +30,16 @@ fn main() {
         }
     };
 
+    let target_arch = target.split('-').next().unwrap_or_default();
+
     // Note that this is `no_*`, not `has_*`. This allows treating
     // `cfg(target_has_atomic = "ptr")` as true when the build script doesn't
     // run. This is needed for compatibility with non-cargo build systems that
     // don't run the build script.
-    if NO_ATOMIC_CAS.contains(&&*target) {
+    if NO_ATOMIC_CAS
+        .iter()
+        .any(|t| t.split('-').next().unwrap_or_default() == target_arch)
+    {
         println!("cargo:rustc-cfg=crossbeam_no_atomic_cas");
     }
 

--- a/crossbeam-utils/build.rs
+++ b/crossbeam-utils/build.rs
@@ -42,17 +42,28 @@ fn main() {
         }
     };
 
+    let target_arch = target.split('-').next().unwrap_or_default();
+
     // Note that this is `no_*`, not `has_*`. This allows treating
     // `cfg(target_has_atomic = "ptr")` as true when the build script doesn't
     // run. This is needed for compatibility with non-cargo build systems that
     // don't run the build script.
-    if NO_ATOMIC_CAS.contains(&&*target) {
+    if NO_ATOMIC_CAS
+        .iter()
+        .any(|t| t.split('-').next().unwrap_or_default() == target_arch)
+    {
         println!("cargo:rustc-cfg=crossbeam_no_atomic_cas");
     }
-    if NO_ATOMIC.contains(&&*target) {
+    if NO_ATOMIC
+        .iter()
+        .any(|t| t.split('-').next().unwrap_or_default() == target_arch)
+    {
         println!("cargo:rustc-cfg=crossbeam_no_atomic");
         println!("cargo:rustc-cfg=crossbeam_no_atomic_64");
-    } else if NO_ATOMIC_64.contains(&&*target) {
+    } else if NO_ATOMIC_64
+        .iter()
+        .any(|t| t.split('-').next().unwrap_or_default() == target_arch)
+    {
         println!("cargo:rustc-cfg=crossbeam_no_atomic_64");
     } else {
         // Otherwise, assuming `"max-atomic-width" == 64`.


### PR DESCRIPTION
There can be custom targets in use, and it's not possible to make a list
of them; for the check only the first item in the target string is actually
relevant (the architecture of the target, which is generally consistent
between standard and custom targets).

Signed-off-by: Alexander Kanavin <alex@linutronix.de>