### PR TITLE
Miri: enable preemption again

### DIFF
--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -5,35 +5,30 @@ cd "$(dirname "$0")"/..
 
 export RUSTFLAGS="${RUSTFLAGS:-} -Z randomize-layout"
 
-# disable preemption due to https://github.com/rust-lang/rust/issues/55005
-MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-disable-isolation -Zmiri-preemption-rate=0" \
+MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-disable-isolation" \
     cargo miri test \
     -p crossbeam-queue \
     -p crossbeam-utils
 
 # -Zmiri-ignore-leaks is needed because we use detached threads in tests/docs: https://github.com/rust-lang/miri/issues/1371
-# disable preemption due to https://github.com/rust-lang/rust/issues/55005
-MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-disable-isolation -Zmiri-ignore-leaks -Zmiri-preemption-rate=0" \
+MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-disable-isolation -Zmiri-ignore-leaks" \
     cargo miri test \
     -p crossbeam-channel
 
 # -Zmiri-ignore-leaks is needed for https://github.com/crossbeam-rs/crossbeam/issues/579
 # -Zmiri-disable-stacked-borrows is needed for https://github.com/crossbeam-rs/crossbeam/issues/545
-# disable preemption due to https://github.com/rust-lang/rust/issues/55005
-MIRIFLAGS="-Zmiri-check-number-validity -Zmiri-symbolic-alignment-check -Zmiri-disable-isolation -Zmiri-disable-stacked-borrows -Zmiri-ignore-leaks -Zmiri-preemption-rate=0" \
+MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-disable-isolation -Zmiri-disable-stacked-borrows -Zmiri-ignore-leaks" \
     cargo miri test \
     -p crossbeam-epoch \
     -p crossbeam-skiplist
 
 # -Zmiri-ignore-leaks is needed for https://github.com/crossbeam-rs/crossbeam/issues/579
 # -Zmiri-disable-stacked-borrows is needed for https://github.com/crossbeam-rs/crossbeam/issues/545
-# disable preemption due to https://github.com/rust-lang/rust/issues/55005
-MIRIFLAGS="-Zmiri-check-number-validity -Zmiri-symbolic-alignment-check -Zmiri-disable-stacked-borrows -Zmiri-ignore-leaks -Zmiri-compare-exchange-weak-failure-rate=0.0 -Zmiri-preemption-rate=0" \
+MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-disable-stacked-borrows -Zmiri-ignore-leaks -Zmiri-compare-exchange-weak-failure-rate=0.0" \
     cargo miri test \
     -p crossbeam-deque
 
 # -Zmiri-ignore-leaks is needed for https://github.com/crossbeam-rs/crossbeam/issues/579
-# disable preemption due to https://github.com/rust-lang/rust/issues/55005
-MIRIFLAGS="-Zmiri-check-number-validity -Zmiri-symbolic-alignment-check -Zmiri-ignore-leaks -Zmiri-preemption-rate=0" \
+MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-ignore-leaks" \
     cargo miri test \
     -p crossbeam

--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -5,7 +5,8 @@ cd "$(dirname "$0")"/..
 
 export RUSTFLAGS="${RUSTFLAGS:-} -Z randomize-layout"
 
-MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-disable-isolation" \
+# -Zmiri-ignore-leaks is needed because we use detached threads in tests/docs: https://github.com/rust-lang/miri/issues/1371
+MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-disable-isolation -Zmiri-ignore-leaks" \
     cargo miri test \
     -p crossbeam-queue \
     -p crossbeam-utils

--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -27,7 +27,8 @@ MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-disable-isolation -Zmiri-disab
 # -Zmiri-disable-stacked-borrows is needed for https://github.com/crossbeam-rs/crossbeam/issues/545
 # -Zmiri-compare-exchange-weak-failure-rate=0.0 is needed because some sequential tests (e.g.,
 # doctest of Stealer::steal) incorrectly assume that sequential weak CAS will never fail.
-MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-disable-stacked-borrows -Zmiri-ignore-leaks -Zmiri-compare-exchange-weak-failure-rate=0.0" \
+# -Zmiri-preemption-rate=0 is needed because this code technically has UB and Miri catches that.
+MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-disable-stacked-borrows -Zmiri-ignore-leaks -Zmiri-compare-exchange-weak-failure-rate=0.0 -Zmiri-preemption-rate=0" \
     cargo miri test \
     -p crossbeam-deque
 

--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -10,13 +10,13 @@ echo
 export RUSTFLAGS="${RUSTFLAGS:-} -Z randomize-layout"
 
 # -Zmiri-ignore-leaks is needed because we use detached threads in tests/docs: https://github.com/rust-lang/miri/issues/1371
-MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-disable-isolation -Zmiri-ignore-leaks" \
+MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-disable-isolation -Zmiri-ignore-leaks" \
     cargo miri test \
     -p crossbeam-queue \
     -p crossbeam-utils 2>&1 | ts -i '%.s  '
 
 # -Zmiri-ignore-leaks is needed because we use detached threads in tests/docs: https://github.com/rust-lang/miri/issues/1371
-MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-disable-isolation -Zmiri-ignore-leaks" \
+MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-disable-isolation -Zmiri-ignore-leaks" \
     cargo miri test \
     -p crossbeam-channel 2>&1 | ts -i '%.s  '
 

--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -25,6 +25,8 @@ MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-disable-isolation -Zmiri-disab
 
 # -Zmiri-ignore-leaks is needed for https://github.com/crossbeam-rs/crossbeam/issues/579
 # -Zmiri-disable-stacked-borrows is needed for https://github.com/crossbeam-rs/crossbeam/issues/545
+# -Zmiri-compare-exchange-weak-failure-rate=0.0 is needed because some sequential tests (e.g.,
+# doctest of Stealer::steal) incorrectly assume that sequential weak CAS will never fail.
 MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-disable-stacked-borrows -Zmiri-ignore-leaks -Zmiri-compare-exchange-weak-failure-rate=0.0" \
     cargo miri test \
     -p crossbeam-deque

--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -3,25 +3,29 @@ set -euxo pipefail
 IFS=$'\n\t'
 cd "$(dirname "$0")"/..
 
+# We need 'ts' for the per-line timing
+sudo apt-get -y install moreutils
+echo
+
 export RUSTFLAGS="${RUSTFLAGS:-} -Z randomize-layout"
 
 # -Zmiri-ignore-leaks is needed because we use detached threads in tests/docs: https://github.com/rust-lang/miri/issues/1371
 MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-disable-isolation -Zmiri-ignore-leaks" \
     cargo miri test \
     -p crossbeam-queue \
-    -p crossbeam-utils
+    -p crossbeam-utils 2>&1 | ts -i '%.s  '
 
 # -Zmiri-ignore-leaks is needed because we use detached threads in tests/docs: https://github.com/rust-lang/miri/issues/1371
 MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-disable-isolation -Zmiri-ignore-leaks" \
     cargo miri test \
-    -p crossbeam-channel
+    -p crossbeam-channel 2>&1 | ts -i '%.s  '
 
 # -Zmiri-ignore-leaks is needed for https://github.com/crossbeam-rs/crossbeam/issues/579
 # -Zmiri-disable-stacked-borrows is needed for https://github.com/crossbeam-rs/crossbeam/issues/545
 MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-disable-isolation -Zmiri-disable-stacked-borrows -Zmiri-ignore-leaks" \
     cargo miri test \
     -p crossbeam-epoch \
-    -p crossbeam-skiplist
+    -p crossbeam-skiplist 2>&1 | ts -i '%.s  '
 
 # -Zmiri-ignore-leaks is needed for https://github.com/crossbeam-rs/crossbeam/issues/579
 # -Zmiri-disable-stacked-borrows is needed for https://github.com/crossbeam-rs/crossbeam/issues/545
