### PR TITLE
Mark some structures with `#[clippy::has_significant_drop]`

### DIFF
--- a/crossbeam-utils/src/sync/sharded_lock.rs
+++ b/crossbeam-utils/src/sync/sharded_lock.rs
@@ -480,6 +480,7 @@ impl<T> From<T> for ShardedLock<T> {
 }
 
 /// A guard used to release the shared read access of a [`ShardedLock`] when dropped.
+#[clippy::has_significant_drop]
 pub struct ShardedLockReadGuard<'a, T: ?Sized> {
     lock: &'a ShardedLock<T>,
     _guard: RwLockReadGuard<'a, ()>,
@@ -511,6 +512,7 @@ impl<T: ?Sized + fmt::Display> fmt::Display for ShardedLockReadGuard<'_, T> {
 }
 
 /// A guard used to release the exclusive write access of a [`ShardedLock`] when dropped.
+#[clippy::has_significant_drop]
 pub struct ShardedLockWriteGuard<'a, T: ?Sized> {
     lock: &'a ShardedLock<T>,
     _marker: PhantomData<RwLockWriteGuard<'a, T>>,


### PR DESCRIPTION
`#[clippy::has_significant_drop]` tells that a structure should be considered when evaluating some lints. Examples of such behavior are the existent `clippy::significant_drop_in_scrutinee` and the soon-to-be-finished https://github.com/rust-lang/rust-clippy/issues/9399.