### PR TITLE
Remove unnecessarily allowed lints

### DIFF
--- a/crossbeam-channel/src/err.rs
+++ b/crossbeam-channel/src/err.rs
@@ -308,7 +308,6 @@ impl From<RecvError> for TryRecvError {
 
 impl TryRecvError {
     /// Returns `true` if the receive operation failed because the channel is empty.
-    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn is_empty(&self) -> bool {
         match self {
             TryRecvError::Empty => true,
@@ -317,7 +316,6 @@ impl TryRecvError {
     }
 
     /// Returns `true` if the receive operation failed because the channel is disconnected.
-    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn is_disconnected(&self) -> bool {
         match self {
             TryRecvError::Disconnected => true,
@@ -347,7 +345,6 @@ impl From<RecvError> for RecvTimeoutError {
 
 impl RecvTimeoutError {
     /// Returns `true` if the receive operation timed out.
-    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn is_timeout(&self) -> bool {
         match self {
             RecvTimeoutError::Timeout => true,
@@ -356,7 +353,6 @@ impl RecvTimeoutError {
     }
 
     /// Returns `true` if the receive operation failed because the channel is disconnected.
-    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn is_disconnected(&self) -> bool {
         match self {
             RecvTimeoutError::Disconnected => true,

--- a/crossbeam-channel/src/flavors/array.rs
+++ b/crossbeam-channel/src/flavors/array.rs
@@ -469,7 +469,6 @@ impl<T> Channel<T> {
     }
 
     /// Returns the capacity of the channel.
-    #[allow(clippy::unnecessary_wraps)] // This is intentional.
     pub(crate) fn capacity(&self) -> Option<usize> {
         Some(self.cap)
     }

--- a/crossbeam-channel/src/flavors/at.rs
+++ b/crossbeam-channel/src/flavors/at.rs
@@ -142,7 +142,6 @@ impl Channel {
     }
 
     /// Returns the capacity of the channel.
-    #[allow(clippy::unnecessary_wraps)] // This is intentional.
     #[inline]
     pub(crate) fn capacity(&self) -> Option<usize> {
         Some(1)

--- a/crossbeam-channel/src/flavors/never.rs
+++ b/crossbeam-channel/src/flavors/never.rs
@@ -65,7 +65,6 @@ impl<T> Channel<T> {
     }
 
     /// Returns the capacity of the channel.
-    #[allow(clippy::unnecessary_wraps)] // This is intentional.
     #[inline]
     pub(crate) fn capacity(&self) -> Option<usize> {
         Some(0)

--- a/crossbeam-channel/src/flavors/tick.rs
+++ b/crossbeam-channel/src/flavors/tick.rs
@@ -112,7 +112,6 @@ impl Channel {
     }
 
     /// Returns the capacity of the channel.
-    #[allow(clippy::unnecessary_wraps)] // This is intentional.
     #[inline]
     pub(crate) fn capacity(&self) -> Option<usize> {
         Some(1)

--- a/crossbeam-channel/src/flavors/zero.rs
+++ b/crossbeam-channel/src/flavors/zero.rs
@@ -363,7 +363,6 @@ impl<T> Channel<T> {
     }
 
     /// Returns the capacity of the channel.
-    #[allow(clippy::unnecessary_wraps)] // This is intentional.
     pub(crate) fn capacity(&self) -> Option<usize> {
         Some(0)
     }

--- a/crossbeam-epoch/src/atomic.rs
+++ b/crossbeam-epoch/src/atomic.rs
@@ -1284,7 +1284,6 @@ impl<'g, T> Shared<'g, T> {
     /// let p = a.load(SeqCst, guard);
     /// assert_eq!(p.as_raw(), raw);
     /// ```
-    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn as_raw(&self) -> *const T {
         let (raw, _) = decompose_tag::<T>(self.data);
         raw as *const _
@@ -1323,7 +1322,6 @@ impl<'g, T: ?Sized + Pointable> Shared<'g, T> {
     /// a.store(Owned::new(1234), SeqCst);
     /// assert!(!a.load(SeqCst, guard).is_null());
     /// ```
-    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn is_null(&self) -> bool {
         let (raw, _) = decompose_tag::<T>(self.data);
         raw == 0
@@ -1360,8 +1358,6 @@ impl<'g, T: ?Sized + Pointable> Shared<'g, T> {
     ///     assert_eq!(p.deref(), &1234);
     /// }
     /// ```
-    #[allow(clippy::trivially_copy_pass_by_ref)]
-    #[allow(clippy::should_implement_trait)]
     pub unsafe fn deref(&self) -> &'g T {
         let (raw, _) = decompose_tag::<T>(self.data);
         T::deref(raw)
@@ -1403,7 +1399,6 @@ impl<'g, T: ?Sized + Pointable> Shared<'g, T> {
     ///     assert_eq!(p.deref(), &vec![1, 2, 3, 4, 5]);
     /// }
     /// ```
-    #[allow(clippy::should_implement_trait)]
     pub unsafe fn deref_mut(&mut self) -> &'g mut T {
         let (raw, _) = decompose_tag::<T>(self.data);
         T::deref_mut(raw)
@@ -1440,7 +1435,6 @@ impl<'g, T: ?Sized + Pointable> Shared<'g, T> {
     ///     assert_eq!(p.as_ref(), Some(&1234));
     /// }
     /// ```
-    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub unsafe fn as_ref(&self) -> Option<&'g T> {
         let (raw, _) = decompose_tag::<T>(self.data);
         if raw == 0 {
@@ -1492,7 +1486,6 @@ impl<'g, T: ?Sized + Pointable> Shared<'g, T> {
     /// let p = a.load(SeqCst, guard);
     /// assert_eq!(p.tag(), 2);
     /// ```
-    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn tag(&self) -> usize {
         let (_, tag) = decompose_tag::<T>(self.data);
         tag
@@ -1516,7 +1509,6 @@ impl<'g, T: ?Sized + Pointable> Shared<'g, T> {
     /// assert_eq!(p2.tag(), 2);
     /// assert_eq!(p1.as_raw(), p2.as_raw());
     /// ```
-    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn with_tag(&self, tag: usize) -> Shared<'g, T> {
         unsafe { Self::from_usize(compose_tag::<T>(self.data, tag)) }
     }

--- a/crossbeam-epoch/src/deferred.rs
+++ b/crossbeam-epoch/src/deferred.rs
@@ -57,7 +57,6 @@ impl Deferred {
                 unsafe fn call<F: FnOnce()>(raw: *mut u8) {
                     // It's safe to cast `raw` from `*mut u8` to `*mut Box<F>`, because `raw` is
                     // originally derived from `*mut Box<F>`.
-                    #[allow(clippy::cast_ptr_alignment)]
                     let b: Box<F> = ptr::read(raw as *mut Box<F>);
                     (*b)();
                 }

--- a/crossbeam-utils/src/atomic/atomic_cell.rs
+++ b/crossbeam-utils/src/atomic/atomic_cell.rs
@@ -1,6 +1,5 @@
 // Necessary for implementing atomic methods for `AtomicUnit`
 #![allow(clippy::unit_arg)]
-#![allow(clippy::let_unit_value)]
 
 use crate::primitive::sync::atomic::{self, AtomicBool};
 use core::cell::UnsafeCell;
@@ -733,7 +732,6 @@ impl AtomicUnit {
     #[inline]
     fn swap(&self, _val: (), _order: Ordering) {}
 
-    #[allow(clippy::unnecessary_wraps)] // This is intentional.
     #[inline]
     fn compare_exchange_weak(
         &self,


### PR DESCRIPTION
Most of these lints have been downgraded to be allowed by default.