@@ -30,9 +34,9 @@ MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-disable-isolation -Zmiri-disab
 # -Zmiri-preemption-rate=0 is needed because this code technically has UB and Miri catches that.
 MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-disable-stacked-borrows -Zmiri-ignore-leaks -Zmiri-compare-exchange-weak-failure-rate=0.0 -Zmiri-preemption-rate=0" \
     cargo miri test \
-    -p crossbeam-deque
+    -p crossbeam-deque 2>&1 | ts -i '%.s  '
 
 # -Zmiri-ignore-leaks is needed for https://github.com/crossbeam-rs/crossbeam/issues/579
 MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-ignore-leaks" \
     cargo miri test \
-    -p crossbeam
+    -p crossbeam 2>&1 | ts -i '%.s  '

--- a/crossbeam-channel/tests/array.rs
+++ b/crossbeam-channel/tests/array.rs
@@ -532,16 +532,12 @@ fn drops() {
             scope.spawn(|_| {
                 for _ in 0..steps {
                     r.recv().unwrap();
-                    #[cfg(miri)]
-                    std::thread::yield_now(); // https://github.com/rust-lang/miri/issues/1388
                 }
             });
 
             scope.spawn(|_| {
                 for _ in 0..steps {
                     s.send(DropCounter).unwrap();
-                    #[cfg(miri)]
-                    std::thread::yield_now(); // https://github.com/rust-lang/miri/issues/1388
                 }
             });
         })

