### PR TITLE
Bump crossbeam-utils

### DIFF
--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -49,7 +49,7 @@ scopeguard = { version = "1.1", default-features = false }
 loom-crate = { package = "loom", version = "0.5", optional = true }
 
 [dependencies.crossbeam-utils]
-version = "0.8.5"
+version = "0.8.12"
 path = "../crossbeam-utils"
 default-features = false
 


### PR DESCRIPTION
crossbeam-epoch was using a yanked version of crossbeam-utils, updated to latest released version