### PR TITLE
Change panic handling in scoped thread

### DIFF
--- a/crossbeam-channel/benches/crossbeam.rs
+++ b/crossbeam-channel/benches/crossbeam.rs
@@ -64,8 +64,7 @@ mod unbounded {
                 }
             });
             drop(s1);
-        })
-        .unwrap();
+        });
     }
 
     #[bench]
@@ -93,8 +92,7 @@ mod unbounded {
                 r2.recv().unwrap();
             });
             drop(s1);
-        })
-        .unwrap();
+        });
     }
 
     #[bench]
@@ -129,8 +127,7 @@ mod unbounded {
                 }
             });
             drop(s1);
-        })
-        .unwrap();
+        });
     }
 
     #[bench]
@@ -165,8 +162,7 @@ mod unbounded {
                 }
             });
             drop(s1);
-        })
-        .unwrap();
+        });
     }
 
     #[bench]
@@ -208,8 +204,7 @@ mod unbounded {
                 }
             });
             drop(s1);
-        })
-        .unwrap();
+        });
     }
 }
 
@@ -241,8 +236,7 @@ mod bounded_n {
                 r2.recv().unwrap();
             });
             drop(s1);
-        })
-        .unwrap();
+        });
     }
 
     #[bench]
@@ -277,8 +271,7 @@ mod bounded_n {
                 }
             });
             drop(s1);
-        })
-        .unwrap();
+        });
     }
 
     #[bench]
@@ -313,8 +306,7 @@ mod bounded_n {
                 }
             });
             drop(s1);
-        })
-        .unwrap();
+        });
     }
 
     #[bench]
@@ -347,8 +339,7 @@ mod bounded_n {
                 }
             });
             drop(s1);
-        })
-        .unwrap();
+        });
     }
 
     #[bench]
@@ -391,8 +382,7 @@ mod bounded_n {
                 }
             });
             drop(s1);
-        })
-        .unwrap();
+        });
     }
 }
 
@@ -438,8 +428,7 @@ mod bounded_1 {
                 r2.recv().unwrap();
             });
             drop(s1);
-        })
-        .unwrap();
+        });
     }
 
     #[bench]
@@ -474,8 +463,7 @@ mod bounded_1 {
                 }
             });
             drop(s1);
-        })
-        .unwrap();
+        });
     }
 
     #[bench]
@@ -510,8 +498,7 @@ mod bounded_1 {
                 }
             });
             drop(s1);
-        })
-        .unwrap();
+        });
     }
 
     #[bench]
@@ -553,8 +540,7 @@ mod bounded_1 {
                 }
             });
             drop(s1);
-        })
-        .unwrap();
+        });
     }
 }
 
@@ -591,8 +577,7 @@ mod bounded_0 {
                 r2.recv().unwrap();
             });
             drop(s1);
-        })
-        .unwrap();
+        });
     }
 
     #[bench]
@@ -627,8 +612,7 @@ mod bounded_0 {
                 }
             });
             drop(s1);
-        })
-        .unwrap();
+        });
     }
 
     #[bench]
@@ -663,8 +647,7 @@ mod bounded_0 {
                 }
             });
             drop(s1);
-        })
-        .unwrap();
+        });
     }
 
     #[bench]
@@ -706,7 +689,6 @@ mod bounded_0 {
                 }
             });
             drop(s1);
-        })
-        .unwrap();
+        });
     }
 }

--- a/crossbeam-channel/benchmarks/atomicring.rs
+++ b/crossbeam-channel/benchmarks/atomicring.rs
@@ -49,8 +49,7 @@ fn spsc(cap: usize) {
                 }
             }
         }
-    })
-    .unwrap();
+    });
 }
 
 fn mpsc(cap: usize) {
@@ -80,8 +79,7 @@ fn mpsc(cap: usize) {
                 }
             }
         }
-    })
-    .unwrap();
+    });
 }
 
 fn mpmc(cap: usize) {
@@ -114,8 +112,7 @@ fn mpmc(cap: usize) {
                 }
             });
         }
-    })
-    .unwrap();
+    });
 }
 
 fn main() {

--- a/crossbeam-channel/benchmarks/atomicringqueue.rs
+++ b/crossbeam-channel/benchmarks/atomicringqueue.rs
@@ -43,8 +43,7 @@ fn spsc(cap: usize) {
         for _ in 0..MESSAGES {
             q.pop();
         }
-    })
-    .unwrap();
+    });
 }
 
 fn mpsc(cap: usize) {
@@ -68,8 +67,7 @@ fn mpsc(cap: usize) {
         for _ in 0..MESSAGES {
             q.pop();
         }
-    })
-    .unwrap();
+    });
 }
 
 fn mpmc(cap: usize) {
@@ -97,8 +95,7 @@ fn mpmc(cap: usize) {
                 }
             });
         }
-    })
-    .unwrap();
+    });
 }
 
 fn main() {

--- a/crossbeam-channel/benchmarks/bus.rs
+++ b/crossbeam-channel/benchmarks/bus.rs
@@ -31,8 +31,7 @@ fn spsc(cap: usize) {
         for _ in 0..MESSAGES {
             rx.recv().unwrap();
         }
-    })
-    .unwrap();
+    });
 }
 
 fn main() {

--- a/crossbeam-channel/benchmarks/crossbeam-channel.rs
+++ b/crossbeam-channel/benchmarks/crossbeam-channel.rs
@@ -37,8 +37,7 @@ fn spsc(cap: Option<usize>) {
         for _ in 0..MESSAGES {
             rx.recv().unwrap();
         }
-    })
-    .unwrap();
+    });
 }
 
 fn mpsc(cap: Option<usize>) {
@@ -56,8 +55,7 @@ fn mpsc(cap: Option<usize>) {
         for _ in 0..MESSAGES {
             rx.recv().unwrap();
         }
-    })
-    .unwrap();
+    });
 }
 
 fn mpmc(cap: Option<usize>) {
@@ -79,8 +77,7 @@ fn mpmc(cap: Option<usize>) {
                 }
             });
         }