--- a/crossbeam-channel/tests/array.rs
+++ b/crossbeam-channel/tests/array.rs
@@ -377,7 +377,7 @@ fn spsc() {
 #[test]
 fn mpmc() {
     #[cfg(miri)]
-    const COUNT: usize = 100;
+    const COUNT: usize = 50;
     #[cfg(not(miri))]
     const COUNT: usize = 25_000;
     const THREADS: usize = 4;

--- a/crossbeam-channel/tests/golang.rs
+++ b/crossbeam-channel/tests/golang.rs
@@ -959,7 +959,7 @@ mod chan_test {
     #[test]
     fn test_chan() {
         #[cfg(miri)]
-        const N: i32 = 20;
+        const N: i32 = 12;
         #[cfg(not(miri))]
         const N: i32 = 200;
 
@@ -1489,7 +1489,7 @@ mod chan_test {
     fn test_multi_consumer() {
         const NWORK: usize = 23;
         #[cfg(miri)]
-        const NITER: usize = 100;
+        const NITER: usize = 50;
         #[cfg(not(miri))]
         const NITER: usize = 271828;
 

--- a/crossbeam-channel/tests/list.rs
+++ b/crossbeam-channel/tests/list.rs
@@ -433,8 +433,6 @@ fn drops() {
             scope.spawn(|_| {
                 for _ in 0..steps {
                     r.recv().unwrap();
-                    #[cfg(miri)]
-                    std::thread::yield_now(); // https://github.com/rust-lang/miri/issues/1388
                 }
             });
 

--- a/crossbeam-channel/tests/mpsc.rs
+++ b/crossbeam-channel/tests/mpsc.rs
@@ -339,25 +339,22 @@ mod channel_tests {
 
     #[test]
     fn stress_shared() {
-        #[cfg(miri)]
-        const AMT: u32 = 100;
-        #[cfg(not(miri))]
-        const AMT: u32 = 10000;
-        const NTHREADS: u32 = 8;
+        let amt: u32 = if cfg!(miri) { 100 } else { 10_000 };
+        let nthreads: u32 = if cfg!(miri) { 4 } else { 8 };
         let (tx, rx) = channel::<i32>();
 
         let t = thread::spawn(move || {
-            for _ in 0..AMT * NTHREADS {
+            for _ in 0..amt * nthreads {
                 assert_eq!(rx.recv().unwrap(), 1);
             }
             assert!(rx.try_recv().is_err());
         });
 
-        let mut ts = Vec::with_capacity(NTHREADS as usize);
-        for _ in 0..NTHREADS {
+        let mut ts = Vec::with_capacity(nthreads as usize);
+        for _ in 0..nthreads {
             let tx = tx.clone();
             let t = thread::spawn(move || {
-                for _ in 0..AMT {
+                for _ in 0..amt {
                     tx.send(1).unwrap();
                 }
             });

--- a/crossbeam-channel/tests/thread_locals.rs
+++ b/crossbeam-channel/tests/thread_locals.rs
@@ -1,6 +1,6 @@
 //! Tests that make sure accessing thread-locals while exiting the thread doesn't cause panics.
 
-#![cfg(not(miri))] // error: abnormal termination: the evaluated program aborted execution
+#![cfg(not(miri))] // Miri detects that this test is buggy: the destructor of `FOO` uses `std::thread::current()`!
 
 use std::thread;
 use std::time::Duration;

--- a/crossbeam-channel/tests/zero.rs
+++ b/crossbeam-channel/tests/zero.rs
@@ -403,7 +403,7 @@ fn drops() {
     #[cfg(not(miri))]
     const RUNS: usize = 100;
     #[cfg(miri)]
-    const STEPS: usize = 500;
+    const STEPS: usize = 100;
     #[cfg(not(miri))]
     const STEPS: usize = 10_000;
 

--- a/crossbeam-queue/tests/array_queue.rs
+++ b/crossbeam-queue/tests/array_queue.rs
@@ -124,7 +124,7 @@ fn len() {
 #[test]
 fn spsc() {
     #[cfg(miri)]
-    const COUNT: usize = 100;
+    const COUNT: usize = 50;
     #[cfg(not(miri))]
     const COUNT: usize = 100_000;
 
@@ -276,14 +276,9 @@ fn mpmc_ring_buffer() {
 
 #[test]
 fn drops() {
-    #[cfg(miri)]
-    const RUNS: usize = 5;
-    #[cfg(not(miri))]
-    const RUNS: usize = 100;
-    #[cfg(miri)]
-    const STEPS: usize = 50;
-    #[cfg(not(miri))]
-    const STEPS: usize = 10_000;
+    let runs: usize = if cfg!(miri) { 3 } else { 100 };
+    let steps: usize = if cfg!(miri) { 50 } else { 10_000 };
+    let additional: usize = if cfg!(miri) { 10 } else { 50 };
 
     static DROPS: AtomicUsize = AtomicUsize::new(0);
 
@@ -298,9 +293,9 @@ fn drops() {
 
     let mut rng = thread_rng();
 
-    for _ in 0..RUNS {
-        let steps = rng.gen_range(0..STEPS);
-        let additional = rng.gen_range(0..50);
+    for _ in 0..runs {
+        let steps = rng.gen_range(0..steps);
+        let additional = rng.gen_range(0..additional);
 
         DROPS.store(0, Ordering::SeqCst);
         let q = ArrayQueue::new(50);

--- a/crossbeam-queue/tests/array_queue.rs
+++ b/crossbeam-queue/tests/array_queue.rs
@@ -103,8 +103,6 @@ fn len() {
                         assert_eq!(x, i);
                         break;
                     }
-                    #[cfg(miri)]
-                    std::thread::yield_now(); // https://github.com/rust-lang/miri/issues/1388
                 }
                 let len = q.len();
                 assert!(len <= CAP);
@@ -113,10 +111,7 @@ fn len() {
 
         scope.spawn(|_| {
             for i in 0..COUNT {
-                while q.push(i).is_err() {
-                    #[cfg(miri)]
-                    std::thread::yield_now(); // https://github.com/rust-lang/miri/issues/1388
-                }
+                while q.push(i).is_err() {}
                 let len = q.len();
                 assert!(len <= CAP);
             }
@@ -143,8 +138,6 @@ fn spsc() {
                         assert_eq!(x, i);
                         break;
                     }
-                    #[cfg(miri)]
-                    std::thread::yield_now(); // https://github.com/rust-lang/miri/issues/1388
                 }
             }
             assert!(q.pop().is_none());
@@ -152,10 +145,7 @@ fn spsc() {
 
         scope.spawn(|_| {
             for i in 0..COUNT {
-                while q.push(i).is_err() {
-                    #[cfg(miri)]
-                    std::thread::yield_now(); // https://github.com/rust-lang/miri/issues/1388
-                }
+                while q.push(i).is_err() {}
             }
         });
     })
@@ -184,8 +174,6 @@ fn spsc_ring_buffer() {
                     }
                 }
             }
-            #[cfg(miri)]
-            std::thread::yield_now(); // https://github.com/rust-lang/miri/issues/1388
         });
 
         scope.spawn(|_| {
@@ -320,10 +308,7 @@ fn drops() {
         scope(|scope| {
             scope.spawn(|_| {
                 for _ in 0..steps {
-                    while q.pop().is_none() {
-                        #[cfg(miri)]
-                        std::thread::yield_now(); // https://github.com/rust-lang/miri/issues/1388
-                    }
+                    while q.pop().is_none() {}
                 }
             });
 
@@ -331,8 +316,6 @@ fn drops() {
                 for _ in 0..steps {
                     while q.push(DropCounter).is_err() {
                         DROPS.fetch_sub(1, Ordering::SeqCst);
-                        #[cfg(miri)]
-                        std::thread::yield_now(); // https://github.com/rust-lang/miri/issues/1388
                     }
                 }
             });

--- a/crossbeam-queue/tests/seg_queue.rs
+++ b/crossbeam-queue/tests/seg_queue.rs
@@ -121,14 +121,9 @@ fn mpmc() {
 
 #[test]
 fn drops() {
-    #[cfg(miri)]
-    const RUNS: usize = 5;
-    #[cfg(not(miri))]
-    const RUNS: usize = 100;
-    #[cfg(miri)]
-    const STEPS: usize = 50;
-    #[cfg(not(miri))]
-    const STEPS: usize = 10_000;
+    let runs: usize = if cfg!(miri) { 5 } else { 100 };
+    let steps: usize = if cfg!(miri) { 50 } else { 10_000 };
+    let additional: usize = if cfg!(miri) { 100 } else { 1_000 };
 
     static DROPS: AtomicUsize = AtomicUsize::new(0);
 
@@ -143,9 +138,9 @@ fn drops() {
 
     let mut rng = thread_rng();
 
-    for _ in 0..RUNS {
-        let steps = rng.gen_range(0..STEPS);
-        let additional = rng.gen_range(0..1000);
+    for _ in 0..runs {
+        let steps = rng.gen_range(0..steps);
+        let additional = rng.gen_range(0..additional);
 
         DROPS.store(0, Ordering::SeqCst);
         let q = SegQueue::new();

--- a/crossbeam-queue/tests/seg_queue.rs
+++ b/crossbeam-queue/tests/seg_queue.rs
@@ -69,8 +69,6 @@ fn spsc() {
                         assert_eq!(x, i);
                         break;
                     }
-                    #[cfg(miri)]
-                    std::thread::yield_now(); // https://github.com/rust-lang/miri/issues/1388
                 }
             }
             assert!(q.pop().is_none());
@@ -155,10 +153,7 @@ fn drops() {
         scope(|scope| {
             scope.spawn(|_| {
                 for _ in 0..steps {
-                    while q.pop().is_none() {
-                        #[cfg(miri)]
-                        std::thread::yield_now(); // https://github.com/rust-lang/miri/issues/1388
-                    }
+                    while q.pop().is_none() {}
                 }
             });
 

--- a/crossbeam-utils/tests/wait_group.rs
+++ b/crossbeam-utils/tests/wait_group.rs
@@ -36,6 +36,7 @@ fn wait() {
 }
 
 #[test]
+#[cfg(not(miri))] // this test makes timing assumptions, but Miri is so slow it violates them
 fn wait_and_drop() {
     let wg = WaitGroup::new();
     let (tx, rx) = mpsc::channel();
@@ -51,8 +52,8 @@ fn wait_and_drop() {
         });
     }
 
-    // At this point, all spawned threads should be sleeping, so we shouldn't get anything from the
-    // channel.
+    // At this point, all spawned threads should be in `thread::sleep`, so we shouldn't get anything
+    // from the channel.
     assert!(rx.try_recv().is_err());
 
     wg.wait();


### PR DESCRIPTION
Miri has a [work-around](https://github.com/rust-lang/miri/pull/2248) for https://github.com/rust-lang/rust/issues/55005 now.

Also, "check-number-validity" is on by default these days.  And I am not sure why "compare-exchange-weak-failure-rate=0.0" was set so let's see what happens when we remove it. :)