### PR TITLE
Add receiver.disconnect() for atomic graceful shutdown

### DIFF
--- a/crossbeam-channel/src/lib.rs
+++ b/crossbeam-channel/src/lib.rs
@@ -363,7 +363,7 @@ cfg_if! {
 
         pub use crate::channel::{after, at, never, tick};
         pub use crate::channel::{bounded, unbounded};
-        pub use crate::channel::{IntoIter, Iter, TryIter};
+        pub use crate::channel::{IntoIter, Iter, TryIter, DisconnectIter};
         pub use crate::channel::{Receiver, Sender};
 
         pub use crate::select::{Select, SelectedOperation};


### PR DESCRIPTION
Firstly, congrats for adaptation by `std::sync::mpsc`!

Hi, yes... Me again. :) I'm the guy who submitted this stale issue: https://github.com/crossbeam-rs/crossbeam/issues/852. (i haven't forget it... just priority thing...)

However, I'm eager for this completely unrelated pr to get across the line this time really :)

In short, there's no way to shutdown channels from the receiver-side _with guarantee of no loss of messages_.

That's because the only way to shutdown channels explicitly is `drop()`-ing the last alive `receiver` and i can't `.try_recv()`, now that it's gone. ;)

So, there's still a chance sender has managed to sneak more, no matter hard I'm draining with `loop`-ed `try_recv()` before `drop()` at the receiver side in advance. (i.e. tocttou)

In other words, I'd like to clarify the semantics of channel shutdown and want to play with many short-lived ones.

This desire is arising from the use-case where I want to commit tasks from many worker threads to the committer thread and the committer is time-sliced and the worker needs to know which current time slice it succeed to commit or not *as extremely fast as possible*. 

So, I'd like to map the time slice to each crossbeam_channels 1-to-1. At the end of any time slice, the workers-side and the committer-side should agree with _identical_ set of committed tasks. Also, it's okay to take some time to switch to new crossbeam channel after first commit error due to expired time slice, which the committer determines and initiates the rollover via `.disconnect()`.
So that there's no need for round-trip with `futex`s, which is the overhead for common pattern of passing a sender to return the commit result back. the `.disconnect()` approach will just require a few of just atomic CASes.

I think there's no performant alternative way, other than trying to persuade 70M-all-time-downloaded crate's maintainer's mind. :)

This pr is still a draft but I'd like to work on more if this sounds sensible (writing tests/supporting all flavors).

Thanks.