-    })
-    .unwrap();
+    });
 }
 
 fn select_rx(cap: Option<usize>) {
@@ -105,8 +102,7 @@ fn select_rx(cap: Option<usize>) {
             let index = case.index();
             case.recv(&chans[index].1).unwrap();
         }
-    })
-    .unwrap();
+    });
 }
 
 fn select_both(cap: Option<usize>) {
@@ -140,8 +136,7 @@ fn select_both(cap: Option<usize>) {
                 }
             });
         }
-    })
-    .unwrap();
+    });
 }
 
 fn main() {

--- a/crossbeam-channel/benchmarks/crossbeam-deque.rs
+++ b/crossbeam-channel/benchmarks/crossbeam-deque.rs
@@ -43,8 +43,7 @@ fn spsc() {
                 }
             }
         });
-    })
-    .unwrap();
+    });
 }
 
 fn main() {

--- a/crossbeam-channel/benchmarks/flume.rs
+++ b/crossbeam-channel/benchmarks/flume.rs
@@ -75,8 +75,7 @@ fn spsc_unbounded() {
         for _ in 0..MESSAGES {
             rx.recv().unwrap();
         }
-    })
-    .unwrap();
+    });
 }
 
 fn spsc_bounded(cap: usize) {
@@ -92,8 +91,7 @@ fn spsc_bounded(cap: usize) {
         for _ in 0..MESSAGES {
             rx.recv().unwrap();
         }
-    })
-    .unwrap();
+    });
 }
 
 fn mpsc_unbounded() {
@@ -112,8 +110,7 @@ fn mpsc_unbounded() {
         for _ in 0..MESSAGES {
             rx.recv().unwrap();
         }
-    })
-    .unwrap();
+    });
 }
 
 fn mpsc_bounded(cap: usize) {
@@ -132,8 +129,7 @@ fn mpsc_bounded(cap: usize) {
         for _ in 0..MESSAGES {
             rx.recv().unwrap();
         }
-    })
-    .unwrap();
+    });
 }
 
 fn main() {

--- a/crossbeam-channel/benchmarks/lockfree.rs
+++ b/crossbeam-channel/benchmarks/lockfree.rs
@@ -36,8 +36,7 @@ fn spsc() {
                 thread::yield_now();
             }
         }
-    })
-    .unwrap();
+    });
 }
 
 fn mpsc() {
@@ -57,8 +56,7 @@ fn mpsc() {
                 thread::yield_now();
             }
         }
-    })
-    .unwrap();
+    });
 }
 
 fn mpmc() {
@@ -82,8 +80,7 @@ fn mpmc() {
                 }
             });
         }
-    })
-    .unwrap();
+    });
 }
 
 fn main() {

--- a/crossbeam-channel/benchmarks/mpmc.rs
+++ b/crossbeam-channel/benchmarks/mpmc.rs
@@ -48,8 +48,7 @@ fn spsc(cap: usize) {
                 }
             }
         }
-    })
-    .unwrap();
+    });
 }
 
 fn mpsc(cap: usize) {
@@ -79,8 +78,7 @@ fn mpsc(cap: usize) {
                 }
             }
         }
-    })
-    .unwrap();
+    });
 }
 
 fn mpmc(cap: usize) {
@@ -114,8 +112,7 @@ fn mpmc(cap: usize) {
                 }
             });
         }
-    })
-    .unwrap();
+    });
 }
 
 fn main() {

--- a/crossbeam-channel/benchmarks/mpsc.rs
+++ b/crossbeam-channel/benchmarks/mpsc.rs
@@ -77,8 +77,7 @@ fn spsc_async() {
         for _ in 0..MESSAGES {
             rx.recv().unwrap();
         }
-    })
-    .unwrap();
+    });
 }
 
 fn spsc_sync(cap: usize) {
@@ -94,8 +93,7 @@ fn spsc_sync(cap: usize) {
         for _ in 0..MESSAGES {
             rx.recv().unwrap();
         }
-    })
-    .unwrap();
+    });
 }
 
 fn mpsc_async() {
@@ -114,8 +112,7 @@ fn mpsc_async() {
         for _ in 0..MESSAGES {
             rx.recv().unwrap();
         }
-    })
-    .unwrap();
+    });
 }
 
 fn mpsc_sync(cap: usize) {
@@ -134,8 +131,7 @@ fn mpsc_sync(cap: usize) {
         for _ in 0..MESSAGES {
             rx.recv().unwrap();
         }
-    })
-    .unwrap();
+    });
 }
 
 fn main() {

--- a/crossbeam-channel/benchmarks/segqueue.rs
+++ b/crossbeam-channel/benchmarks/segqueue.rs
@@ -37,8 +37,7 @@ fn spsc() {
                 }
             }
         }
-    })
-    .unwrap();
+    });
 }
 
 fn mpsc() {
@@ -62,8 +61,7 @@ fn mpsc() {
                 }
             }
         }
-    })
-    .unwrap();
+    });
 }
 
 fn mpmc() {
@@ -91,8 +89,7 @@ fn mpmc() {
                 }
             });
         }
