### PR TITLE
v0.8: Prepare for the next release

### DIFF
--- a/build-common.rs
+++ b/build-common.rs
@@ -5,8 +5,8 @@
 // so that mapping to rust standard targets happens correctly.
 fn convert_custom_linux_target(target: String) -> String {
     let mut parts: Vec<&str> = target.split('-').collect();
-    let system = parts[2];
-    if system == "linux" {
+    let system = parts.get(2);
+    if system == Some(&"linux") {
         parts[1] = "unknown";
     };
     parts.join("-")

--- a/crossbeam-epoch/CHANGELOG.md
+++ b/crossbeam-epoch/CHANGELOG.md
@@ -1,4 +1,10 @@
+# Version 0.9.13
+
+- Fix build script bug introduced in 0.9.12. (#932)
+
 # Version 0.9.12
+
+**Note:** This release has been yanked due to regression fixed in 0.9.13.
 
 - Update `memoffset` to 0.7. (#926)
 - Improve support for custom targets. (#922)

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-epoch"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-epoch-X.Y.Z" git tag
-version = "0.9.12"
+version = "0.9.13"
 edition = "2018"
 rust-version = "1.38"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-queue/CHANGELOG.md
+++ b/crossbeam-queue/CHANGELOG.md
@@ -1,4 +1,10 @@
+# Version 0.3.8
+
+- Fix build script bug introduced in 0.3.7. (#932)
+
 # Version 0.3.7
+
+**Note:** This release has been yanked due to regression fixed in 0.3.8.
 
 - Improve support for custom targets. (#922)
 

--- a/crossbeam-queue/Cargo.toml
+++ b/crossbeam-queue/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-queue"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-queue-X.Y.Z" git tag
-version = "0.3.7"
+version = "0.3.8"
 edition = "2018"
 rust-version = "1.38"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-utils/CHANGELOG.md
+++ b/crossbeam-utils/CHANGELOG.md
@@ -1,4 +1,10 @@
+# Version 0.8.14
+
+- Fix build script bug introduced in 0.8.13. (#932)
+
 # Version 0.8.13
+
+**Note:** This release has been yanked due to regression fixed in 0.8.14.
 
 - Improve support for custom targets. (#922)
 

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-utils"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-utils-X.Y.Z" git tag
-version = "0.8.13"
+version = "0.8.14"
 edition = "2018"
 rust-version = "1.38"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Backports #932

Changes:
- crossbeam-epoch 0.9.13
  - Fix build script bug introduced in 0.9.12. (#932)
- crossbeam-queue 0.3.8
  - Fix build script bug introduced in 0.9.12. (#932)
- crossbeam-utils 0.8.14
  - Fix build script bug introduced in 0.9.12. (#932)