### PR TITLE
Prepare for the next release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,8 +160,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      # TODO: unpin nightly toolchain once https://github.com/rust-lang/miri/issues/2223 fixed.
       - name: Install Rust
-        run: rustup toolchain install nightly --component miri && rustup default nightly
+        run: rustup toolchain install nightly-2022-06-08 --component miri && rustup default nightly-2022-06-08
       - name: miri
         run: ./ci/miri.sh
 

--- a/crossbeam-channel/CHANGELOG.md
+++ b/crossbeam-channel/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.5.5
+
+- Replace Spinlock with Mutex. (#835)
+
 # Version 0.5.4
 
 - Workaround a bug in upstream related to TLS access on AArch64 Linux. (#802)

--- a/crossbeam-channel/Cargo.toml
+++ b/crossbeam-channel/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-channel"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-channel-X.Y.Z" git tag
-version = "0.5.4"
+version = "0.5.5"
 edition = "2018"
 rust-version = "1.36"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-epoch/CHANGELOG.md
+++ b/crossbeam-epoch/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.9.9
+
+- Replace lazy_static with once_cell. (#817)
+
 # Version 0.9.8
 
 - Make `Atomic::null()` const function at 1.61+. (#797)

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-epoch"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-epoch-X.Y.Z" git tag
-version = "0.9.8"
+version = "0.9.9"
 edition = "2018"
 rust-version = "1.36"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-utils/CHANGELOG.md
+++ b/crossbeam-utils/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.8.9
+
+- Replace lazy_static with once_cell. (#817)
+
 # Version 0.8.8
 
 - Fix a bug when unstable `loom` support is enabled. (#787)

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-utils"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-utils-X.Y.Z" git tag
-version = "0.8.8"
+version = "0.8.9"
 edition = "2018"
 rust-version = "1.36"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
- crossbeam-channel 0.5.4 -> 0.5.5
  - Replace Spinlock with Mutex. (#835)
- crossbeam-epoch 0.9.8 -> 0.9.9
  - Replace lazy_static with once_cell. (#817)
- crossbeam-utils 0.8.8 -> 0.8.9
  - Replace lazy_static with once_cell. (#817)