-    })
-    .unwrap();
+    });
 }
 
 fn main() {

--- a/crossbeam-channel/examples/matching.rs
+++ b/crossbeam-channel/examples/matching.rs
@@ -62,8 +62,7 @@ fn main() {
             let (s, r) = (s.clone(), r.clone());
             scope.spawn(move |_| seek(name, s, r));
         }
-    })
-    .unwrap();
+    });
 
     // Check if there is a pending send operation.
     if let Ok(name) = r.try_recv() {

--- a/crossbeam-channel/src/lib.rs
+++ b/crossbeam-channel/src/lib.rs
@@ -137,7 +137,7 @@
 //!     // Send a message and then receive one.
 //!     s.send(1).unwrap();
 //!     r.recv().unwrap();
-//! }).unwrap();
+//! });
 //! ```
 //!
 //! # Disconnection

--- a/crossbeam-channel/tests/after.rs
+++ b/crossbeam-channel/tests/after.rs
@@ -146,8 +146,7 @@ fn recv_two() {
                 recv(r2) -> _ => {}
             }
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -220,8 +219,7 @@ fn select() {
                 }
             });
         }
-    })
-    .unwrap();
+    });
 
     assert_eq!(hits.load(Ordering::SeqCst), COUNT);
 }
@@ -263,8 +261,7 @@ fn ready() {
                 }
             });
         }
-    })
-    .unwrap();
+    });
 
     assert_eq!(hits.load(Ordering::SeqCst), COUNT);
 }
@@ -290,8 +287,7 @@ fn stress_clone() {
                     }
                 });
             }
-        })
-        .unwrap();
+        });
     }
 }
 

--- a/crossbeam-channel/tests/array.rs
+++ b/crossbeam-channel/tests/array.rs
@@ -93,8 +93,7 @@ fn try_recv() {
             thread::sleep(ms(1000));
             s.send(7).unwrap();
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -116,8 +115,7 @@ fn recv() {
             s.send(8).unwrap();
             s.send(9).unwrap();
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -137,8 +135,7 @@ fn recv_timeout() {
             thread::sleep(ms(1500));
             s.send(7).unwrap();
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -160,8 +157,7 @@ fn try_send() {
             assert_eq!(r.try_recv(), Err(TryRecvError::Empty));
             assert_eq!(r.recv(), Ok(3));
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -184,8 +180,7 @@ fn send() {
             assert_eq!(r.recv(), Ok(8));
             assert_eq!(r.recv(), Ok(9));
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -212,8 +207,7 @@ fn send_timeout() {
             assert_eq!(r.recv(), Ok(2));
             assert_eq!(r.recv(), Ok(4));
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -309,8 +303,7 @@ fn len() {
                 assert!(len <= CAP);
             }
         });
-    })
-    .unwrap();
+    });
 
     assert_eq!(s.len(), 0);
     assert_eq!(r.len(), 0);
@@ -329,8 +322,7 @@ fn disconnect_wakes_sender() {
             thread::sleep(ms(1000));
             drop(r);
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -345,8 +337,7 @@ fn disconnect_wakes_receiver() {
             thread::sleep(ms(1000));
             drop(s);
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -370,8 +361,7 @@ fn spsc() {
                 s.send(i).unwrap();
             }
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -401,8 +391,7 @@ fn mpmc() {
                 }
             });
         }
-    })
-    .unwrap();
+    });
 
     for c in v {
         assert_eq!(c.load(Ordering::SeqCst), THREADS);
@@ -422,8 +411,7 @@ fn stress_oneshot() {
         scope(|scope| {
             scope.spawn(|_| r.recv().unwrap());
             scope.spawn(|_| s.send(0).unwrap());
-        })
-        .unwrap();
+        });
     }
 }
 
@@ -456,8 +444,7 @@ fn stress_iter() {
                 break;
             }
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -493,8 +480,7 @@ fn stress_timeout_two_threads() {
                 }
             }
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -540,8 +526,7 @@ fn drops() {
                     s.send(DropCounter).unwrap();
                 }
             });
-        })
-        .unwrap();
+        });
 
         for _ in 0..additional {
             s.send(DropCounter).unwrap();
@@ -573,8 +558,7 @@ fn linearizable() {
                 }
             });
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -686,8 +670,7 @@ fn channel_through_channel() {
                     .unwrap()
             }
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]

--- a/crossbeam-channel/tests/iter.rs
+++ b/crossbeam-channel/tests/iter.rs
@@ -22,8 +22,7 @@ fn nested_recv_iter() {
         s.send(2).unwrap();
         drop(s);
         assert_eq!(total_r.recv().unwrap(), 6);
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -50,8 +49,7 @@ fn recv_iter_break() {
         let _ = s.send(2);
         drop(s);
         assert_eq!(count_r.recv().unwrap(), 4);
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -78,8 +76,7 @@ fn recv_try_iter() {
                 break;
             }
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]

--- a/crossbeam-channel/tests/list.rs
+++ b/crossbeam-channel/tests/list.rs
@@ -83,8 +83,7 @@ fn try_recv() {
             thread::sleep(ms(1000));
             s.send(7).unwrap();
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -106,8 +105,7 @@ fn recv() {
             s.send(8).unwrap();
             s.send(9).unwrap();
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -127,8 +125,7 @@ fn recv_timeout() {
             thread::sleep(ms(1500));
             s.send(7).unwrap();
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -249,8 +246,7 @@ fn disconnect_wakes_receiver() {
             thread::sleep(ms(1000));
             drop(s);
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -274,8 +270,7 @@ fn spsc() {
                 s.send(i).unwrap();
             }
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -305,8 +300,7 @@ fn mpmc() {
                 }
             });
         }
-    })
-    .unwrap();
+    });
 
     assert_eq!(r.try_recv(), Err(TryRecvError::Empty));
 
