### PR TITLE
Prepare for the next release

### DIFF
--- a/crossbeam-channel/CHANGELOG.md
+++ b/crossbeam-channel/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.5.3
+
+- Fix panic on very large timeout. (#798)
+
 # Version 0.5.2
 
 - Fix stacked borrows violations when `-Zmiri-tag-raw-pointers` is enabled. (#763, #764)

--- a/crossbeam-channel/Cargo.toml
+++ b/crossbeam-channel/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-channel"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-channel-X.Y.Z" git tag
-version = "0.5.2"
+version = "0.5.3"
 edition = "2018"
 rust-version = "1.36"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-epoch/CHANGELOG.md
+++ b/crossbeam-epoch/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.9.8
+
+- Make `Atomic::null()` const function at 1.61+. (#797)
+
 # Version 0.9.7
 
 - Fix Miri error when `-Zmiri-check-number-validity` is enabled. (#779)

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-epoch"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-epoch-X.Y.Z" git tag
-version = "0.9.7"
+version = "0.9.8"
 edition = "2018"
 rust-version = "1.36"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-queue/CHANGELOG.md
+++ b/crossbeam-queue/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.3.5
+
+- Add `ArrayQueue::force_push`. (#789)
+
 # Version 0.3.4
 
 - Implement `IntoIterator` for `ArrayQueue` and `SegQueue`. (#772)

--- a/crossbeam-queue/Cargo.toml
+++ b/crossbeam-queue/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-queue"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-queue-X.Y.Z" git tag
-version = "0.3.4"
+version = "0.3.5"
 edition = "2018"
 rust-version = "1.36"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-utils/CHANGELOG.md
+++ b/crossbeam-utils/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.8.8
+
+- Fix a bug when unstable `loom` support is enabled. (#787)
+
 # Version 0.8.7
 
 - Add `AtomicCell<{i*,u*}>::{fetch_max,fetch_min}`. (#785)

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-utils"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-utils-X.Y.Z" git tag
-version = "0.8.7"
+version = "0.8.8"
 edition = "2018"
 rust-version = "1.36"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
- crossbeam-channel 0.5.2 -> 0.5.3
  - Fix panic on very large timeout. (#798)
- crossbeam-epoch 0.9.7 -> 0.9.8
  - Make `Atomic::null()` const function at 1.61+. (#797)
- crossbeam-queue 0.3.4 -> 0.3.5
  - Add `ArrayQueue::force_push`. (#789)
- crossbeam-utils 0.8.7 -> 0.8.8
  - Fix a bug when unstable `loom` support is enabled. (#787)
