### PR TITLE
Use setup-cross-toolchain-action instead of cross

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ defaults:
   run:
     shell: bash
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   # Test crates on their minimum Rust versions and nightly Rust.
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
           - rust: nightly
             os: ubuntu-latest
             target: i686-unknown-linux-gnu
+          - rust: nightly
+            os: ubuntu-latest
+            target: armv7-unknown-linux-gnueabihf
           # Test 32-bit target that does not have AtomicU64/AtomicI64.
           - rust: nightly
             os: ubuntu-latest
@@ -61,8 +64,9 @@ jobs:
       - name: Install Rust
         # --no-self-update is necessary because the windows environment cannot self-update rustup.exe.
         run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
-      - name: Install cross
-        uses: taiki-e/install-action@cross
+      - uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: ${{ matrix.target }}
         if: matrix.target != ''
       - name: Test
         run: ./ci/test.sh

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -3,10 +3,10 @@ set -euxo pipefail
 IFS=$'\n\t'
 cd "$(dirname "$0")"/..
 
+# shellcheck disable=SC2086
 if [[ -n "${RUST_TARGET:-}" ]]; then
-    # If RUST_TARGET is specified, use cross for testing.
-    cross test --all --target "$RUST_TARGET" --exclude benchmarks -- --test-threads=1
-    cross test --all --target "$RUST_TARGET" --exclude benchmarks --release -- --test-threads=1
+    cargo test --all --target "$RUST_TARGET" --exclude benchmarks ${DOCTEST_XCOMPILE:-} -- --test-threads=1
+    cargo test --all --target "$RUST_TARGET" --exclude benchmarks --release ${DOCTEST_XCOMPILE:-} -- --test-threads=1
 
     # For now, the non-host target only runs tests.
     exit 0


### PR DESCRIPTION
[setup-cross-toolchain-action](https://github.com/taiki-e/setup-cross-toolchain-action) is a GitHub Action to set up CI environment for cross-testing, including doctest, without dockers.

This also enables tests for armv7hf on CI.