@@ -328,8 +322,7 @@ fn stress_oneshot() {
         scope(|scope| {
             scope.spawn(|_| r.recv().unwrap());
             scope.spawn(|_| s.send(0).unwrap());
-        })
-        .unwrap();
+        });
     }
 }
 
@@ -362,8 +355,7 @@ fn stress_iter() {
                 break;
             }
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -395,8 +387,7 @@ fn stress_timeout_two_threads() {
                 }
             }
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -442,8 +433,7 @@ fn drops() {
                     s.send(DropCounter).unwrap();
                 }
             });
-        })
-        .unwrap();
+        });
 
         for _ in 0..additional {
             s.try_send(DropCounter).unwrap();
@@ -475,8 +465,7 @@ fn linearizable() {
                 }
             });
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -577,6 +566,5 @@ fn channel_through_channel() {
                     .unwrap()
             }
         });
-    })
-    .unwrap();
+    });
 }

--- a/crossbeam-channel/tests/ready.rs
+++ b/crossbeam-channel/tests/ready.rs
@@ -78,8 +78,7 @@ fn disconnected() {
         }
 
         r2.recv().unwrap();
-    })
-    .unwrap();
+    });
 
     let mut sel = Select::new();
     sel.recv(&r1);
@@ -101,8 +100,7 @@ fn disconnected() {
             Ok(0) => assert_eq!(r2.try_recv(), Err(TryRecvError::Disconnected)),
             _ => panic!(),
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -165,8 +163,7 @@ fn timeout() {
             Ok(1) => assert_eq!(r2.try_recv(), Ok(2)),
             _ => panic!(),
         }
-    })
-    .unwrap();
+    });
 
     scope(|scope| {
         let (s, r) = unbounded::<i32>();
@@ -185,8 +182,7 @@ fn timeout() {
             Ok(0) => assert_eq!(r.try_recv(), Err(TryRecvError::Disconnected)),
             _ => panic!(),
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -264,8 +260,7 @@ fn unblocks() {
             Ok(1) => assert_eq!(r2.try_recv(), Ok(2)),
             _ => panic!(),
         }
-    })
-    .unwrap();
+    });
 
     scope(|scope| {
         scope.spawn(|_| {
@@ -285,8 +280,7 @@ fn unblocks() {
                 _ => unreachable!(),
             },
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -311,8 +305,7 @@ fn both_ready() {
                 _ => panic!(),
             }
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -342,8 +335,7 @@ fn cloning1() {
         }
 
         s3.send(()).unwrap();
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -367,8 +359,7 @@ fn cloning2() {
         thread::sleep(ms(500));
         drop(s1.clone());
         s2.send(()).unwrap();
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -527,8 +518,7 @@ fn stress_recv() {
                 s3.send(()).unwrap();
             }
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -564,8 +554,7 @@ fn stress_send() {
             }
             s3.send(()).unwrap();
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -601,8 +590,7 @@ fn stress_mixed() {
             }
             s3.send(()).unwrap();
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -653,8 +641,7 @@ fn stress_timeout_two_threads() {
                 }
             }
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -730,8 +717,7 @@ fn channel_through_channel() {
                     r = new;
                 }
             });
-        })
-        .unwrap();
+        });
     }
 }
 
@@ -848,6 +834,5 @@ fn fairness2() {
             }
         }
         assert!(hits.iter().all(|x| x.get() > 0));
-    })
-    .unwrap();
+    });
 }

--- a/crossbeam-channel/tests/select.rs
+++ b/crossbeam-channel/tests/select.rs
@@ -97,8 +97,7 @@ fn disconnected() {
         }
 
         r2.recv().unwrap();
-    })
-    .unwrap();
+    });
 
     let mut sel = Select::new();
     let oper1 = sel.recv(&r1);
@@ -129,8 +128,7 @@ fn disconnected() {
                 _ => unreachable!(),
             },
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -227,8 +225,7 @@ fn timeout() {
                 _ => unreachable!(),
             },
         }
-    })
-    .unwrap();
+    });
 
     scope(|scope| {
         let (s, r) = unbounded::<i32>();
@@ -255,8 +252,7 @@ fn timeout() {
             }
             Ok(_) => unreachable!(),
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -356,8 +352,7 @@ fn unblocks() {
                 _ => unreachable!(),
             },
         }
-    })
-    .unwrap();
+    });
 
     scope(|scope| {
         scope.spawn(|_| {
@@ -377,8 +372,7 @@ fn unblocks() {
                 _ => unreachable!(),
             },
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -404,8 +398,7 @@ fn both_ready() {
                 _ => unreachable!(),
             }
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -499,8 +492,7 @@ fn loop_try() {
 
                 drop(s_end);
             });
-        })
-        .unwrap();
+        });
     }
 }
 
@@ -532,8 +524,7 @@ fn cloning1() {
         }
 
         s3.send(()).unwrap();
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -558,8 +549,7 @@ fn cloning2() {
         thread::sleep(ms(500));
         drop(s1.clone());
         s2.send(()).unwrap();
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -727,8 +717,7 @@ fn stress_recv() {
                 s3.send(()).unwrap();
             }
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -765,8 +754,7 @@ fn stress_send() {
             }
             s3.send(()).unwrap();
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -803,8 +791,7 @@ fn stress_mixed() {
             }
             s3.send(()).unwrap();
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -861,8 +848,7 @@ fn stress_timeout_two_threads() {
                 }
             }
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -916,8 +902,7 @@ fn matching() {
                 }
             });
         }
-    })
-    .unwrap();
+    });
 
     assert_eq!(r.try_recv(), Err(TryRecvError::Empty));
 }
@@ -943,8 +928,7 @@ fn matching_with_leftover() {
             });
         }
         s.send(!0).unwrap();
