### PR TITLE
Fix newly added clippy warnings

### DIFF
--- a/crossbeam-channel/tests/golang.rs
+++ b/crossbeam-channel/tests/golang.rs
@@ -1047,10 +1047,10 @@ mod chan_test {
                     }
                 }
 
-                if c.recv() != None {
+                if c.recv().is_some() {
                     panic!();
                 }
-                if c.try_recv() != None {
+                if c.try_recv().is_some() {
                     panic!();
                 }
             }

--- a/crossbeam-epoch/src/internal.rs
+++ b/crossbeam-epoch/src/internal.rs
@@ -209,7 +209,7 @@ impl Global {
 
         for _ in 0..steps {
             match self.queue.try_pop_if(
-                &|sealed_bag: &SealedBag| sealed_bag.is_expired(global_epoch),
+                |sealed_bag: &SealedBag| sealed_bag.is_expired(global_epoch),
                 guard,
             ) {
                 None => break,

--- a/crossbeam-skiplist/benches/skiplist.rs
+++ b/crossbeam-skiplist/benches/skiplist.rs
@@ -1,4 +1,5 @@
 #![feature(test)]
+#![allow(clippy::unit_arg)]
 
 extern crate test;
 

--- a/crossbeam-utils/src/sync/wait_group.rs
+++ b/crossbeam-utils/src/sync/wait_group.rs
@@ -139,7 +139,7 @@ impl Clone for WaitGroup {
 
 impl fmt::Debug for WaitGroup {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let count: &usize = &*self.inner.count.lock().unwrap();
+        let count: &usize = &self.inner.count.lock().unwrap();
         f.debug_struct("WaitGroup").field("count", count).finish()
     }
 }


### PR DESCRIPTION
```
error: deref which would be done by auto-deref
   --> crossbeam-utils/src/sync/wait_group.rs:142:29
    |
142 |         let count: &usize = &*self.inner.count.lock().unwrap();
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&self.inner.count.lock().unwrap()`
    |
    = note: `-D clippy::explicit-auto-deref` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref
```