### PR TITLE
CachePadded: Use 32-byte alignment on riscv32/sparc/hexagon, 16-byte alignment on m68k

### DIFF
--- a/crossbeam-utils/src/cache_padded.rs
+++ b/crossbeam-utils/src/cache_padded.rs
@@ -14,7 +14,8 @@ use core::ops::{Deref, DerefMut};
 /// Cache lines are assumed to be N bytes long, depending on the architecture:
 ///
 /// * On x86-64, aarch64, and powerpc64, N = 128.
-/// * On arm, mips, mips64, and riscv64, N = 32.
+/// * On arm, mips, mips64, riscv32, riscv64, sparc, and hexagon, N = 32.
+/// * On m68k, N = 16.
 /// * On s390x, N = 256.
 /// * On all others, N = 64.
 ///
@@ -83,7 +84,7 @@ use core::ops::{Deref, DerefMut};
     ),
     repr(align(128))
 )]
-// arm, mips, mips64, and riscv64 have 32-byte cache line size.
+// arm, mips, mips64, riscv64, sparc, and hexagon have 32-byte cache line size.
 //
 // Sources:
 // - https://github.com/golang/go/blob/3dd58676054223962cd915bb0934d1f9f489d4d2/src/internal/cpu/cpu_arm.go#L7
@@ -91,25 +92,39 @@ use core::ops::{Deref, DerefMut};
 // - https://github.com/golang/go/blob/3dd58676054223962cd915bb0934d1f9f489d4d2/src/internal/cpu/cpu_mipsle.go#L7
 // - https://github.com/golang/go/blob/3dd58676054223962cd915bb0934d1f9f489d4d2/src/internal/cpu/cpu_mips64x.go#L9
 // - https://github.com/golang/go/blob/3dd58676054223962cd915bb0934d1f9f489d4d2/src/internal/cpu/cpu_riscv64.go#L7
+// - https://github.com/torvalds/linux/blob/3516bd729358a2a9b090c1905bd2a3fa926e24c6/arch/sparc/include/asm/cache.h#L17
+// - https://github.com/torvalds/linux/blob/3516bd729358a2a9b090c1905bd2a3fa926e24c6/arch/hexagon/include/asm/cache.h#L12
+//
+// riscv32 is assumed not to exceed the cache line size of riscv64.
 #[cfg_attr(
     any(
         target_arch = "arm",
         target_arch = "mips",
         target_arch = "mips64",
+        target_arch = "riscv32",
         target_arch = "riscv64",
+        target_arch = "sparc",
+        target_arch = "hexagon",
     ),
     repr(align(32))
 )]
+// m68k has 16-byte cache line size.
+//
+// Sources:
+// - https://github.com/torvalds/linux/blob/3516bd729358a2a9b090c1905bd2a3fa926e24c6/arch/m68k/include/asm/cache.h#L9
+#[cfg_attr(target_arch = "m68k", repr(align(16)))]
 // s390x has 256-byte cache line size.
 //
 // Sources:
 // - https://github.com/golang/go/blob/3dd58676054223962cd915bb0934d1f9f489d4d2/src/internal/cpu/cpu_s390x.go#L7
+// - https://github.com/torvalds/linux/blob/3516bd729358a2a9b090c1905bd2a3fa926e24c6/arch/s390/include/asm/cache.h#L13
 #[cfg_attr(target_arch = "s390x", repr(align(256)))]
-// x86 and wasm have 64-byte cache line size.
+// x86, wasm, and sparc64 have 64-byte cache line size.
 //
 // Sources:
 // - https://github.com/golang/go/blob/dda2991c2ea0c5914714469c4defc2562a907230/src/internal/cpu/cpu_x86.go#L9
 // - https://github.com/golang/go/blob/3dd58676054223962cd915bb0934d1f9f489d4d2/src/internal/cpu/cpu_wasm.go#L7
+// - https://github.com/torvalds/linux/blob/3516bd729358a2a9b090c1905bd2a3fa926e24c6/arch/sparc/include/asm/cache.h#L19
 //
 // All others are assumed to have 64-byte cache line size.
 #[cfg_attr(
@@ -120,7 +135,11 @@ use core::ops::{Deref, DerefMut};
         target_arch = "arm",
         target_arch = "mips",
         target_arch = "mips64",
+        target_arch = "riscv32",
         target_arch = "riscv64",
+        target_arch = "sparc",
+        target_arch = "hexagon",
+        target_arch = "m68k",
         target_arch = "s390x",
     )),
     repr(align(64))


### PR DESCRIPTION
- riscv32 is assumed not to exceed the cache line size of riscv64.
- sparc, hexagon, and m68k's cache line sizes are from Linux kernel's __cacheline_aligned ([SMP_CACHE_BYTES, or L1_CACHE_BYTES if SMP_CACHE_BYTES is not set](https://github.com/torvalds/linux/blob/3516bd729358a2a9b090c1905bd2a3fa926e24c6/include/linux/cache.h)).
