### PR TITLE
Run cargo-careful in CI

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -4,3 +4,4 @@ status = [
     "test (aarch64-apple-darwin)",
     "test (x86_64-apple-darwin)",
 ]
+timeout_sec = 7200

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,18 @@ jobs:
       - name: miri
         run: ./ci/miri.sh
 
+  # Run cargo-careful.
+  careful:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        run: rustup toolchain install nightly --component rust-src && rustup default nightly
+      - name: Install cargo-careful
+        run: cargo install cargo-careful --locked --debug
+      - name: Run cargo-careful
+        run: ./ci/careful.sh
+
   # Run sanitizers.
   san:
     runs-on: ubuntu-latest
@@ -222,6 +234,7 @@ jobs:
       - rustfmt
       - clippy
       - miri
+      - careful
       - san
       - loom
       - docs

--- a/ci/careful.sh
+++ b/ci/careful.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euxo pipefail
+IFS=$'\n\t'
+cd "$(dirname "$0")"/..
+
+export RUSTFLAGS="${RUSTFLAGS:-} -Z randomize-layout"
+
+cargo careful test --all --all-features --exclude benchmarks -- --test-threads=1


### PR DESCRIPTION
https://github.com/RalfJung/cargo-careful

This allows to catch UB like https://github.com/crossbeam-rs/crossbeam/pull/940.