### PR TITLE
Add spin loop hints in tests for Miri

### DIFF
--- a/crossbeam-deque/tests/injector.rs
+++ b/crossbeam-deque/tests/injector.rs
@@ -61,6 +61,8 @@ fn spsc() {
                         assert_eq!(i, v);
                         break;
                     }
+                    #[cfg(miri)]
+                    std::hint::spin_loop();
                 }
             }
 
@@ -102,6 +104,8 @@ fn mpmc() {
                             v[n].fetch_add(1, SeqCst);
                             break;
                         }
+                        #[cfg(miri)]
+                        std::hint::spin_loop();
                     }
                 }
             });

--- a/crossbeam-deque/tests/lifo.rs
+++ b/crossbeam-deque/tests/lifo.rs
@@ -87,6 +87,8 @@ fn spsc() {
                         assert_eq!(i, v);
                         break;
                     }
+                    #[cfg(miri)]
+                    std::hint::spin_loop();
                 }
             }
 


### PR DESCRIPTION
This is a better way to do #829 

Miri does not have a pre-emptive scheduler, so once the execution falls into a spin loop it'll hang forever: https://github.com/rust-lang/miri/issues/1388

Similar measures (`yield_now()`) are already present in [some other tests](https://github.com/crossbeam-rs/crossbeam/blob/master/crossbeam-queue/tests/array_queue.rs), but it's missing here