### PR TITLE
v0.8: Prepare for the next release

### DIFF
--- a/build-common.rs
+++ b/build-common.rs
@@ -1,0 +1,13 @@
+// The target triplets have the form of 'arch-vendor-system'.
+//
+// When building for Linux (e.g. the 'system' part is
+// 'linux-something'), replace the vendor with 'unknown'
+// so that mapping to rust standard targets happens correctly.
+fn convert_custom_linux_target(target: String) -> String {
+    let mut parts: Vec<&str> = target.split('-').collect();
+    let system = parts[2];
+    if system == "linux" {
+        parts[1] = "unknown";
+    };
+    parts.join("-")
+}

--- a/crossbeam-epoch/CHANGELOG.md
+++ b/crossbeam-epoch/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 0.9.12
+
+- Update `memoffset` to 0.7. (#926)
+- Improve support for custom targets. (#922)
+
 # Version 0.9.11
 
 - Removes the dependency on the `once_cell` crate to restore the MSRV. (#913)

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-epoch"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-epoch-X.Y.Z" git tag
-version = "0.9.11"
+version = "0.9.12"
 edition = "2018"
 rust-version = "1.38"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -47,7 +47,7 @@ autocfg = "1"
 
 [dependencies]
 cfg-if = "1"
-memoffset = "0.6"
+memoffset = "0.7"
 scopeguard = { version = "1.1", default-features = false }
 
 # Enable the use of loom for concurrency testing.

--- a/crossbeam-epoch/build-common.rs
+++ b/crossbeam-epoch/build-common.rs
@@ -1,0 +1,1 @@
+../build-common.rs

--- a/crossbeam-epoch/build.rs
+++ b/crossbeam-epoch/build.rs
@@ -15,10 +15,11 @@
 use std::env;
 
 include!("no_atomic.rs");
+include!("build-common.rs");
 
 fn main() {
     let target = match env::var("TARGET") {
-        Ok(target) => target,
+        Ok(target) => convert_custom_linux_target(target),
         Err(e) => {
             println!(
                 "cargo:warning={}: unable to get TARGET environment variable: {}",

--- a/crossbeam-queue/CHANGELOG.md
+++ b/crossbeam-queue/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.3.7
+
+- Improve support for custom targets. (#922)
+
 # Version 0.3.6
 
 - Bump the minimum supported Rust version to 1.38. (#877)

--- a/crossbeam-queue/Cargo.toml
+++ b/crossbeam-queue/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-queue"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-queue-X.Y.Z" git tag
-version = "0.3.6"
+version = "0.3.7"
 edition = "2018"
 rust-version = "1.38"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-queue/build-common.rs
+++ b/crossbeam-queue/build-common.rs
@@ -1,0 +1,1 @@
+../build-common.rs

--- a/crossbeam-queue/build.rs
+++ b/crossbeam-queue/build.rs
@@ -15,10 +15,11 @@
 use std::env;
 
 include!("no_atomic.rs");
+include!("build-common.rs");
 
 fn main() {
     let target = match env::var("TARGET") {
-        Ok(target) => target,
+        Ok(target) => convert_custom_linux_target(target),
         Err(e) => {
             println!(
                 "cargo:warning={}: unable to get TARGET environment variable: {}",

--- a/crossbeam-skiplist/build-common.rs
+++ b/crossbeam-skiplist/build-common.rs
@@ -1,0 +1,1 @@
+../build-common.rs

--- a/crossbeam-skiplist/build.rs
+++ b/crossbeam-skiplist/build.rs
@@ -15,10 +15,11 @@
 use std::env;
 
 include!("no_atomic.rs");
+include!("build-common.rs");
 
 fn main() {
     let target = match env::var("TARGET") {
-        Ok(target) => target,
+        Ok(target) => convert_custom_linux_target(target),
         Err(e) => {
             println!(
                 "cargo:warning={}: unable to get TARGET environment variable: {}",

--- a/crossbeam-utils/CHANGELOG.md
+++ b/crossbeam-utils/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.8.13
+
+- Improve support for custom targets. (#922)
+
 # Version 0.8.12
 
 - Removes the dependency on the `once_cell` crate to restore the MSRV. (#913)

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-utils"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-utils-X.Y.Z" git tag
-version = "0.8.12"
+version = "0.8.13"
 edition = "2018"
 rust-version = "1.38"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-utils/build-common.rs
+++ b/crossbeam-utils/build-common.rs
@@ -1,0 +1,1 @@
+../build-common.rs

--- a/crossbeam-utils/build.rs
+++ b/crossbeam-utils/build.rs
@@ -27,10 +27,11 @@
 use std::env;
 
 include!("no_atomic.rs");
+include!("build-common.rs");
 
 fn main() {
     let target = match env::var("TARGET") {
-        Ok(target) => target,
+        Ok(target) => convert_custom_linux_target(target),
         Err(e) => {
             println!(
                 "cargo:warning={}: unable to get TARGET environment variable: {}",

--- a/no_atomic.rs
+++ b/no_atomic.rs
@@ -37,6 +37,7 @@ const NO_ATOMIC_64: &[&str] = &[
     "mips-unknown-linux-musl",
     "mips-unknown-linux-uclibc",
     "mipsel-sony-psp",
+    "mipsel-sony-psx",
     "mipsel-unknown-linux-gnu",
     "mipsel-unknown-linux-musl",
     "mipsel-unknown-linux-uclibc",
@@ -73,6 +74,7 @@ const NO_ATOMIC_64: &[&str] = &[
 #[allow(dead_code)] // Only crossbeam-utils uses this.
 const NO_ATOMIC: &[&str] = &[
     "avr-unknown-gnu-atmega328",
+    "mipsel-sony-psx",
     "msp430-none-elf",
     "riscv32i-unknown-none-elf",
     "riscv32im-unknown-none-elf",


### PR DESCRIPTION
Backports #922 and #926.

Changes:
- crossbeam-utils 0.8.12 -> 0.8.13
  - Update `memoffset` to 0.7. (#926)
  - Improve support for custom targets. (#922)
- crossbeam-queue 0.3.6 -> 0.3.7
  - Improve support for custom targets. (#922)
- crossbeam-epoch 0.9.11 -> 0.9.12
  - Improve support for custom targets. (#922)

Closes #928