### PR TITLE
Remove authors field from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ name = "crossbeam"
 # - Update README.md
 # - Create "crossbeam-X.Y.Z" git tag
 version = "0.8.1"
-authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"

--- a/crossbeam-channel/Cargo.toml
+++ b/crossbeam-channel/Cargo.toml
@@ -5,7 +5,6 @@ name = "crossbeam-channel"
 # - Update README.md
 # - Create "crossbeam-channel-X.Y.Z" git tag
 version = "0.5.1"
-authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"

--- a/crossbeam-deque/Cargo.toml
+++ b/crossbeam-deque/Cargo.toml
@@ -5,7 +5,6 @@ name = "crossbeam-deque"
 # - Update README.md
 # - Create "crossbeam-deque-X.Y.Z" git tag
 version = "0.8.1"
-authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -5,7 +5,6 @@ name = "crossbeam-epoch"
 # - Update README.md
 # - Create "crossbeam-epoch-X.Y.Z" git tag
 version = "0.9.5"
-authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"

--- a/crossbeam-queue/Cargo.toml
+++ b/crossbeam-queue/Cargo.toml
@@ -5,7 +5,6 @@ name = "crossbeam-queue"
 # - Update README.md
 # - Create "crossbeam-queue-X.Y.Z" git tag
 version = "0.3.2"
-authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"

--- a/crossbeam-skiplist/Cargo.toml
+++ b/crossbeam-skiplist/Cargo.toml
@@ -5,7 +5,6 @@ name = "crossbeam-skiplist"
 # - Update README.md
 # - Create "crossbeam-skiplist-X.Y.Z" git tag
 version = "0.0.0"
-authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -5,7 +5,6 @@ name = "crossbeam-utils"
 # - Update README.md
 # - Create "crossbeam-utils-X.Y.Z" git tag
 version = "0.8.5"
-authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"


### PR DESCRIPTION
This field is soft-deprecated, cargo no longer generates this field by default, and Rust's official services no longer reference this field at all.

See [RFC3052](https://rust-lang.github.io/rfcs/3052-optional-authors-field.html) for more.