### PR TITLE
Remove unnecessary allowed lints

### DIFF
--- a/crossbeam-channel/tests/golang.rs
+++ b/crossbeam-channel/tests/golang.rs
@@ -9,7 +9,7 @@
 //!   - https://golang.org/LICENSE
 //!   - https://golang.org/PATENTS
 
-#![allow(clippy::mutex_atomic, clippy::redundant_clone)]
+#![allow(clippy::redundant_clone)]
 
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::any::Any;

--- a/crossbeam-deque/src/lib.rs
+++ b/crossbeam-deque/src/lib.rs
@@ -95,7 +95,6 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![allow(clippy::question_mark)] // https://github.com/rust-lang/rust-clippy/issues/8281
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use cfg_if::cfg_if;

--- a/crossbeam-skiplist/tests/base.rs
+++ b/crossbeam-skiplist/tests/base.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::mutex_atomic, clippy::redundant_clone)]
+#![allow(clippy::redundant_clone)]
 
 use std::ops::Bound;
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/crossbeam-skiplist/tests/map.rs
+++ b/crossbeam-skiplist/tests/map.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::mutex_atomic)]
-
 use std::{iter, ops::Bound, sync::Barrier};
 
 use crossbeam_skiplist::SkipMap;

--- a/crossbeam-utils/src/sync/wait_group.rs
+++ b/crossbeam-utils/src/sync/wait_group.rs
@@ -1,6 +1,3 @@
-// Necessary for using `Mutex<usize>` for conditional variables
-#![allow(clippy::mutex_atomic)]
-
 use crate::primitive::sync::{Arc, Condvar, Mutex};
 use std::fmt;
 


### PR DESCRIPTION
clippy::mutex_atomic has been moved to the allowed by default group in Rust 1.60 (https://github.com/rust-lang/rust-clippy/pull/8260).
clippy::question_mark bug has been fixed in Rust 1.59 (https://github.com/rust-lang/rust-clippy/pull/8080).