### PR TITLE
Support AtomicCell<*64> arithmetics on targets that do not support Atomic*64

### DIFF
--- a/crossbeam-utils/src/atomic/atomic_cell.rs
+++ b/crossbeam-utils/src/atomic/atomic_cell.rs
@@ -523,6 +523,8 @@ impl_arithmetic!(i64, fallback, "let a = AtomicCell::new(7i64);");
 // TODO: AtomicU128 is unstable
 // impl_arithmetic!(u128, atomic::AtomicU128, "let a = AtomicCell::new(7u128);");
 // impl_arithmetic!(i128, atomic::AtomicI128, "let a = AtomicCell::new(7i128);");
+impl_arithmetic!(u128, fallback, "let a = AtomicCell::new(7u128);");
+impl_arithmetic!(i128, fallback, "let a = AtomicCell::new(7i128);");
 
 impl_arithmetic!(
     usize,

--- a/crossbeam-utils/src/atomic/atomic_cell.rs
+++ b/crossbeam-utils/src/atomic/atomic_cell.rs
@@ -313,11 +313,19 @@ macro_rules! impl_arithmetic {
             /// ```
             #[inline]
             pub fn fetch_add(&self, val: $t) -> $t {
-                let _guard = lock(self.value.get() as usize).write();
-                let value = unsafe { &mut *(self.value.get()) };
-                let old = *value;
-                *value = value.wrapping_add(val);
-                old
+                #[cfg(crossbeam_loom)]
+                {
+                    let _ = val;
+                    unimplemented!("loom does not support non-atomic atomic ops");
+                }
+                #[cfg(not(crossbeam_loom))]
+                {
+                    let _guard = lock(self.value.get() as usize).write();
+                    let value = unsafe { &mut *(self.value.get()) };
+                    let old = *value;
+                    *value = value.wrapping_add(val);
+                    old
+                }
             }
 
             /// Decrements the current value by `val` and returns the previous value.
@@ -336,11 +344,19 @@ macro_rules! impl_arithmetic {
             /// ```
             #[inline]
             pub fn fetch_sub(&self, val: $t) -> $t {
-                let _guard = lock(self.value.get() as usize).write();
-                let value = unsafe { &mut *(self.value.get()) };
-                let old = *value;
-                *value = value.wrapping_sub(val);
-                old
+                #[cfg(crossbeam_loom)]
+                {
+                    let _ = val;
+                    unimplemented!("loom does not support non-atomic atomic ops");
+                }
+                #[cfg(not(crossbeam_loom))]
+                {
+                    let _guard = lock(self.value.get() as usize).write();
+                    let value = unsafe { &mut *(self.value.get()) };
+                    let old = *value;
+                    *value = value.wrapping_sub(val);
+                    old
+                }
             }
 
             /// Applies bitwise "and" to the current value and returns the previous value.
@@ -357,11 +373,19 @@ macro_rules! impl_arithmetic {
             /// ```
             #[inline]
             pub fn fetch_and(&self, val: $t) -> $t {
-                let _guard = lock(self.value.get() as usize).write();
-                let value = unsafe { &mut *(self.value.get()) };
-                let old = *value;
-                *value &= val;
-                old
+                #[cfg(crossbeam_loom)]
+                {
+                    let _ = val;
+                    unimplemented!("loom does not support non-atomic atomic ops");
+                }
+                #[cfg(not(crossbeam_loom))]
+                {
+                    let _guard = lock(self.value.get() as usize).write();
+                    let value = unsafe { &mut *(self.value.get()) };
+                    let old = *value;
+                    *value &= val;
+                    old
+                }
             }
 
             /// Applies bitwise "or" to the current value and returns the previous value.
@@ -378,11 +402,19 @@ macro_rules! impl_arithmetic {
             /// ```
             #[inline]
             pub fn fetch_or(&self, val: $t) -> $t {
-                let _guard = lock(self.value.get() as usize).write();
-                let value = unsafe { &mut *(self.value.get()) };
-                let old = *value;
-                *value |= val;
-                old
+                #[cfg(crossbeam_loom)]
+                {
+                    let _ = val;
+                    unimplemented!("loom does not support non-atomic atomic ops");
+                }
+                #[cfg(not(crossbeam_loom))]
+                {
+                    let _guard = lock(self.value.get() as usize).write();
+                    let value = unsafe { &mut *(self.value.get()) };
+                    let old = *value;
+                    *value |= val;
+                    old
+                }
             }
 
             /// Applies bitwise "xor" to the current value and returns the previous value.
@@ -399,11 +431,19 @@ macro_rules! impl_arithmetic {
             /// ```
             #[inline]
             pub fn fetch_xor(&self, val: $t) -> $t {
-                let _guard = lock(self.value.get() as usize).write();
-                let value = unsafe { &mut *(self.value.get()) };
-                let old = *value;
-                *value ^= val;
-                old
+                #[cfg(crossbeam_loom)]
+                {
+                    let _ = val;
+                    unimplemented!("loom does not support non-atomic atomic ops");
+                }
+                #[cfg(not(crossbeam_loom))]
+                {
+                    let _guard = lock(self.value.get() as usize).write();
+                    let value = unsafe { &mut *(self.value.get()) };
+                    let old = *value;
+                    *value ^= val;
+                    old
+                }
             }
         }
     };


### PR DESCRIPTION
This adds `AtomicCell<{i,u}64>::{fetch_add,fetch_sub,fetch_and,fetch_or,fetch_xor}` on targets that do not support `Atomic{I,U}64`.
This also adds `AtomicCell<{i,u}128>::{fetch_add,fetch_sub,fetch_and,fetch_or,fetch_xor}`.

These were provided in older versions of crossbeam-utils, but were unintentionally removed in 0.8.0 (https://github.com/crossbeam-rs/crossbeam/commit/11fbf05968ba702b61b6c61e32fdd4250b2c0aba).