### PR TITLE
Make doc test for tick channel more reliable

### DIFF
--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -298,7 +298,7 @@ pub fn never<T>() -> Receiver<T> {
 /// let ms = |ms| Duration::from_millis(ms);
 ///
 /// // Returns `true` if `a` and `b` are very close `Instant`s.
-/// let eq = |a, b| a + ms(50) > b && b + ms(50) > a;
+/// let eq = |a, b| a + ms(65) > b && b + ms(65) > a;
 ///
 /// let start = Instant::now();
 /// let r = tick(ms(100));


### PR DESCRIPTION
Increase time margin for checking event times to make the doc test more reliable

ref #825