-    })
-    .unwrap();
+    });
 
     assert_eq!(r.try_recv(), Err(TryRecvError::Empty));
 }
@@ -1005,8 +989,7 @@ fn channel_through_channel() {
                     r = new;
                 }
             });
-        })
-        .unwrap();
+        });
     }
 }
 
@@ -1060,8 +1043,7 @@ fn linearizable_try() {
 
                 end_r.recv().unwrap();
             }
-        })
-        .unwrap();
+        });
     }
 }
 
@@ -1115,8 +1097,7 @@ fn linearizable_timeout() {
 
                 end_r.recv().unwrap();
             }
-        })
-        .unwrap();
+        });
     }
 }
 
@@ -1227,8 +1208,7 @@ fn fairness2() {
             }
         }
         assert!(hits.iter().all(|x| x.get() >= COUNT / hits.len() / 50));
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -1254,8 +1234,7 @@ fn sync_and_clone() {
                 }
             });
         }
-    })
-    .unwrap();
+    });
 
     assert_eq!(r.try_recv(), Err(TryRecvError::Empty));
 }
@@ -1282,8 +1261,7 @@ fn send_and_clone() {
                 }
             });
         }
-    })
-    .unwrap();
+    });
 
     assert_eq!(r.try_recv(), Err(TryRecvError::Empty));
 }
@@ -1323,6 +1301,5 @@ fn reuse() {
             }
             s3.send(()).unwrap();
         }
-    })
-    .unwrap();
+    });
 }

--- a/crossbeam-channel/tests/select_macro.rs
+++ b/crossbeam-channel/tests/select_macro.rs
@@ -75,8 +75,7 @@ fn disconnected() {
         }
 
         r2.recv().unwrap();
-    })
-    .unwrap();
+    });
 
     select! {
         recv(r1) -> v => assert!(v.is_err()),
@@ -94,8 +93,7 @@ fn disconnected() {
             recv(r2) -> v => assert!(v.is_err()),
             default(ms(1000)) => panic!(),
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -156,8 +154,7 @@ fn timeout() {
             recv(r2) -> v => assert_eq!(v, Ok(2)),
             default(ms(1000)) => panic!(),
         }
-    })
-    .unwrap();
+    });
 
     scope(|scope| {
         let (s, r) = unbounded::<i32>();
@@ -175,8 +172,7 @@ fn timeout() {
                 }
             }
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -244,8 +240,7 @@ fn unblocks() {
             recv(r2) -> v => assert_eq!(v, Ok(2)),
             default(ms(1000)) => panic!(),
         }
-    })
-    .unwrap();
+    });
 
     scope(|scope| {
         scope.spawn(|_| {
@@ -258,8 +253,7 @@ fn unblocks() {
             send(s2, 2) -> _ => panic!(),
             default(ms(1000)) => panic!(),
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -280,8 +274,7 @@ fn both_ready() {
                 send(s2, 2) -> _ => {},
             }
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -329,8 +322,7 @@ fn loop_try() {
 
                 drop(s_end);
             });
-        })
-        .unwrap();
+        });
     }
 }
 
@@ -357,8 +349,7 @@ fn cloning1() {
         }
 
         s3.send(()).unwrap();
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -378,8 +369,7 @@ fn cloning2() {
         thread::sleep(ms(500));
         drop(s1.clone());
         s2.send(()).unwrap();
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -516,8 +506,7 @@ fn stress_recv() {
                 s3.send(()).unwrap();
             }
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -549,8 +538,7 @@ fn stress_send() {
             }
             s3.send(()).unwrap();
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -582,8 +570,7 @@ fn stress_mixed() {
             }
             s3.send(()).unwrap();
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -625,8 +612,7 @@ fn stress_timeout_two_threads() {
                 }
             }
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -661,8 +647,7 @@ fn matching() {
                 }
             });
         }
-    })
-    .unwrap();
+    });
 
     assert_eq!(r.try_recv(), Err(TryRecvError::Empty));
 }
@@ -683,8 +668,7 @@ fn matching_with_leftover() {
             });
         }
         s.send(!0).unwrap();
-    })
-    .unwrap();
+    });
 
     assert_eq!(r.try_recv(), Err(TryRecvError::Empty));
 }
@@ -732,8 +716,7 @@ fn channel_through_channel() {
                     }
                 }
             });
-        })
-        .unwrap();
+        });
     }
 }
 
@@ -779,8 +762,7 @@ fn linearizable_default() {
 
                 end_r.recv().unwrap();
             }
-        })
-        .unwrap();
+        });
     }
 }
 
@@ -826,8 +808,7 @@ fn linearizable_timeout() {
 
                 end_r.recv().unwrap();
             }
-        })
-        .unwrap();
+        });
     }
 }
 
@@ -894,8 +875,7 @@ fn fairness2() {
             }
         }
         assert!(hits.iter().all(|x| x.get() >= COUNT / hits.len() / 50));
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -1268,8 +1248,7 @@ fn try_recv() {
                 send(s, 7) -> res => res.unwrap(),
             }
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -1305,8 +1284,7 @@ fn recv() {
                 send(s, 9) -> res => res.unwrap(),
             }
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -1334,8 +1312,7 @@ fn recv_timeout() {
                 send(s, 7) -> res => res.unwrap(),
             }
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -1365,8 +1342,7 @@ fn try_send() {
                 recv(r) -> v => assert_eq!(v, Ok(8)),
             }
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -1399,8 +1375,7 @@ fn send() {
                 recv(r) -> v => assert_eq!(v, Ok(9)),
             }
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -1428,8 +1403,7 @@ fn send_timeout() {
                 recv(r) -> v => assert_eq!(v, Ok(8)),
             }
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -1446,8 +1420,7 @@ fn disconnect_wakes_sender() {
             thread::sleep(ms(1000));
             drop(r);
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -1464,8 +1437,7 @@ fn disconnect_wakes_receiver() {
             thread::sleep(ms(1000));
             drop(s);
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]

--- a/crossbeam-channel/tests/thread_locals.rs
+++ b/crossbeam-channel/tests/thread_locals.rs
@@ -48,6 +48,5 @@ fn use_while_exiting() {
             thread::sleep(ms(100));
             s.send(()).unwrap();
         });
