### PR TITLE
Add mips-unknown-linux-gnu to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Install Rust
         # --no-self-update is necessary because the windows environment cannot self-update rustup.exe.
         run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
+      - name: Install cross
+        uses: taiki-e/install-action@cross
+        if: matrix.target != ''
       - name: Test
         run: ./ci/test.sh
 
@@ -79,7 +82,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install Rust
         run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
-      - uses: taiki-e/install-action@cargo-hack
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
       - name: Check features
         run: ./ci/check-features.sh
 
@@ -90,7 +94,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install Rust
         run: rustup update nightly && rustup default nightly
-      - uses: taiki-e/install-action@cargo-hack
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
       - name: dependency tree check
         run: ./ci/dependencies.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,10 @@ jobs:
           - rust: nightly
             os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
+          # Test 32-bit target that does not have AtomicU64/AtomicI64.
+          - rust: nightly
+            os: ubuntu-latest
+            target: mips-unknown-linux-gnu
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -7,7 +7,6 @@ export RUSTFLAGS="-D warnings"
 
 if [[ -n "$RUST_TARGET" ]]; then
     # If RUST_TARGET is specified, use cross for testing.
-    cargo install cross
     cross test --all --target "$RUST_TARGET" --exclude benchmarks -- --test-threads=1
 
     # For now, the non-host target only runs tests.

--- a/crossbeam-utils/tests/atomic_cell.rs
+++ b/crossbeam-utils/tests/atomic_cell.rs
@@ -279,7 +279,10 @@ fn issue_748() {
     }
 
     assert_eq!(mem::size_of::<Test>(), 8);
-    assert!(AtomicCell::<Test>::is_lock_free());
+    assert_eq!(
+        AtomicCell::<Test>::is_lock_free(),
+        cfg!(not(crossbeam_no_atomic_64))
+    );
     let x = AtomicCell::new(Test::FieldLess);
     assert_eq!(x.load(), Test::FieldLess);
 }

--- a/crossbeam-utils/tests/atomic_cell.rs
+++ b/crossbeam-utils/tests/atomic_cell.rs
@@ -265,6 +265,41 @@ fn const_atomic_cell_new() {
     assert_eq!(CELL.load(), 1);
 }
 
+// https://github.com/crossbeam-rs/crossbeam/pull/767
+macro_rules! test_arithmetic {
+    ($test_name:ident, $ty:ident) => {
+        #[test]
+        fn $test_name() {
+            let a: AtomicCell<$ty> = AtomicCell::new(7);
+
+            assert_eq!(a.fetch_add(3), 7);
+            assert_eq!(a.load(), 10);
+
+            assert_eq!(a.fetch_sub(3), 10);
+            assert_eq!(a.load(), 7);
+
+            assert_eq!(a.fetch_and(3), 7);
+            assert_eq!(a.load(), 3);
+
+            assert_eq!(a.fetch_or(16), 3);
+            assert_eq!(a.load(), 19);
+
+            assert_eq!(a.fetch_xor(2), 19);
+            assert_eq!(a.load(), 17);
+        }
+    };
+}
+test_arithmetic!(arithmetic_u8, u8);
+test_arithmetic!(arithmetic_i8, i8);
+test_arithmetic!(arithmetic_u16, u16);
+test_arithmetic!(arithmetic_i16, i16);
+test_arithmetic!(arithmetic_u32, u32);
+test_arithmetic!(arithmetic_i32, i32);
+test_arithmetic!(arithmetic_u64, u64);
+test_arithmetic!(arithmetic_i64, i64);
+test_arithmetic!(arithmetic_u128, u128);
+test_arithmetic!(arithmetic_i128, i128);
+
 // https://github.com/crossbeam-rs/crossbeam/issues/748
 #[cfg_attr(miri, ignore)] // TODO
 #[rustversion::since(1.37)] // #[repr(align(N))] requires Rust 1.37


### PR DESCRIPTION
Test 32-bit target that does not have AtomicU64/AtomicI64.

This also adds a test for the regression that #767 caught.