### PR TITLE
When building for linux, replace all vendors with 'unknown'

### DIFF
--- a/build-common.rs
+++ b/build-common.rs
@@ -1,0 +1,13 @@
+// The target triplets have the form of 'arch-vendor-system'.
+//
+// When building for Linux (e.g. the 'system' part is
+// 'linux-something'), replace the vendor with 'unknown'
+// so that mapping to rust standard targets happens correctly.
+fn convert_custom_linux_target(target: String) -> String {
+    let mut parts: Vec<&str> = target.split('-').collect();
+    let system = parts[2];
+    if system == "linux" {
+        parts[1] = "unknown";
+    };
+    parts.join("-")
+}

--- a/crossbeam-epoch/build-common.rs
+++ b/crossbeam-epoch/build-common.rs
@@ -1,0 +1,1 @@
+../build-common.rs

--- a/crossbeam-epoch/build.rs
+++ b/crossbeam-epoch/build.rs
@@ -15,10 +15,11 @@
 use std::env;
 
 include!("no_atomic.rs");
+include!("build-common.rs");
 
 fn main() {
     let target = match env::var("TARGET") {
-        Ok(target) => target,
+        Ok(target) => convert_custom_linux_target(target),
         Err(e) => {
             println!(
                 "cargo:warning={}: unable to get TARGET environment variable: {}",

--- a/crossbeam-queue/build-common.rs
+++ b/crossbeam-queue/build-common.rs
@@ -1,0 +1,1 @@
+../build-common.rs

--- a/crossbeam-queue/build.rs
+++ b/crossbeam-queue/build.rs
@@ -15,10 +15,11 @@
 use std::env;
 
 include!("no_atomic.rs");
+include!("build-common.rs");
 
 fn main() {
     let target = match env::var("TARGET") {
-        Ok(target) => target,
+        Ok(target) => convert_custom_linux_target(target),
         Err(e) => {
             println!(
                 "cargo:warning={}: unable to get TARGET environment variable: {}",

--- a/crossbeam-skiplist/build-common.rs
+++ b/crossbeam-skiplist/build-common.rs
@@ -1,0 +1,1 @@
+../build-common.rs

--- a/crossbeam-skiplist/build.rs
+++ b/crossbeam-skiplist/build.rs
@@ -15,10 +15,11 @@
 use std::env;
 
 include!("no_atomic.rs");
+include!("build-common.rs");
 
 fn main() {
     let target = match env::var("TARGET") {
-        Ok(target) => target,
+        Ok(target) => convert_custom_linux_target(target),
         Err(e) => {
             println!(
                 "cargo:warning={}: unable to get TARGET environment variable: {}",

--- a/crossbeam-utils/build-common.rs
+++ b/crossbeam-utils/build-common.rs
@@ -1,0 +1,1 @@
+../build-common.rs

--- a/crossbeam-utils/build.rs
+++ b/crossbeam-utils/build.rs
@@ -27,10 +27,11 @@
 use std::env;
 
 include!("no_atomic.rs");
+include!("build-common.rs");
 
 fn main() {
     let target = match env::var("TARGET") {
-        Ok(target) => target,
+        Ok(target) => convert_custom_linux_target(target),
         Err(e) => {
             println!(
                 "cargo:warning={}: unable to get TARGET environment variable: {}",


### PR DESCRIPTION
Some build systems such as the Yocto project define custom rust targets, of the form 'arch-somevendor-linux-{gnu|musl}' (only the 'somevendor' part is custom, the rest matches rust's definitions).

This causes mismatches with crossbeam's lists of targets which are built from the standard rust target list, and always have 'unknown' as the vendor.

This change simply replaces such custom vendors with 'unknown' when the third component of the target is 'linux'.

---
Note from Alex: this is a reworked and hopefully better/more precise/acceptable version of https://github.com/crossbeam-rs/crossbeam/pull/751