### PR TITLE
Use `UnsafeCell<MaybeUninit<T>>` in AtomicCell

### DIFF
--- a/crossbeam-utils/tests/atomic_cell.rs
+++ b/crossbeam-utils/tests/atomic_cell.rs
@@ -330,3 +330,43 @@ fn issue_748() {
     let x = AtomicCell::new(Test::FieldLess);
     assert_eq!(x.load(), Test::FieldLess);
 }
+
+// https://github.com/crossbeam-rs/crossbeam/issues/833
+#[rustversion::since(1.40)] // const_constructor requires Rust 1.40
+#[test]
+fn issue_833() {
+    use std::num::NonZeroU128;
+    use std::thread;
+
+    const N: usize = 1_000_000;
+
+    #[allow(dead_code)]
+    enum Enum {
+        NeverConstructed,
+        Cell(AtomicCell<NonZeroU128>),
+    }
+
+    static STATIC: Enum = Enum::Cell(AtomicCell::new(match NonZeroU128::new(1) {
+        Some(nonzero) => nonzero,
+        None => unreachable!(),
+    }));
+
+    thread::spawn(|| {
+        let cell = match &STATIC {
+            Enum::NeverConstructed => unreachable!(),
+            Enum::Cell(cell) => cell,
+        };
+        let x = NonZeroU128::new(0xFFFF_FFFF_FFFF_FFFF_0000_0000_0000_0000).unwrap();
+        let y = NonZeroU128::new(0x0000_0000_0000_0000_FFFF_FFFF_FFFF_FFFF).unwrap();
+        loop {
+            cell.store(x);
+            cell.store(y);
+        }
+    });
+
+    for _ in 0..N {
+        if let Enum::NeverConstructed = STATIC {
+            unreachable!(":(");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #833

Note: This contains two breaking changes:
- Unsized values are no longer allowed.
  This is because `MaybeUninit` doesn't allow it.
- `AtomicCell` now implements `Drop`.
  This is because `MaybeUninit` prevents `T` from being dropped, so we need to implement `Drop` for `AtomicCell` to avoid leaks of non-`Copy` types.

Breakages are allowed because this is a soundness bug fix. However, given the amount of breakage, we would not be able to yank the affected releases and would only create an advisory.