### PR TITLE
channel: Replace Spinlock with Mutex

### DIFF
--- a/crossbeam-channel/src/waker.rs
+++ b/crossbeam-channel/src/waker.rs
@@ -2,11 +2,11 @@
 
 use std::ptr;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
 use std::thread::{self, ThreadId};
 
 use crate::context::Context;
 use crate::select::{Operation, Selected};
-use crate::utils::Spinlock;
 
 /// Represents a thread blocked on a specific channel operation.
 pub(crate) struct Entry {
@@ -176,7 +176,7 @@ impl Drop for Waker {
 /// This is a simple wrapper around `Waker` that internally uses a mutex for synchronization.
 pub(crate) struct SyncWaker {
     /// The inner `Waker`.
-    inner: Spinlock<Waker>,
+    inner: Mutex<Waker>,
 
     /// `true` if the waker is empty.
     is_empty: AtomicBool,
@@ -187,7 +187,7 @@ impl SyncWaker {
     #[inline]
     pub(crate) fn new() -> Self {
         SyncWaker {
-            inner: Spinlock::new(Waker::new()),
+            inner: Mutex::new(Waker::new()),
             is_empty: AtomicBool::new(true),
         }
     }
@@ -195,7 +195,7 @@ impl SyncWaker {
     /// Registers the current thread with an operation.
     #[inline]
     pub(crate) fn register(&self, oper: Operation, cx: &Context) {
-        let mut inner = self.inner.lock();
+        let mut inner = self.inner.lock().unwrap();
         inner.register(oper, cx);
         self.is_empty.store(
             inner.selectors.is_empty() && inner.observers.is_empty(),
@@ -206,7 +206,7 @@ impl SyncWaker {
     /// Unregisters an operation previously registered by the current thread.
     #[inline]
     pub(crate) fn unregister(&self, oper: Operation) -> Option<Entry> {
-        let mut inner = self.inner.lock();
+        let mut inner = self.inner.lock().unwrap();
         let entry = inner.unregister(oper);
         self.is_empty.store(
             inner.selectors.is_empty() && inner.observers.is_empty(),
@@ -219,7 +219,7 @@ impl SyncWaker {
     #[inline]
     pub(crate) fn notify(&self) {
         if !self.is_empty.load(Ordering::SeqCst) {
-            let mut inner = self.inner.lock();
+            let mut inner = self.inner.lock().unwrap();
             if !self.is_empty.load(Ordering::SeqCst) {
                 inner.try_select();
                 inner.notify();
@@ -234,7 +234,7 @@ impl SyncWaker {
     /// Registers an operation waiting to be ready.
     #[inline]
     pub(crate) fn watch(&self, oper: Operation, cx: &Context) {
-        let mut inner = self.inner.lock();
+        let mut inner = self.inner.lock().unwrap();
         inner.watch(oper, cx);
         self.is_empty.store(
             inner.selectors.is_empty() && inner.observers.is_empty(),
@@ -245,7 +245,7 @@ impl SyncWaker {
     /// Unregisters an operation waiting to be ready.
     #[inline]
     pub(crate) fn unwatch(&self, oper: Operation) {
-        let mut inner = self.inner.lock();
+        let mut inner = self.inner.lock().unwrap();
         inner.unwatch(oper);
         self.is_empty.store(
             inner.selectors.is_empty() && inner.observers.is_empty(),
@@ -256,7 +256,7 @@ impl SyncWaker {
     /// Notifies all threads that the channel is disconnected.
     #[inline]
     pub(crate) fn disconnect(&self) {
-        let mut inner = self.inner.lock();
+        let mut inner = self.inner.lock().unwrap();
         inner.disconnect();
         self.is_empty.store(
             inner.selectors.is_empty() && inner.observers.is_empty(),


### PR DESCRIPTION
Addresses one of @thomcc's reviews in https://github.com/rust-lang/rust/pull/93563#discussion_r799137958 (sorry for the late response!)

Historically, the use of spinlock was introduced when the dependency on parking_lot was removed (https://github.com/crossbeam-rs/crossbeam/commit/5208895dbcf568fc92e70b1644217dfe1b634e51).
However, given that it is used in Waker, which includes vectors that may be reallocated, using mutex seems to be the right choice here.

r? @ibraheemdev
bors d=ibraheemdev 