### PR TITLE
Fix miri tests

### DIFF
--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -24,7 +24,7 @@ MIRIFLAGS="-Zmiri-check-number-validity -Zmiri-symbolic-alignment-check -Zmiri-d
 
 # -Zmiri-ignore-leaks is needed for https://github.com/crossbeam-rs/crossbeam/issues/579
 # -Zmiri-disable-stacked-borrows is needed for https://github.com/crossbeam-rs/crossbeam/issues/545
-MIRIFLAGS="-Zmiri-check-number-validity -Zmiri-symbolic-alignment-check -Zmiri-disable-stacked-borrows -Zmiri-ignore-leaks -Zmiri-compare-exchange-weak-failure-rate=1.0" \
+MIRIFLAGS="-Zmiri-check-number-validity -Zmiri-symbolic-alignment-check -Zmiri-disable-stacked-borrows -Zmiri-ignore-leaks -Zmiri-compare-exchange-weak-failure-rate=0.0" \
     cargo miri test \
     -p crossbeam-deque
 

--- a/crossbeam-channel/tests/array.rs
+++ b/crossbeam-channel/tests/array.rs
@@ -253,11 +253,11 @@ fn recv_after_disconnect() {
 #[test]
 fn len() {
     #[cfg(miri)]
-    const COUNT: usize = 250;
+    const COUNT: usize = 50;
     #[cfg(not(miri))]
     const COUNT: usize = 25_000;
     #[cfg(miri)]
-    const CAP: usize = 100;
+    const CAP: usize = 50;
     #[cfg(not(miri))]
     const CAP: usize = 1000;
 
@@ -500,11 +500,11 @@ fn stress_timeout_two_threads() {
 #[test]
 fn drops() {
     #[cfg(miri)]
-    const RUNS: usize = 20;
+    const RUNS: usize = 10;
     #[cfg(not(miri))]
     const RUNS: usize = 100;
     #[cfg(miri)]
-    const STEPS: usize = 500;
+    const STEPS: usize = 100;
     #[cfg(not(miri))]
     const STEPS: usize = 10_000;
 
@@ -561,7 +561,7 @@ fn drops() {
 #[test]
 fn linearizable() {
     #[cfg(miri)]
-    const COUNT: usize = 100;
+    const COUNT: usize = 50;
     #[cfg(not(miri))]
     const COUNT: usize = 25_000;
     const THREADS: usize = 4;

--- a/crossbeam-channel/tests/golang.rs
+++ b/crossbeam-channel/tests/golang.rs
@@ -728,7 +728,7 @@ mod select2 {
     use super::*;
 
     #[cfg(miri)]
-    const N: i32 = 1000;
+    const N: i32 = 200;
     #[cfg(not(miri))]
     const N: i32 = 100000;
 
@@ -923,6 +923,9 @@ mod sieve1 {
             2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83,
             89, 97,
         ];
+        #[cfg(miri)]
+        let a = &a[..10];
+
         for item in a.iter() {
             let x = primes.recv().unwrap();
             if x != *item {
@@ -959,6 +962,11 @@ mod chan_test {
         const N: i32 = 20;
         #[cfg(not(miri))]
         const N: i32 = 200;
+
+        #[cfg(miri)]
+        const MESSAGES_COUNT: i32 = 20;
+        #[cfg(not(miri))]
+        const MESSAGES_COUNT: i32 = 100;
 
         for cap in 0..N {
             {
@@ -1066,15 +1074,15 @@ mod chan_test {
             }
 
             {
-                // Send 100 integers,
+                // Send many integers,
                 // ensure that we receive them non-corrupted in FIFO order.
                 let c = make::<i32>(cap as usize);
                 go!(c, {
-                    for i in 0..100 {
+                    for i in 0..MESSAGES_COUNT {
                         c.send(i);
                     }
                 });
-                for i in 0..100 {
+                for i in 0..MESSAGES_COUNT {
                     if c.recv() != Some(i) {
                         panic!();
                     }
@@ -1082,11 +1090,11 @@ mod chan_test {
 
                 // Same, but using recv2.
                 go!(c, {
-                    for i in 0..100 {
+                    for i in 0..MESSAGES_COUNT {
                         c.send(i);
                     }
                 });
-                for i in 0..100 {
+                for i in 0..MESSAGES_COUNT {
                     if c.recv() != Some(i) {
                         panic!();
                     }
@@ -1572,14 +1580,12 @@ mod race_chan_test {
 }
 
 // https://github.com/golang/go/blob/master/test/ken/chan.go
+#[cfg(not(miri))] // Miri is too slow
 mod chan {
 
     use super::*;
 
-    #[cfg(not(miri))]
     const MESSAGES_PER_CHANEL: u32 = 76;
-    #[cfg(miri)]
-    const MESSAGES_PER_CHANEL: u32 = 2; // Miri is too slow on these tests
     const MESSAGES_RANGE_LEN: u32 = 100;
     const END: i32 = 10000;
 
@@ -2080,7 +2086,7 @@ mod chan1 {
 
     // sent messages
     #[cfg(miri)]
-    const N: usize = 100;
+    const N: usize = 20;
     #[cfg(not(miri))]
     const N: usize = 1000;
     // receiving "goroutines"

--- a/crossbeam-channel/tests/list.rs
+++ b/crossbeam-channel/tests/list.rs
@@ -132,8 +132,13 @@ fn recv_timeout() {
 
 #[test]
 fn try_send() {
+    #[cfg(miri)]
+    const COUNT: usize = 50;
+    #[cfg(not(miri))]
+    const COUNT: usize = 1000;
+
     let (s, r) = unbounded();
-    for i in 0..1000 {
+    for i in 0..COUNT {
         assert_eq!(s.try_send(i), Ok(()));
     }
 
@@ -143,8 +148,13 @@ fn try_send() {
 
 #[test]
 fn send() {
+    #[cfg(miri)]
+    const COUNT: usize = 50;
+    #[cfg(not(miri))]
+    const COUNT: usize = 1000;
+
     let (s, r) = unbounded();
-    for i in 0..1000 {
+    for i in 0..COUNT {
         assert_eq!(s.send(i), Ok(()));
     }
 
@@ -154,8 +164,13 @@ fn send() {
 
 #[test]
 fn send_timeout() {
+    #[cfg(miri)]
+    const COUNT: usize = 50;
+    #[cfg(not(miri))]
+    const COUNT: usize = 1000;
+
     let (s, r) = unbounded();
-    for i in 0..1000 {
+    for i in 0..COUNT {
         assert_eq!(s.send_timeout(i, ms(i as u64)), Ok(()));
     }
 
@@ -390,7 +405,7 @@ fn drops() {
     #[cfg(not(miri))]
     const RUNS: usize = 100;
     #[cfg(miri)]
-    const STEPS: usize = 500;
+    const STEPS: usize = 100;
     #[cfg(not(miri))]
     const STEPS: usize = 10_000;
 
@@ -409,7 +424,7 @@ fn drops() {
 
     for _ in 0..RUNS {
         let steps = rng.gen_range(0..STEPS);
-        let additional = rng.gen_range(0..1000);
+        let additional = rng.gen_range(0..STEPS / 10);
 
         DROPS.store(0, Ordering::SeqCst);
         let (s, r) = unbounded::<DropCounter>();

--- a/crossbeam-channel/tests/mpsc.rs
+++ b/crossbeam-channel/tests/mpsc.rs
@@ -321,7 +321,7 @@ mod channel_tests {
     #[test]
     fn stress() {
         #[cfg(miri)]
-        const COUNT: usize = 500;
+        const COUNT: usize = 100;
         #[cfg(not(miri))]
         const COUNT: usize = 10000;
 
@@ -340,7 +340,7 @@ mod channel_tests {
     #[test]
     fn stress_shared() {
         #[cfg(miri)]
-        const AMT: u32 = 500;
+        const AMT: u32 = 100;
         #[cfg(not(miri))]
         const AMT: u32 = 10000;
         const NTHREADS: u32 = 8;
@@ -747,7 +747,7 @@ mod channel_tests {
     #[test]
     fn recv_a_lot() {
         #[cfg(miri)]
-        const N: usize = 100;
+        const N: usize = 50;
         #[cfg(not(miri))]
         const N: usize = 10000;
 

--- a/crossbeam-channel/tests/select.rs
+++ b/crossbeam-channel/tests/select.rs
@@ -694,7 +694,7 @@ fn nesting() {
 #[test]
 fn stress_recv() {
     #[cfg(miri)]
-    const COUNT: usize = 100;
+    const COUNT: usize = 50;
     #[cfg(not(miri))]
     const COUNT: usize = 10_000;
 
@@ -735,7 +735,7 @@ fn stress_recv() {
 #[test]
 fn stress_send() {
     #[cfg(miri)]
-    const COUNT: usize = 100;
+    const COUNT: usize = 50;
     #[cfg(not(miri))]
     const COUNT: usize = 10_000;
 
@@ -953,7 +953,7 @@ fn matching_with_leftover() {
 #[test]
 fn channel_through_channel() {
     #[cfg(miri)]
-    const COUNT: usize = 100;
+    const COUNT: usize = 50;
     #[cfg(not(miri))]
     const COUNT: usize = 1000;
 
@@ -1014,7 +1014,7 @@ fn channel_through_channel() {
 #[test]
 fn linearizable_try() {
     #[cfg(miri)]
-    const COUNT: usize = 100;
+    const COUNT: usize = 50;
     #[cfg(not(miri))]
     const COUNT: usize = 100_000;
 
@@ -1069,7 +1069,7 @@ fn linearizable_try() {
 #[test]
 fn linearizable_timeout() {
     #[cfg(miri)]
-    const COUNT: usize = 100;
+    const COUNT: usize = 50;
     #[cfg(not(miri))]
     const COUNT: usize = 100_000;
 
@@ -1124,7 +1124,7 @@ fn linearizable_timeout() {
 #[test]
 fn fairness1() {
     #[cfg(miri)]
-    const COUNT: usize = 100;
+    const COUNT: usize = 50;
     #[cfg(not(miri))]
     const COUNT: usize = 10_000;
 
@@ -1173,7 +1173,7 @@ fn fairness1() {
 #[test]
 fn fairness2() {
     #[cfg(miri)]
-    const COUNT: usize = 100;
+    const COUNT: usize = 50;
     #[cfg(not(miri))]
     const COUNT: usize = 10_000;
 
@@ -1292,7 +1292,7 @@ fn send_and_clone() {
 #[test]
 fn reuse() {
     #[cfg(miri)]
-    const COUNT: usize = 100;
+    const COUNT: usize = 50;
     #[cfg(not(miri))]
     const COUNT: usize = 10_000;
 

--- a/crossbeam-channel/tests/select_macro.rs
+++ b/crossbeam-channel/tests/select_macro.rs
@@ -488,7 +488,7 @@ fn panic_receiver() {
 #[test]
 fn stress_recv() {
     #[cfg(miri)]
-    const COUNT: usize = 100;
+    const COUNT: usize = 50;
     #[cfg(not(miri))]
     const COUNT: usize = 10_000;
 

--- a/crossbeam-channel/tests/zero.rs
+++ b/crossbeam-channel/tests/zero.rs
@@ -188,7 +188,7 @@ fn send_timeout() {
 #[test]
 fn len() {
     #[cfg(miri)]
-    const COUNT: usize = 100;
+    const COUNT: usize = 50;
     #[cfg(not(miri))]
     const COUNT: usize = 25_000;
 
@@ -253,7 +253,7 @@ fn disconnect_wakes_receiver() {
 #[test]
 fn spsc() {
     #[cfg(miri)]
-    const COUNT: usize = 100;
+    const COUNT: usize = 50;
     #[cfg(not(miri))]
     const COUNT: usize = 100_000;
 
@@ -278,7 +278,7 @@ fn spsc() {
 #[test]
 fn mpmc() {
     #[cfg(miri)]
-    const COUNT: usize = 100;
+    const COUNT: usize = 50;
     #[cfg(not(miri))]
     const COUNT: usize = 25_000;
     const THREADS: usize = 4;
@@ -313,7 +313,7 @@ fn mpmc() {
 #[test]
 fn stress_oneshot() {
     #[cfg(miri)]
-    const COUNT: usize = 100;
+    const COUNT: usize = 50;
     #[cfg(not(miri))]
     const COUNT: usize = 10_000;
 
@@ -451,7 +451,7 @@ fn drops() {
 #[test]
 fn fairness() {
     #[cfg(miri)]
-    const COUNT: usize = 100;
+    const COUNT: usize = 50;
     #[cfg(not(miri))]
     const COUNT: usize = 10_000;
 
@@ -485,7 +485,7 @@ fn fairness() {
 #[test]
 fn fairness_duplicates() {
     #[cfg(miri)]
-    const COUNT: usize = 100;
+    const COUNT: usize = 50;
     #[cfg(not(miri))]
     const COUNT: usize = 10_000;
 
@@ -546,7 +546,7 @@ fn recv_in_send() {
 #[test]
 fn channel_through_channel() {
     #[cfg(miri)]
-    const COUNT: usize = 100;
+    const COUNT: usize = 50;
     #[cfg(not(miri))]
     const COUNT: usize = 1000;
 

--- a/crossbeam-queue/tests/array_queue.rs
+++ b/crossbeam-queue/tests/array_queue.rs
@@ -60,26 +60,27 @@ fn len_empty_full() {
 #[test]
 fn len() {
     #[cfg(miri)]
-    const COUNT: usize = 500;
+    const COUNT: usize = 30;
     #[cfg(not(miri))]
     const COUNT: usize = 25_000;
     #[cfg(miri)]
-    const CAP: usize = 100;
+    const CAP: usize = 40;
     #[cfg(not(miri))]
     const CAP: usize = 1000;
+    const ITERS: usize = CAP / 20;
 
     let q = ArrayQueue::new(CAP);
     assert_eq!(q.len(), 0);
 
     for _ in 0..CAP / 10 {
-        for i in 0..50 {
+        for i in 0..ITERS {
             q.push(i).unwrap();
             assert_eq!(q.len(), i + 1);
         }
 
-        for i in 0..50 {
+        for i in 0..ITERS {
             q.pop().unwrap();
-            assert_eq!(q.len(), 50 - i - 1);
+            assert_eq!(q.len(), ITERS - i - 1);
         }
     }
     assert_eq!(q.len(), 0);
@@ -128,7 +129,7 @@ fn len() {
 #[test]
 fn spsc() {
     #[cfg(miri)]
-    const COUNT: usize = 500;
+    const COUNT: usize = 100;
     #[cfg(not(miri))]
     const COUNT: usize = 100_000;
 
@@ -164,7 +165,7 @@ fn spsc() {
 #[test]
 fn spsc_ring_buffer() {
     #[cfg(miri)]
-    const COUNT: usize = 500;
+    const COUNT: usize = 50;
     #[cfg(not(miri))]
     const COUNT: usize = 100_000;
 
@@ -288,11 +289,11 @@ fn mpmc_ring_buffer() {
 #[test]
 fn drops() {
     #[cfg(miri)]
-    const RUNS: usize = 50;
+    const RUNS: usize = 5;
     #[cfg(not(miri))]
     const RUNS: usize = 100;
     #[cfg(miri)]
-    const STEPS: usize = 500;
+    const STEPS: usize = 50;
     #[cfg(not(miri))]
     const STEPS: usize = 10_000;
 
@@ -351,7 +352,7 @@ fn drops() {
 #[test]
 fn linearizable() {
     #[cfg(miri)]
-    const COUNT: usize = 500;
+    const COUNT: usize = 100;
     #[cfg(not(miri))]
     const COUNT: usize = 25_000;
     const THREADS: usize = 4;

--- a/crossbeam-queue/tests/seg_queue.rs
+++ b/crossbeam-queue/tests/seg_queue.rs
@@ -55,7 +55,7 @@ fn len() {
 #[test]
 fn spsc() {
     #[cfg(miri)]
-    const COUNT: usize = 500;
+    const COUNT: usize = 100;
     #[cfg(not(miri))]
     const COUNT: usize = 100_000;
 
@@ -124,11 +124,11 @@ fn mpmc() {
 #[test]
 fn drops() {
     #[cfg(miri)]
-    const RUNS: usize = 50;
+    const RUNS: usize = 5;
     #[cfg(not(miri))]
     const RUNS: usize = 100;
     #[cfg(miri)]
-    const STEPS: usize = 500;
+    const STEPS: usize = 50;
     #[cfg(not(miri))]
     const STEPS: usize = 10_000;
 

--- a/crossbeam-utils/tests/sharded_lock.rs
+++ b/crossbeam-utils/tests/sharded_lock.rs
@@ -22,7 +22,7 @@ fn smoke() {
 fn frob() {
     const N: u32 = 10;
     #[cfg(miri)]
-    const M: usize = 100;
+    const M: usize = 50;
     #[cfg(not(miri))]
     const M: usize = 1000;
 


### PR DESCRIPTION
There were several changes in Miri recently, including [breaking ones](https://github.com/rust-lang/miri/pull/2105) and affecting its speed. They caused CI builds failures.

This fix makes the most expensive Miri tests less intensive, so they have decent execution time again.
