### PR TITLE
Fix get_unchecked panic by raw pointer calculation

### DIFF
--- a/crossbeam-skiplist/src/base.rs
+++ b/crossbeam-skiplist/src/base.rs
@@ -36,7 +36,7 @@ impl<K, V> Index<usize> for Tower<K, V> {
     fn index(&self, index: usize) -> &Atomic<Node<K, V>> {
         // This implementation is actually unsafe since we don't check if the
         // index is in-bounds. But this is fine since this is only used internally.
-        unsafe { self.pointers.get_unchecked(index) }
+        unsafe { &*(&self.pointers as *const Atomic<Node<K, V>>).add(index) }
     }
 }
 


### PR DESCRIPTION
It is related to #878 but doesn't fix it. Miri still complains with this PR.

It fixes the panic on recent toolchains (after https://github.com/rust-lang/rust/pull/92686) when using `-Zbuild-std`.

```
$ RUST_BACKTRACE=1 cargo test -p crossbeam-skiplist -Zbuild-std --target x86_64-unknown-linux-gnu --test map -- smoke
    Finished test [unoptimized + debuginfo] target(s) in 0.03s
     Running tests/map.rs (target/x86_64-unknown-linux-gnu/debug/deps/map-509dc855f6125f07)

running 1 test
thread 'smoke' panicked at 'unsafe precondition(s) violated: slice::get_unchecked requires that the index is within the slice', /home/yilin/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panicking.rs:87:58
stack backtrace:
   0: rust_begin_unwind
             at /home/yilin/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:575:5
   1: core::panicking::panic_str_nounwind
             at /home/yilin/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panicking.rs:90:14
   2: <usize as core::slice::index::SliceIndex<[T]>>::get_unchecked::runtime
             at /home/yilin/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/intrinsics.rs:2284:21
   3: <usize as core::slice::index::SliceIndex<[T]>>::get_unchecked
             at /home/yilin/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/index.rs:236:13
   4: core::slice::<impl [T]>::get_unchecked
             at /home/yilin/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/mod.rs:399:20
   5: <crossbeam_skiplist::base::Tower<K,V> as core::ops::index::Index<usize>>::index
             at ./src/base.rs:39:18
   6: crossbeam_skiplist::base::SkipList<K,V>::search_position
             at ./src/base.rs:781:24
   7: crossbeam_skiplist::base::SkipList<K,V>::insert_internal
             at ./src/base.rs:871:26
   8: crossbeam_skiplist::base::SkipList<K,V>::insert
             at ./src/base.rs:1085:9
   9: crossbeam_skiplist::map::SkipMap<K,V>::insert
             at ./src/map.rs:375:20
  10: map::smoke
             at ./tests/map.rs:9:5
  11: map::smoke::{{closure}}
             at ./tests/map.rs:7:12
  12: core::ops::function::FnOnce::call_once
             at /home/yilin/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:507:5
  13: core::ops::function::FnOnce::call_once
             at /home/yilin/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:507:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
thread panicked while panicking. aborting.
error: test failed, to rerun pass `-p crossbeam-skiplist --test map`

Caused by:
  process didn't exit successfully: `/home/yilin/Repos/crossbeam/target/x86_64-unknown-linux-gnu/debug/deps/map-509dc855f6125f07 smoke` (signal: 6, SIGABRT: process abort signal)
```