### PR TITLE
channel: use `AtomicUsize::get_mut` in `flavors::{array,list}::Channel::drop`

### DIFF
--- a/crossbeam-channel/src/flavors/array.rs
+++ b/crossbeam-channel/src/flavors/array.rs
@@ -521,8 +521,11 @@ impl<T> Channel<T> {
 impl<T> Drop for Channel<T> {
     fn drop(&mut self) {
         // Get the index of the head.
-        let hix = *self.head.get_mut() & (self.mark_bit - 1);
-        let tix = *self.tail.get_mut() & (self.mark_bit - 1);
+        let head = *self.head.get_mut();
+        let tail = *self.tail.get_mut();
+
+        let hix = head & (self.mark_bit - 1);
+        let tix = tail & (self.mark_bit - 1);
 
         let len = if hix < tix {
             tix - hix

--- a/crossbeam-channel/src/flavors/array.rs
+++ b/crossbeam-channel/src/flavors/array.rs
@@ -521,10 +521,21 @@ impl<T> Channel<T> {
 impl<T> Drop for Channel<T> {
     fn drop(&mut self) {
         // Get the index of the head.
-        let hix = self.head.load(Ordering::Relaxed) & (self.mark_bit - 1);
+        let hix = *self.head.get_mut() & (self.mark_bit - 1);
+        let tix = *self.tail.get_mut() & (self.mark_bit - 1);
+
+        let len = if hix < tix {
+            tix - hix
+        } else if hix > tix {
+            self.cap - hix + tix
+        } else if (tail & !self.mark_bit) == head {
+            0
+        } else {
+            self.cap
+        };
 
         // Loop over all slots that hold a message and drop them.
-        for i in 0..self.len() {
+        for i in 0..len {
             // Compute the index of the next slot holding a message.
             let index = if hix + i < self.cap {
                 hix + i

--- a/crossbeam-channel/src/flavors/list.rs
+++ b/crossbeam-channel/src/flavors/list.rs
@@ -634,9 +634,9 @@ impl<T> Channel<T> {
 
 impl<T> Drop for Channel<T> {
     fn drop(&mut self) {
-        let mut head = self.head.index.load(Ordering::Relaxed);
-        let mut tail = self.tail.index.load(Ordering::Relaxed);
-        let mut block = self.head.block.load(Ordering::Relaxed);
+        let mut head = *self.head.index.get_mut();
+        let mut tail = *self.tail.index.get_mut();
+        let mut block = *self.head.block.get_mut();
 
         // Erase the lower bits.
         head &= !((1 << SHIFT) - 1);
@@ -654,7 +654,7 @@ impl<T> Drop for Channel<T> {
                     p.as_mut_ptr().drop_in_place();
                 } else {
                     // Deallocate the block and move to the next one.
-                    let next = (*block).next.load(Ordering::Relaxed);
+                    let next = *(*block).next.get_mut();
                     drop(Box::from_raw(block));
                     block = next;
                 }


### PR DESCRIPTION
As access to `&mut self` in `Drop` impls gives exclusive access, it's
unnecessary to atomically load `self.head` and `self.tail` there.