### PR TITLE
Make installation of cargo-hack faster and robust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install Rust
         run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
+      - uses: taiki-e/install-action@cargo-hack
       - name: Check features
         run: ./ci/check-features.sh
 
@@ -87,6 +88,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install Rust
         run: rustup update nightly && rustup default nightly
+      - uses: taiki-e/install-action@cargo-hack
       - name: dependency tree check
         run: ./ci/dependencies.sh
 

--- a/ci/check-features.sh
+++ b/ci/check-features.sh
@@ -3,10 +3,6 @@
 cd "$(dirname "$0")"/..
 set -ex
 
-if [[ ! -x "$(command -v cargo-hack)" ]]; then
-    cargo +stable install --debug cargo-hack || exit 1
-fi
-
 if [[ "$RUST_VERSION" != "nightly"* ]]; then
     # On MSRV, features other than nightly should work.
     # * `--feature-powerset` - run for the feature powerset which includes --no-default-features and default features of package

--- a/ci/dependencies.sh
+++ b/ci/dependencies.sh
@@ -3,8 +3,6 @@
 cd "$(dirname "$0")"/..
 set -ex
 
-cargo install cargo-hack
-
 cargo tree
 cargo tree --duplicate
 cargo tree --duplicate || exit 1


### PR DESCRIPTION
Use [taiki-e/install-action](https://github.com/taiki-e/install-action) to install prebuilt binaries. This makes the installation faster and may avoid the impact of [problems caused by upstream changes](https://github.com/tokio-rs/bytes/issues/506).