### PR TITLE
crossbeam-epoch: Bump memoffset to 0.7

### DIFF
--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -38,7 +38,7 @@ autocfg = "1"
 
 [dependencies]
 cfg-if = "1"
-memoffset = "0.6"
+memoffset = "0.7"
 scopeguard = { version = "1.1", default-features = false }
 
 # Enable the use of loom for concurrency testing.


### PR DESCRIPTION
mostly to keep the number of dupes of crates in my dependency graph down