### PR TITLE
Fix panicking when target triplets has less than three elements

### DIFF
--- a/build-common.rs
+++ b/build-common.rs
@@ -5,8 +5,8 @@
 // so that mapping to rust standard targets happens correctly.
 fn convert_custom_linux_target(target: String) -> String {
     let mut parts: Vec<&str> = target.split('-').collect();
-    let system = parts[2];
-    if system == "linux" {
+    let system = parts.get(2);
+    if system == Some(&"linux") {
         parts[1] = "unknown";
     };
     parts.join("-")


### PR DESCRIPTION
Currently the build script panic when the target triplets have less than three elements, for example `wasm32-wasi`, this PR fixes that issue.

Fixes #931