-    })
-    .unwrap();
+    });
 }

--- a/crossbeam-channel/tests/tick.rs
+++ b/crossbeam-channel/tests/tick.rs
@@ -176,8 +176,7 @@ fn recv_two() {
                 }
             }
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -248,8 +247,7 @@ fn select() {
                 }
             });
         }
-    })
-    .unwrap();
+    });
 
     assert_eq!(hits.load(Ordering::SeqCst), 8);
 }
@@ -297,8 +295,7 @@ fn ready() {
                 }
             });
         }
-    })
-    .unwrap();
+    });
 
     assert_eq!(hits.load(Ordering::SeqCst), 8);
 }

--- a/crossbeam-channel/tests/zero.rs
+++ b/crossbeam-channel/tests/zero.rs
@@ -44,8 +44,7 @@ fn len_empty_full() {
     scope(|scope| {
         scope.spawn(|_| s.send(0).unwrap());
         scope.spawn(|_| r.recv().unwrap());
-    })
-    .unwrap();
+    });
 
     assert_eq!(s.len(), 0);
     assert!(s.is_empty());
@@ -71,8 +70,7 @@ fn try_recv() {
             thread::sleep(ms(1000));
             s.send(7).unwrap();
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -94,8 +92,7 @@ fn recv() {
             s.send(8).unwrap();
             s.send(9).unwrap();
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -115,8 +112,7 @@ fn recv_timeout() {
             thread::sleep(ms(1500));
             s.send(7).unwrap();
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -135,8 +131,7 @@ fn try_send() {
             thread::sleep(ms(1000));
             assert_eq!(r.recv(), Ok(8));
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -157,8 +152,7 @@ fn send() {
             assert_eq!(r.recv(), Ok(8));
             assert_eq!(r.recv(), Ok(9));
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -181,8 +175,7 @@ fn send_timeout() {
             thread::sleep(ms(1500));
             assert_eq!(r.recv(), Ok(8));
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -211,8 +204,7 @@ fn len() {
                 assert_eq!(s.len(), 0);
             }
         });
-    })
-    .unwrap();
+    });
 
     assert_eq!(s.len(), 0);
     assert_eq!(r.len(), 0);
@@ -230,8 +222,7 @@ fn disconnect_wakes_sender() {
             thread::sleep(ms(1000));
             drop(r);
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -246,8 +237,7 @@ fn disconnect_wakes_receiver() {
             thread::sleep(ms(1000));
             drop(s);
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -271,8 +261,7 @@ fn spsc() {
                 s.send(i).unwrap();
             }
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -302,8 +291,7 @@ fn mpmc() {
                 }
             });
         }
-    })
-    .unwrap();
+    });
 
     for c in v {
         assert_eq!(c.load(Ordering::SeqCst), THREADS);
@@ -323,8 +311,7 @@ fn stress_oneshot() {
         scope(|scope| {
             scope.spawn(|_| r.recv().unwrap());
             scope.spawn(|_| s.send(0).unwrap());
-        })
-        .unwrap();
+        });
     }
 }
 
@@ -357,8 +344,7 @@ fn stress_iter() {
                 break;
             }
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -394,8 +380,7 @@ fn stress_timeout_two_threads() {
                 }
             }
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -440,8 +425,7 @@ fn drops() {
                     s.send(DropCounter).unwrap();
                 }
             });
-        })
-        .unwrap();
+        });
 
         assert_eq!(DROPS.load(Ordering::SeqCst), steps);
         drop(s);
@@ -480,8 +464,7 @@ fn fairness() {
             }
         }
         assert!(hits.iter().all(|x| *x >= COUNT / hits.len() / 2));
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -519,8 +502,7 @@ fn fairness_duplicates() {
             }
         }
         assert!(hits.iter().all(|x| *x >= COUNT / hits.len() / 2));
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -541,8 +523,7 @@ fn recv_in_send() {
         select! {
             send(s, r.recv().unwrap()) -> _ => {}
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -582,6 +563,5 @@ fn channel_through_channel() {
                     .unwrap()
             }
         });
-    })
-    .unwrap();
+    });
 }

--- a/crossbeam-deque/tests/fifo.rs
+++ b/crossbeam-deque/tests/fifo.rs
@@ -96,8 +96,7 @@ fn spsc() {
         for i in 0..STEPS {
             w.push(i);
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -140,8 +139,7 @@ fn stampede() {
                 remaining.fetch_sub(1, SeqCst);
             }
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -202,8 +200,7 @@ fn stress() {
             }
         }
         done.store(true, SeqCst);
-    })
-    .unwrap();
+    });
 }
 
 #[cfg_attr(miri, ignore)] // Miri is too slow
@@ -262,8 +259,7 @@ fn no_starvation() {
             }
         }
         done.store(true, SeqCst);
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -332,8 +328,7 @@ fn destructors() {
                 remaining.fetch_sub(1, SeqCst);
             }
         }
-    })
-    .unwrap();
+    });
 
     let rem = remaining.load(SeqCst);
     assert!(rem > 0);

