### PR TITLE
Add caveat documentation on panicking.

### DIFF
--- a/crossbeam-utils/src/thread.rs
+++ b/crossbeam-utils/src/thread.rs
@@ -130,7 +130,8 @@ type SharedOption<T> = Arc<Mutex<Option<T>>>;
 /// All child threads that haven't been manually joined will be automatically joined just before
 /// this function invocation ends. If all joined threads have successfully completed, `Ok` is
 /// returned with the return value of `f`. If any of the joined threads has panicked, an `Err` is
-/// returned containing errors from panicked threads.
+/// returned containing errors from panicked threads. Note that if panics are implemented by
+/// aborting the process, no error is returned; see the notes of [std::panic::catch_unwind].
 ///
 /// # Examples
 ///
@@ -490,7 +491,8 @@ pub struct ScopedJoinHandle<'scope, T> {
 impl<T> ScopedJoinHandle<'_, T> {
     /// Waits for the thread to finish and returns its result.
     ///
-    /// If the child thread panics, an error is returned.
+    /// If the child thread panics, an error is returned. Note that if panics are implemented by
+    /// aborting the process, no error is returned; see the notes of [std::panic::catch_unwind].
     ///
     /// # Panics
     ///


### PR DESCRIPTION
This PR is related to issue #792. Sorry for the delay!

I also want to double check that this is expected behaviour. I quickly made a
test crate:

`main.rs`:
```rust
use crossbeam_utils::thread;

fn main() {
    let scoped_threads_result = thread::scope(|scope| {
        scope.spawn(move |_| {
            panic!("oh no!");
        });
    });
    dbg!(scoped_threads_result.unwrap());
}
```

`Cargo.toml`:
```toml
[package]
name = "crossbeam-test"
version = "0.1.0"
edition = "2021"

[dependencies]
crossbeam-utils = "0.8.8"

[profile.release]
panic = "abort"
```

This gives:
```
cargo run --release
    Finished release [optimized] target(s) in 0.00s
     Running `target/release/crossbeam-test`
thread '<unnamed>' panicked at 'oh no!', src/main.rs:6:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

whereas without the `panic = "abort"` gives:
```
cargo run --release
    Finished release [optimized] target(s) in 0.00s
     Running `target/release/crossbeam-test`
thread '<unnamed>' panicked at 'oh no!', src/main.rs:6:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Any { .. }', src/main.rs:9:32
```

If this is expected and fine, then please have a look at my additional docs. There isn't much, but hopefully it's enough to help someone not "go down a rabbit hole" because they forgot that they're aborting.

Closes #792