### PR TITLE
Improve commented example for the never<T>() function

### DIFF
--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -256,8 +256,8 @@ pub fn at(when: Instant) -> Receiver<Instant> {
 ///
 /// // Create a channel that times out after the specified duration.
 /// let timeout = duration
-///     .map(|d| after(d))
-///     .unwrap_or(never());
+///     .map(after)
+///     .unwrap_or_else(never);
 ///
 /// select! {
 ///     recv(r) -> msg => assert_eq!(msg, Ok(1)),


### PR DESCRIPTION
Fixes the following clippy warnings when the commented code example is used from the never function :

- warning: redundant closure 
- warning: use of `unwrap_or` followed by a function call

The functionality remains intact.