### PR TITLE
Revert "Disable feature check on MSRV"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,7 @@ jobs:
       fail-fast: false
       matrix:
         rust:
-          # Some dependencies of benchmarks use the 2021 edition.
-          # TODO: Uncomment once https://github.com/taiki-e/cargo-hack/issues/135 implemented.
-          # - 1.36.0
+          - 1.36.0
           - nightly
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This reverts commit bce74ca9a5405c31204894a8c4b8f13d16fa9686.

cargo-hack fixed the problem in [0.5.9](https://github.com/taiki-e/cargo-hack/releases/tag/v0.5.9).