### PR TITLE
Disable Miri weak memory emulation for deque tests

### DIFF
--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -24,7 +24,7 @@ MIRIFLAGS="-Zmiri-check-number-validity -Zmiri-symbolic-alignment-check -Zmiri-d
 
 # -Zmiri-ignore-leaks is needed for https://github.com/crossbeam-rs/crossbeam/issues/579
 # -Zmiri-disable-stacked-borrows is needed for https://github.com/crossbeam-rs/crossbeam/issues/545
-MIRIFLAGS="-Zmiri-check-number-validity -Zmiri-symbolic-alignment-check -Zmiri-disable-stacked-borrows -Zmiri-ignore-leaks -Zmiri-compare-exchange-weak-failure-rate=1.0" \
+MIRIFLAGS="-Zmiri-check-number-validity -Zmiri-symbolic-alignment-check -Zmiri-disable-stacked-borrows -Zmiri-ignore-leaks -Zmiri-compare-exchange-weak-failure-rate=1.0 -Zmiri-disable-weak-memory-emulation" \
     cargo miri test \
     -p crossbeam-deque
 


### PR DESCRIPTION
(**Don't merge yet**) Once https://github.com/rust-lang/miri/pull/1963 is merged into Miri to support weak memory emulation, `crossbeam-deque/tests/injector.rs::mpmc()` test will hang forever on Miri CI. This PR disables weak memory emulation for deque tests to prevent this. This is why we need to do this:

Miri README says
> Threading support is not finished yet. E.g., weak memory effects are not emulated and **spin loops (without syscalls) just loop forever**. There is no threading support on Windows.

This is because Miri's scheduler is not pre-emptive. It runs the current thread until it terminates or `yield_now()` is called explicitly.

The test has a spin loop without yielding. When run natively it relies on the OS to have a pre-emptive scheduler:
https://github.com/crossbeam-rs/crossbeam/blob/6f52beaaddfd64fc1f47fdc9e011b2d94c79ccc8/crossbeam-deque/tests/injector.rs#L100-L105

This currently passes due to the fact that all the pushing threads run and terminate before any stealing threads gets to run. `.steal()` never returns anything other than success.

However, if a pushing thread's `push()` call causes it to yield, then Miri could end up in a stealing thread. If this happens multiple times then Miri could land in a stealing spin loop with nothing in the queue since there aren't enough successful pushes. The test ends up hanging.

`push()` could yield the thread by a compare exchange failure:
https://github.com/crossbeam-rs/crossbeam/blob/6f52beaaddfd64fc1f47fdc9e011b2d94c79ccc8/crossbeam-deque/src/deque.rs#L1301-L1330

Without weak memory behaviour or thread interleaving, the previously loaded `tail` value is always the most recent one which is what the compare exchange will observe, so the only way it could fail is spuriously. This is why currently we turned off spurious failure, and the thread never yields:
https://github.com/crossbeam-rs/crossbeam/blob/6f52beaaddfd64fc1f47fdc9e011b2d94c79ccc8/ci/miri.sh#L27
(yes, `-Zmiri-compare-exchange-weak-failure-rate=1.0` implies that the exchange _always_ fails. However it actually means never failing because a comparison in Miri was written backwards. This will be fixed https://github.com/rust-lang/miri/pull/2105)

However, once weak memory is added, `tail` doesn't have to be the most recent value, meaning the compare exchange could fail and the pushing thread yields, landing us in a stealing spin loop.
https://github.com/crossbeam-rs/crossbeam/blob/6f52beaaddfd64fc1f47fdc9e011b2d94c79ccc8/crossbeam-deque/src/deque.rs#L1276

The best way to solve this for Miri to have a pre-emptive scheduler. But to keep the CI green this workaround is fine.