### PR TITLE
Prepare for the next release

### DIFF
--- a/crossbeam-skiplist/CHANGELOG.md
+++ b/crossbeam-skiplist/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 0.1.1
+
+- Fix `get_unchecked` panic by raw pointer calculation. (#940)
+
 # Version 0.1.0
+
+**Note:** This release has been yanked due to bug fixed in 0.1.1.
 
 - Initial implementation.

--- a/crossbeam-skiplist/Cargo.toml
+++ b/crossbeam-skiplist/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-skiplist"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-skiplist-X.Y.Z" git tag
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 rust-version = "1.38"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
- crossbeam-skiplist 0.1.1
  - Fix `get_unchecked` panic by raw pointer calculation. (#940)

Also, I'll yank crossbeam-skiplist 0.1.0 once 0.1.1 is released.