### PR TITLE
Fix links to macro rules in docs

### DIFF
--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -232,6 +232,8 @@ pub fn at(when: Instant) -> Receiver<Instant> {
 /// # Examples
 ///
 /// Using a `never` channel to optionally add a timeout to [`select!`]:
+/// 
+/// [`select!`]: crate::select!
 ///
 /// ```
 /// use std::thread;

--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -232,7 +232,7 @@ pub fn at(when: Instant) -> Receiver<Instant> {
 /// # Examples
 ///
 /// Using a `never` channel to optionally add a timeout to [`select!`]:
-/// 
+///
 /// [`select!`]: crate::select!
 ///
 /// ```

--- a/crossbeam-channel/src/select.rs
+++ b/crossbeam-channel/src/select.rs
@@ -518,7 +518,7 @@ pub(crate) fn select_deadline<'a>(
 ///
 /// The [`select!`] macro is a convenience wrapper around `Select`. However, it cannot select over a
 /// dynamically created list of channel operations.
-/// 
+///
 /// [`select!`]: crate::select!
 ///
 /// Once a list of operations has been built with `Select`, there are two different ways of

--- a/crossbeam-channel/src/select.rs
+++ b/crossbeam-channel/src/select.rs
@@ -518,6 +518,8 @@ pub(crate) fn select_deadline<'a>(
 ///
 /// The [`select!`] macro is a convenience wrapper around `Select`. However, it cannot select over a
 /// dynamically created list of channel operations.
+/// 
+/// [`select!`]: crate::select!
 ///
 /// Once a list of operations has been built with `Select`, there are two different ways of
 /// proceeding:

--- a/crossbeam-channel/src/select_macro.rs
+++ b/crossbeam-channel/src/select_macro.rs
@@ -993,7 +993,7 @@ macro_rules! crossbeam_channel_internal {
 /// An operation is considered to be ready if it doesn't have to block. Note that it is ready even
 /// when it will simply return an error because the channel is disconnected.
 ///
-/// The `select` macro is a convenience wrapper around [`Select`]. However, it cannot select over a
+/// The `select!` macro is a convenience wrapper around [`Select`]. However, it cannot select over a
 /// dynamically created list of channel operations.
 ///
 /// [`Select`]: super::Select


### PR DESCRIPTION
The fix provides explicit links to macro rules in docs because they [are not resolved globally anymore](https://github.com/rust-lang/rust/pull/96676).
