### PR TITLE
epoch: Remove ptr-to-int casts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,3 +86,7 @@ members = [
   "crossbeam-skiplist",
   "crossbeam-utils",
 ]
+
+[patch.crates-io]
+# https://github.com/matklad/once_cell/pull/185
+once_cell = { git = "https://github.com/saethlin/once_cell.git", rev = "4aa5ac4aa30b9eed4a0848f3ad22a5eeb025760d" }

--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -19,23 +19,26 @@ MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-disable-isolation -Zmiri-ignor
     cargo miri test \
     -p crossbeam-channel 2>&1 | ts -i '%.s  '
 
-# -Zmiri-ignore-leaks is needed for https://github.com/crossbeam-rs/crossbeam/issues/579
+# -Zmiri-disable-stacked-borrows is needed for https://github.com/crossbeam-rs/crossbeam/issues/545
+MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-disable-isolation -Zmiri-disable-stacked-borrows" \
+    cargo miri test \
+    -p crossbeam-epoch 2>&1 | ts -i '%.s  '
+
+# -Zmiri-ignore-leaks is needed for https://github.com/crossbeam-rs/crossbeam/issues/614
 # -Zmiri-disable-stacked-borrows is needed for https://github.com/crossbeam-rs/crossbeam/issues/545
 MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-disable-isolation -Zmiri-disable-stacked-borrows -Zmiri-ignore-leaks" \
     cargo miri test \
-    -p crossbeam-epoch \
     -p crossbeam-skiplist 2>&1 | ts -i '%.s  '
 
-# -Zmiri-ignore-leaks is needed for https://github.com/crossbeam-rs/crossbeam/issues/579
 # -Zmiri-disable-stacked-borrows is needed for https://github.com/crossbeam-rs/crossbeam/issues/545
 # -Zmiri-compare-exchange-weak-failure-rate=0.0 is needed because some sequential tests (e.g.,
 # doctest of Stealer::steal) incorrectly assume that sequential weak CAS will never fail.
 # -Zmiri-preemption-rate=0 is needed because this code technically has UB and Miri catches that.
-MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-disable-stacked-borrows -Zmiri-ignore-leaks -Zmiri-compare-exchange-weak-failure-rate=0.0 -Zmiri-preemption-rate=0" \
+MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-disable-stacked-borrows -Zmiri-compare-exchange-weak-failure-rate=0.0 -Zmiri-preemption-rate=0" \
     cargo miri test \
     -p crossbeam-deque 2>&1 | ts -i '%.s  '
 
-# -Zmiri-ignore-leaks is needed for https://github.com/crossbeam-rs/crossbeam/issues/579
-MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-ignore-leaks" \
+# -Zmiri-disable-stacked-borrows is needed for https://github.com/crossbeam-rs/crossbeam/issues/545
+MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-disable-stacked-borrows" \
     cargo miri test \
     -p crossbeam 2>&1 | ts -i '%.s  '

--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -9,24 +9,24 @@ echo
 
 export RUSTFLAGS="${RUSTFLAGS:-} -Z randomize-layout"
 
-MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-disable-isolation" \
+MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-disable-isolation" \
     cargo miri test \
     -p crossbeam-queue \
     -p crossbeam-utils 2>&1 | ts -i '%.s  '
 
 # -Zmiri-ignore-leaks is needed because we use detached threads in tests/docs: https://github.com/rust-lang/miri/issues/1371
-MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-disable-isolation -Zmiri-ignore-leaks" \
+MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-disable-isolation -Zmiri-ignore-leaks" \
     cargo miri test \
     -p crossbeam-channel 2>&1 | ts -i '%.s  '
 
 # -Zmiri-disable-stacked-borrows is needed for https://github.com/crossbeam-rs/crossbeam/issues/545
-MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-disable-isolation -Zmiri-disable-stacked-borrows" \
+MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-disable-isolation -Zmiri-disable-stacked-borrows" \
     cargo miri test \
     -p crossbeam-epoch 2>&1 | ts -i '%.s  '
 
 # -Zmiri-ignore-leaks is needed for https://github.com/crossbeam-rs/crossbeam/issues/614
 # -Zmiri-disable-stacked-borrows is needed for https://github.com/crossbeam-rs/crossbeam/issues/545
-MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-disable-isolation -Zmiri-disable-stacked-borrows -Zmiri-ignore-leaks" \
+MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-disable-isolation -Zmiri-disable-stacked-borrows -Zmiri-ignore-leaks" \
     cargo miri test \
     -p crossbeam-skiplist 2>&1 | ts -i '%.s  '
 