--- a/crossbeam-deque/tests/injector.rs
+++ b/crossbeam-deque/tests/injector.rs
@@ -72,8 +72,7 @@ fn spsc() {
         for i in 0..COUNT {
             q.push(i);
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -110,8 +109,7 @@ fn mpmc() {
                 }
             });
         }
-    })
-    .unwrap();
+    });
 
     for c in v {
         assert_eq!(c.load(SeqCst), THREADS);
@@ -158,8 +156,7 @@ fn stampede() {
                 remaining.fetch_sub(1, SeqCst);
             }
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -220,8 +217,7 @@ fn stress() {
             }
         }
         done.store(true, SeqCst);
-    })
-    .unwrap();
+    });
 }
 
 #[cfg_attr(miri, ignore)] // Miri is too slow
@@ -280,8 +276,7 @@ fn no_starvation() {
             }
         }
         done.store(true, SeqCst);
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -350,8 +345,7 @@ fn destructors() {
                 remaining.fetch_sub(1, SeqCst);
             }
         }
-    })
-    .unwrap();
+    });
 
     let rem = remaining.load(SeqCst);
     assert!(rem > 0);

--- a/crossbeam-deque/tests/lifo.rs
+++ b/crossbeam-deque/tests/lifo.rs
@@ -98,8 +98,7 @@ fn spsc() {
         for i in 0..STEPS {
             w.push(i);
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -142,8 +141,7 @@ fn stampede() {
                 remaining.fetch_sub(1, SeqCst);
             }
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -204,8 +202,7 @@ fn stress() {
             }
         }
         done.store(true, SeqCst);
-    })
-    .unwrap();
+    });
 }
 
 #[cfg_attr(miri, ignore)] // Miri is too slow
@@ -264,8 +261,7 @@ fn no_starvation() {
             }
         }
         done.store(true, SeqCst);
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -334,8 +330,7 @@ fn destructors() {
                 remaining.fetch_sub(1, SeqCst);
             }
         }
-    })
-    .unwrap();
+    });
 
     let rem = remaining.load(SeqCst);
     assert!(rem > 0);

--- a/crossbeam-epoch/benches/defer.rs
+++ b/crossbeam-epoch/benches/defer.rs
@@ -43,8 +43,7 @@ fn multi_alloc_defer_free(b: &mut Bencher) {
                     }
                 });
             }
-        })
-        .unwrap();
+        });
     });
 }
 
@@ -63,7 +62,6 @@ fn multi_defer(b: &mut Bencher) {
                     }
                 });
             }
-        })
-        .unwrap();
+        });
     });
 }

--- a/crossbeam-epoch/benches/flush.rs
+++ b/crossbeam-epoch/benches/flush.rs
@@ -27,8 +27,7 @@ fn single_flush(b: &mut Bencher) {
         start.wait();
         b.iter(|| epoch::pin().flush());
         end.wait();
-    })
-    .unwrap();
+    });
 }
 
 #[bench]
@@ -46,7 +45,6 @@ fn multi_flush(b: &mut Bencher) {
                     }
                 });
             }
-        })
-        .unwrap();
+        });
     });
 }

--- a/crossbeam-epoch/benches/pin.rs
+++ b/crossbeam-epoch/benches/pin.rs
@@ -25,7 +25,6 @@ fn multi_pin(b: &mut Bencher) {
                     }
                 });
             }
-        })
-        .unwrap();
+        });
     });
 }

--- a/crossbeam-epoch/src/collector.rs
+++ b/crossbeam-epoch/src/collector.rs
@@ -200,8 +200,7 @@ mod tests {
                     }
                 });
             }
-        })
-        .unwrap();
+        });
     }
 
     #[cfg(not(crossbeam_sanitize))] // TODO: assertions failed due to `cfg(crossbeam_sanitize)` reduce `internal::MAX_OBJECTS`
@@ -450,8 +449,7 @@ mod tests {
                     }
                 });
             }
-        })
-        .unwrap();
+        });
 
         let handle = collector.register();
         while DROPS.load(Ordering::Relaxed) < COUNT * THREADS {

--- a/crossbeam-epoch/src/default.rs
+++ b/crossbeam-epoch/src/default.rs
@@ -87,7 +87,6 @@ mod tests {
                 super::pin();
                 // At thread exit, `HANDLE` gets dropped first and `FOO` second.
             });
-        })
-        .unwrap();
+        });
     }
 }

--- a/crossbeam-epoch/src/sync/list.rs
+++ b/crossbeam-epoch/src/sync/list.rs
@@ -428,8 +428,7 @@ mod tests {
                     }
                 });
             }
-        })
-        .unwrap();
+        });
 
         let handle = collector.register();
         let guard = handle.pin();
@@ -475,8 +474,7 @@ mod tests {
                     }
                 });
             }
-        })
-        .unwrap();
+        });
 
         let handle = collector.register();
         let guard = handle.pin();

--- a/crossbeam-epoch/src/sync/queue.rs
+++ b/crossbeam-epoch/src/sync/queue.rs
@@ -353,8 +353,7 @@ mod test {
             for i in 0..CONC_COUNT {
                 q.push(i)
             }
-        })
-        .unwrap();
+        });
     }
 
     #[test]
@@ -386,8 +385,7 @@ mod test {
                     q.push(i);
                 }
             });
-        })
-        .unwrap();
+        });
     }
 
     #[test]
@@ -432,8 +430,7 @@ mod test {
                     assert_eq!(vr, vr2);
                 });
             }
-        })
-        .unwrap();
+        });
     }
 
     #[test]
@@ -452,8 +449,7 @@ mod test {
             for i in 0..CONC_COUNT {
                 q.push(i)
             }
-        })
-        .unwrap();
+        });
         assert!(q.is_empty());
     }
 

