### PR TITLE
Prepare for the next release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.8.2
+
+- Bump the minimum supported Rust version to 1.38. (#877)
+
 # Version 0.8.1
 
 - Support targets that do not have atomic CAS on stable Rust (#698)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-X.Y.Z" git tag
-version = "0.8.1"
+version = "0.8.2"
 edition = "2018"
 rust-version = "1.38"
 license = "MIT OR Apache-2.0"
@@ -13,7 +13,7 @@ homepage = "https://github.com/crossbeam-rs/crossbeam"
 description = "Tools for concurrent programming"
 keywords = ["atomic", "garbage", "non-blocking", "lock-free", "rcu"]
 categories = ["concurrency", "memory-management", "data-structures", "no-std"]
-exclude = ["/.github", "/ci"]
+exclude = ["/.*", "/ci", "/tools"]
 
 [features]
 default = ["std"]

--- a/crossbeam-channel/CHANGELOG.md
+++ b/crossbeam-channel/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.5.6
+
+- Bump the minimum supported Rust version to 1.38. (#877)
+
 # Version 0.5.5
 
 - Replace Spinlock with Mutex. (#835)

--- a/crossbeam-channel/Cargo.toml
+++ b/crossbeam-channel/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-channel"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-channel-X.Y.Z" git tag
-version = "0.5.5"
+version = "0.5.6"
 edition = "2018"
 rust-version = "1.38"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-deque/CHANGELOG.md
+++ b/crossbeam-deque/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.8.2
+
+- Bump the minimum supported Rust version to 1.38. (#877)
+
 # Version 0.8.1
 
 - Fix deque steal race condition. (#726)

--- a/crossbeam-deque/Cargo.toml
+++ b/crossbeam-deque/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-deque"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-deque-X.Y.Z" git tag
-version = "0.8.1"
+version = "0.8.2"
 edition = "2018"
 rust-version = "1.38"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-epoch/CHANGELOG.md
+++ b/crossbeam-epoch/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 0.9.10
+
+- Bump the minimum supported Rust version to 1.38. (#877)
+- Mitigate the risk of segmentation faults in buggy downstream implementations. (#879)
+- Add `{Atomic, Shared}::try_into_owned` (#701)
+
 # Version 0.9.9
 
 - Replace lazy_static with once_cell. (#817)

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-epoch"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-epoch-X.Y.Z" git tag
-version = "0.9.9"
+version = "0.9.10"
 edition = "2018"
 rust-version = "1.38"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-queue/CHANGELOG.md
+++ b/crossbeam-queue/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.3.6
+
+- Bump the minimum supported Rust version to 1.38. (#877)
+
 # Version 0.3.5
 
 - Add `ArrayQueue::force_push`. (#789)

--- a/crossbeam-queue/Cargo.toml
+++ b/crossbeam-queue/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-queue"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-queue-X.Y.Z" git tag
-version = "0.3.5"
+version = "0.3.6"
 edition = "2018"
 rust-version = "1.38"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-utils/CHANGELOG.md
+++ b/crossbeam-utils/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.8.11
+
+- Bump the minimum supported Rust version to 1.38. (#877)
+
 # Version 0.8.10
 
 - Fix unsoundness of `AtomicCell` on types containing niches. (#834)

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-utils"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-utils-X.Y.Z" git tag
-version = "0.8.10"
+version = "0.8.11"
 edition = "2018"
 rust-version = "1.38"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
- crossbeam-channel 0.5.5 -> 0.5.6
  - Bump the minimum supported Rust version to 1.38. (#877)
- crossbeam-deque 0.8.1 -> 0.8.2
  - Bump the minimum supported Rust version to 1.38. (#877)
- crossbeam-epoch 0.9.9 -> 0.9.10
  - Bump the minimum supported Rust version to 1.38. (#877)
  - Mitigate the risk of segmentation faults in buggy downstream implementations. (#879)
  - Add `{Atomic, Shared}::try_into_owned` (#701)
- crossbeam-queue 0.3.5 -> 0.3.6
  - Bump the minimum supported Rust version to 1.38. (#877)
- crossbeam-utils 0.8.10 -> 0.8.11
  - Bump the minimum supported Rust version to 1.38. (#877)
- crossbeam 0.8.1 -> 0.8.2
  - Bump the minimum supported Rust version to 1.38. (#877)