@@ -34,11 +34,11 @@ MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-disable-isolation -Zmiri-disab
 # -Zmiri-compare-exchange-weak-failure-rate=0.0 is needed because some sequential tests (e.g.,
 # doctest of Stealer::steal) incorrectly assume that sequential weak CAS will never fail.
 # -Zmiri-preemption-rate=0 is needed because this code technically has UB and Miri catches that.
-MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-disable-stacked-borrows -Zmiri-compare-exchange-weak-failure-rate=0.0 -Zmiri-preemption-rate=0" \
+MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-disable-stacked-borrows -Zmiri-compare-exchange-weak-failure-rate=0.0 -Zmiri-preemption-rate=0" \
     cargo miri test \
     -p crossbeam-deque 2>&1 | ts -i '%.s  '
 
 # -Zmiri-disable-stacked-borrows is needed for https://github.com/crossbeam-rs/crossbeam/issues/545
-MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-disable-stacked-borrows" \
+MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-disable-stacked-borrows" \
     cargo miri test \
     -p crossbeam 2>&1 | ts -i '%.s  '

--- a/crossbeam-epoch/src/collector.rs
+++ b/crossbeam-epoch/src/collector.rs
@@ -403,9 +403,9 @@ mod tests {
             }
 
             let len = v.len();
-            let ptr = ManuallyDrop::new(v).as_mut_ptr() as usize;
+            let ptr = ManuallyDrop::new(v).as_mut_ptr();
             guard.defer_unchecked(move || {
-                drop(Vec::from_raw_parts(ptr as *const i32 as *mut i32, len, len));
+                drop(Vec::from_raw_parts(ptr, len, len));
                 DESTROYS.fetch_add(len, Ordering::Relaxed);
             });
             guard.flush();

--- a/crossbeam-epoch/src/internal.rs
+++ b/crossbeam-epoch/src/internal.rs
@@ -537,14 +537,18 @@ impl Local {
 
 impl IsElement<Local> for Local {
     fn entry_of(local: &Local) -> &Entry {
-        let entry_ptr = (local as *const Local as usize + offset_of!(Local, entry)) as *const Entry;
-        unsafe { &*entry_ptr }
+        unsafe {
+            let entry_ptr = (local as *const Local as *const u8)
+                .add(offset_of!(Local, entry))
+                .cast::<Entry>();
+            &*entry_ptr
+        }
     }
 
     unsafe fn element_of(entry: &Entry) -> &Local {
-        // offset_of! macro uses unsafe, but it's unnecessary in this context.
-        #[allow(unused_unsafe)]
-        let local_ptr = (entry as *const Entry as usize - offset_of!(Local, entry)) as *const Local;
+        let local_ptr = (entry as *const Entry as *const u8)
+            .sub(offset_of!(Local, entry))
+            .cast::<Local>();
         &*local_ptr
     }
 

--- a/crossbeam-epoch/src/lib.rs
+++ b/crossbeam-epoch/src/lib.rs
@@ -62,6 +62,7 @@
     unreachable_pub
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(miri, feature(strict_provenance_atomic_ptr))]
 
 #[cfg(crossbeam_loom)]
 extern crate loom_crate as loom;
@@ -77,7 +78,7 @@ mod primitive {
     pub(crate) mod sync {
         pub(crate) mod atomic {
             use core::sync::atomic::Ordering;
-            pub(crate) use loom::sync::atomic::{fence, AtomicUsize};
+            pub(crate) use loom::sync::atomic::{fence, AtomicPtr, AtomicUsize};
 
             // FIXME: loom does not support compiler_fence at the moment.
             // https://github.com/tokio-rs/loom/issues/117
@@ -127,7 +128,7 @@ mod primitive {
         pub(crate) mod atomic {
             pub(crate) use core::sync::atomic::compiler_fence;
             pub(crate) use core::sync::atomic::fence;
-            pub(crate) use core::sync::atomic::AtomicUsize;
+            pub(crate) use core::sync::atomic::{AtomicPtr, AtomicUsize};
         }
         pub(crate) use alloc::sync::Arc;
     }

--- a/tests/subcrates.rs
+++ b/tests/subcrates.rs
@@ -20,7 +20,6 @@ fn deque() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)] // Miri ICE: https://github.com/crossbeam-rs/crossbeam/pull/870#issuecomment-1189209073
 fn epoch() {
     crossbeam::epoch::pin();
 }


### PR DESCRIPTION
Use [this hack](https://github.com/rust-lang/miri/issues/1866#issuecomment-985802751) to fix compatibility issues with Miri (see https://github.com/crossbeam-rs/crossbeam/pull/490#issuecomment-755435349 for details). 

Due to the https://github.com/crossbeam-rs/crossbeam/issues/545, still not compatible with stacked borrows. This will be fixed by the subsequent PR (#871).

Note: this is a breaking change because changes API of Pointable and Pointer traits

Fixes #579