--- a/crossbeam-queue/tests/array_queue.rs
+++ b/crossbeam-queue/tests/array_queue.rs
@@ -116,8 +116,7 @@ fn len() {
                 assert!(len <= CAP);
             }
         });
-    })
-    .unwrap();
+    });
     assert_eq!(q.len(), 0);
 }
 
@@ -148,8 +147,7 @@ fn spsc() {
                 while q.push(i).is_err() {}
             }
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -185,8 +183,7 @@ fn spsc_ring_buffer() {
 
             t.fetch_sub(1, Ordering::SeqCst);
         });
-    })
-    .unwrap();
+    });
 
     for c in v {
         assert_eq!(c.load(Ordering::SeqCst), 1);
@@ -224,8 +221,7 @@ fn mpmc() {
                 }
             });
         }
-    })
-    .unwrap();
+    });
 
     for c in v {
         assert_eq!(c.load(Ordering::SeqCst), THREADS);
@@ -270,8 +266,7 @@ fn mpmc_ring_buffer() {
                 t.fetch_sub(1, Ordering::SeqCst);
             });
         }
-    })
-    .unwrap();
+    });
 
     for c in v {
         assert_eq!(c.load(Ordering::SeqCst), THREADS);
@@ -318,8 +313,7 @@ fn drops() {
                     }
                 }
             });
-        })
-        .unwrap();
+        });
 
         for _ in 0..additional {
             q.push(DropCounter).unwrap();
@@ -358,8 +352,7 @@ fn linearizable() {
                 }
             });
         }
-    })
-    .unwrap();
+    });
 }
 
 #[test]

--- a/crossbeam-queue/tests/seg_queue.rs
+++ b/crossbeam-queue/tests/seg_queue.rs
@@ -78,8 +78,7 @@ fn spsc() {
                 q.push(i);
             }
         });
-    })
-    .unwrap();
+    });
 }
 
 #[test]
@@ -113,8 +112,7 @@ fn mpmc() {
                 }
             });
         }
-    })
-    .unwrap();
+    });
 
     for c in v {
         assert_eq!(c.load(Ordering::SeqCst), THREADS);
@@ -159,8 +157,7 @@ fn drops() {
                     q.push(DropCounter);
                 }
             });
-        })
-        .unwrap();
+        });
 
         for _ in 0..additional {
             q.push(DropCounter);

--- a/crossbeam-skiplist/src/lib.rs
+++ b/crossbeam-skiplist/src/lib.rs
@@ -32,7 +32,7 @@
 //!         person_ages.insert("Bryon Conroy", 65);
 //!         person_ages.insert("Lauren Reilly", 2);
 //!     });
-//! }).unwrap();
+//! });
 //!
 //! assert!(person_ages.contains_key("Spike Garrett"));
 //! person_ages.remove("Rea Bryan");
@@ -64,7 +64,7 @@
 //!     // The other thread may remove the value
 //!     // before we perform this check.
 //!     assert!(numbers.contains(&5));
-//! }).unwrap();
+//! });
 //! ```
 //!
 //! In effect, a _single_ operation on the map, such as [`insert`],

--- a/crossbeam-skiplist/tests/map.rs
+++ b/crossbeam-skiplist/tests/map.rs
@@ -98,8 +98,7 @@ fn concurrent_insert() {
                 barrier.wait();
                 set.insert(1, 1);
             });
-        })
-        .unwrap();
+        });
     }
 }
 
@@ -118,8 +117,7 @@ fn concurrent_remove() {
                 barrier.wait();
                 set.remove(&1);
             });
-        })
-        .unwrap();
+        });
     }
 }
 

--- a/crossbeam-skiplist/tests/set.rs
+++ b/crossbeam-skiplist/tests/set.rs
@@ -97,8 +97,7 @@ fn concurrent_insert() {
                 barrier.wait();
                 set.insert(1);
             });
-        })
-        .unwrap();
+        });
     }
 }
 
@@ -117,8 +116,7 @@ fn concurrent_remove() {
                 barrier.wait();
                 set.remove(&1);
             });
-        })
-        .unwrap();
+        });
     }
 }
 

--- a/crossbeam-utils/benches/atomic_cell.rs
+++ b/crossbeam-utils/benches/atomic_cell.rs
@@ -77,8 +77,7 @@ fn concurrent_load_u8(b: &mut test::Bencher) {
         start.wait();
         exit.store(true);
         end.wait();
-    })
-    .unwrap();
+    });
 }
 
 #[bench]
@@ -151,6 +150,5 @@ fn concurrent_load_usize(b: &mut test::Bencher) {
         start.wait();
         exit.store(true);
         end.wait();
-    })
-    .unwrap();
+    });
 }

--- a/crossbeam-utils/tests/parker.rs
+++ b/crossbeam-utils/tests/parker.rs
@@ -35,7 +35,6 @@ fn park_timeout_unpark_called_other_thread() {
             });
 
             p.park_timeout(Duration::from_millis(u32::MAX as u64))
-        })
-        .unwrap();
+        });
     }
 }

--- a/tests/subcrates.rs
+++ b/tests/subcrates.rs
@@ -37,11 +37,9 @@ fn utils() {
 
     crossbeam::scope(|scope| {
         scope.spawn(|_| ());
-    })
-    .unwrap();
+    });
 
     crossbeam::thread::scope(|scope| {
         scope.spawn(|_| ());
-    })
-    .unwrap();
+    });
 }


### PR DESCRIPTION
- Panic instead of returning result
- Do not own join handles in main thread

TODO: if we don't do https://github.com/crossbeam-rs/crossbeam/pull/844#issuecomment-1142382387, we probably shouldn't change the signature of scope function.

Fixes #816
Closes #724