### PR TITLE
Fix clippy::explicit_auto_deref warning

### DIFF
--- a/crossbeam-epoch/src/atomic.rs
+++ b/crossbeam-epoch/src/atomic.rs
@@ -1712,7 +1712,7 @@ mod tests {
     #[test]
     fn array_init() {
         let owned = Owned::<[MaybeUninit<usize>]>::init(10);
-        let arr: &[MaybeUninit<usize>] = &*owned;
+        let arr: &[MaybeUninit<usize>] = &owned;
         assert_eq!(arr.len(), 10);
     }
 }

--- a/crossbeam-skiplist/src/base.rs
+++ b/crossbeam-skiplist/src/base.rs
@@ -1042,7 +1042,7 @@ where
                     }
 
                     // Installation failed. Decrement the reference count.
-                    (*n).refs_and_height
+                    n.refs_and_height
                         .fetch_sub(1 << HEIGHT_BITS, Ordering::Relaxed);
 
                     // We don't have the most up-to-date search results. Repeat the search.


### PR DESCRIPTION
```
warning: deref which would be done by auto-deref
    --> crossbeam-epoch/src/atomic.rs:1715:43
     |
1715 |         let arr: &[MaybeUninit<usize>] = &*owned;
     |                                           ^^^^^^ help: try this: `owned`
     |
     = note: `#[warn(clippy::explicit_auto_deref)]` on by default
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref

warning: deref which would be done by auto-deref
    --> crossbeam-skiplist/src/base.rs:1045:21
     |
1045 |                     (*n).refs_and_height
     |                     ^^^^ help: try this: `n`
     |
     = note: `#[warn(clippy::explicit_auto_deref)]` on by default
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref
```