### PR TITLE
Prepare for the next release

### DIFF
--- a/crossbeam-channel/CHANGELOG.md
+++ b/crossbeam-channel/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.5.4
+
+- Workaround a bug in upstream related to TLS access on AArch64 Linux. (#802)
+
 # Version 0.5.3
 
 - Fix panic on very large timeout. (#798)

--- a/crossbeam-channel/Cargo.toml
+++ b/crossbeam-channel/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-channel"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-channel-X.Y.Z" git tag
-version = "0.5.3"
+version = "0.5.4"
 edition = "2018"
 rust-version = "1.36"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
- crossbeam-channel 0.5.3 -> 0.5.4
  - Workaround a bug in upstream related to TLS access on AArch64 Linux. (#802)