### PR TITLE
readme: fix Code of Conduct link

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Crossbeam, but keep in mind that some of the written information is now out of d
 #### Conduct
 
 The Crossbeam project adheres to the
-[Rust Code of Conduct](https://github.com/rust-lang/rust/blob/master/CODE_OF_CONDUCT.md).
+[Rust Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct).
 This describes the minimum behavior expected from all contributors.
 
 ## License


### PR DESCRIPTION
This is _extremely_ minor, but I was clicking through the links in the README and noticed that the link to the CoC is out of date (it was moved to the website, and the GitHub document points to the website). Figured I'd remove that one step of indirection ✌️ 