### PR TITLE
Prepare for the next release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ name = "crossbeam"
 # - Create "crossbeam-X.Y.Z" git tag
 version = "0.8.1"
 edition = "2018"
+rust-version = "1.36"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"
 homepage = "https://github.com/crossbeam-rs/crossbeam"

--- a/crossbeam-channel/CHANGELOG.md
+++ b/crossbeam-channel/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.5.2
+
+- Fix stacked borrows violations. (#763, #764)
+
 # Version 0.5.1
 
 - Fix memory leak in unbounded channel. (#669)

--- a/crossbeam-channel/Cargo.toml
+++ b/crossbeam-channel/Cargo.toml
@@ -6,6 +6,7 @@ name = "crossbeam-channel"
 # - Create "crossbeam-channel-X.Y.Z" git tag
 version = "0.5.1"
 edition = "2018"
+rust-version = "1.36"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"
 homepage = "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-channel"

--- a/crossbeam-channel/Cargo.toml
+++ b/crossbeam-channel/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-channel"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-channel-X.Y.Z" git tag
-version = "0.5.1"
+version = "0.5.2"
 edition = "2018"
 rust-version = "1.36"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-deque/Cargo.toml
+++ b/crossbeam-deque/Cargo.toml
@@ -6,6 +6,7 @@ name = "crossbeam-deque"
 # - Create "crossbeam-deque-X.Y.Z" git tag
 version = "0.8.1"
 edition = "2018"
+rust-version = "1.36"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"
 homepage = "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-deque"

--- a/crossbeam-epoch/CHANGELOG.md
+++ b/crossbeam-epoch/CHANGELOG.md
@@ -1,12 +1,16 @@
+# Version 0.9.6
+
+- Add `Atomic::fetch_update`. (#706)
+
 # Version 0.9.5
 
-- Fix UB in `Pointable` impl of `[MaybeUninit<T>]` (#694)
-- Support targets that do not have atomic CAS on stable Rust (#698)
-- Fix breakage with nightly feature due to rust-lang/rust#84510 (#692)
+- Fix UB in `Pointable` impl of `[MaybeUninit<T>]`. (#694)
+- Support targets that do not have atomic CAS on stable Rust. (#698)
+- Fix breakage with nightly feature due to rust-lang/rust#84510. (#692)
 
 # Version 0.9.4
 
-- Fix UB in `<[MaybeUninit<T>] as Pointable>::init` when global allocator failed allocation (#690)
+- Fix UB in `<[MaybeUninit<T>] as Pointable>::init` when global allocator failed allocation. (#690)
 - Bump `loom` dependency to version 0.5. (#686)
 
 # Version 0.9.3

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -6,6 +6,7 @@ name = "crossbeam-epoch"
 # - Create "crossbeam-epoch-X.Y.Z" git tag
 version = "0.9.5"
 edition = "2018"
+rust-version = "1.36"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"
 homepage = "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-epoch"

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-epoch"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-epoch-X.Y.Z" git tag
-version = "0.9.5"
+version = "0.9.6"
 edition = "2018"
 rust-version = "1.36"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-queue/CHANGELOG.md
+++ b/crossbeam-queue/CHANGELOG.md
@@ -1,6 +1,10 @@
+# Version 0.3.3
+
+- Fix stacked borrows violation in `ArrayQueue`. (#763)
+
 # Version 0.3.2
 
-- Support targets that do not have atomic CAS on stable Rust (#698)
+- Support targets that do not have atomic CAS on stable Rust. (#698)
 
 # Version 0.3.1
 

--- a/crossbeam-queue/Cargo.toml
+++ b/crossbeam-queue/Cargo.toml
@@ -6,6 +6,7 @@ name = "crossbeam-queue"
 # - Create "crossbeam-queue-X.Y.Z" git tag
 version = "0.3.2"
 edition = "2018"
+rust-version = "1.36"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"
 homepage = "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-queue"

--- a/crossbeam-queue/Cargo.toml
+++ b/crossbeam-queue/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-queue"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-queue-X.Y.Z" git tag
-version = "0.3.2"
+version = "0.3.3"
 edition = "2018"
 rust-version = "1.36"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-skiplist/Cargo.toml
+++ b/crossbeam-skiplist/Cargo.toml
@@ -6,6 +6,7 @@ name = "crossbeam-skiplist"
 # - Create "crossbeam-skiplist-X.Y.Z" git tag
 version = "0.0.0"
 edition = "2018"
+rust-version = "1.36"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"
 homepage = "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-skiplist"

--- a/crossbeam-utils/CHANGELOG.md
+++ b/crossbeam-utils/CHANGELOG.md
@@ -1,7 +1,12 @@
+# Version 0.8.6
+
+- Re-add `AtomicCell<{i,u}64>::{fetch_add,fetch_sub,fetch_and,fetch_or,fetch_xor}` that were accidentally removed in 0.8.0 on targets that do not support `Atomic{I,U}64`. (#767)
+- Re-add `AtomicCell<{i,u}128>::{fetch_add,fetch_sub,fetch_and,fetch_or,fetch_xor}` that were accidentally removed in 0.8.0. (#767)
+
 # Version 0.8.5
 
-- Add `AtomicCell::fetch_update` (#704)
-- Support targets that do not have atomic CAS on stable Rust (#698)
+- Add `AtomicCell::fetch_update`. (#704)
+- Support targets that do not have atomic CAS on stable Rust. (#698)
 
 # Version 0.8.4
 

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -6,6 +6,7 @@ name = "crossbeam-utils"
 # - Create "crossbeam-utils-X.Y.Z" git tag
 version = "0.8.5"
 edition = "2018"
+rust-version = "1.36"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"
 homepage = "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-utils"

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-utils"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-utils-X.Y.Z" git tag
-version = "0.8.5"
+version = "0.8.6"
 edition = "2018"
 rust-version = "1.36"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
- crossbeam-channel 0.5.1 -> 0.5.2
  - Fix stacked borrows violations. (#763, #764)
- crossbeam-epoch 0.9.5 -> 0.9.6
  - Add `Atomic::fetch_update`. (#706)
- crossbeam-queue 0.3.2 -> 0.3.3
  - Fix stacked borrows violation in `ArrayQueue`. (#763)
- crossbeam-utils 0.8.5 -> 0.8.6
  - Re-add `AtomicCell<{i,u}64>::{fetch_add,fetch_sub,fetch_and,fetch_or,fetch_xor}` that were accidentally removed in 0.8.0 on targets that do not support `Atomic{I,U}64`. (#767)
  - Re-add `AtomicCell<{i,u}128>::{fetch_add,fetch_sub,fetch_and,fetch_or,fetch_xor}` that were accidentally removed in 0.8.0. (#767)
