### PR TITLE
no_atomic: add `mipsel-unknown-linux`

### DIFF
--- a/no_atomic.rs
+++ b/no_atomic.rs
@@ -38,6 +38,7 @@ const NO_ATOMIC_64: &[&str] = &[
     "mips-unknown-linux-uclibc",
     "mipsel-sony-psp",
     "mipsel-sony-psx",
+    "mipsel-unknown-linux",
     "mipsel-unknown-linux-gnu",
     "mipsel-unknown-linux-musl",
     "mipsel-unknown-linux-uclibc",


### PR DESCRIPTION
We're using yocto dunfell with the unofficial meta-rust layer and it doesn't add a libc suffix.