### PR TITLE
channel: unbounded: synchronize receiver disconnect with initialization 

### DIFF
--- a/crossbeam-channel/src/flavors/list.rs
+++ b/crossbeam-channel/src/flavors/list.rs
@@ -236,6 +236,7 @@ impl<T> Channel<T> {
                     .compare_exchange(block, new, Ordering::Release, Ordering::Relaxed)
                     .is_ok()
                 {
+                    std::thread::sleep(std::time::Duration::from_secs(2));
                     self.head.block.store(new, Ordering::Release);
                     block = new;
                 } else {

--- a/crossbeam-channel/src/flavors/list.rs
+++ b/crossbeam-channel/src/flavors/list.rs
@@ -236,7 +236,6 @@ impl<T> Channel<T> {
                     .compare_exchange(block, new, Ordering::Release, Ordering::Relaxed)
                     .is_ok()
                 {
-                    std::thread::sleep(std::time::Duration::from_secs(2));
                     self.head.block.store(new, Ordering::Release);
                     block = new;
                 } else {

--- a/crossbeam-channel/src/flavors/list.rs
+++ b/crossbeam-channel/src/flavors/list.rs
@@ -585,6 +585,17 @@ impl<T> Channel<T> {
         let mut head = self.head.index.load(Ordering::Acquire);
         let mut block = self.head.block.load(Ordering::Acquire);
 
+        // If we're going to be dropping messages we need to synchronize with initialization
+        if head >> SHIFT != tail >> SHIFT {
+            // The block can be null here only if a sender is in the process of initializing the
+            // channel while another sender managed to send a message by inserting it into the
+            // semi-initialized channel and advanced the tail.
+            // In that case, just wait until it gets initialized.
+            while block.is_null() {
+                backoff.snooze();
+                block = self.head.block.load(Ordering::Acquire);
+            }
+        }
         unsafe {
             // Drop all messages between head and tail and deallocate the heap-allocated blocks.
             while head >> SHIFT != tail >> SHIFT {

--- a/crossbeam-channel/tests/list.rs
+++ b/crossbeam-channel/tests/list.rs
@@ -17,28 +17,6 @@ fn ms(ms: u64) -> Duration {
 }
 
 #[test]
-fn gh_971() {
-    let (s1, r) = unbounded::<u64>();
-    let s2 = s1.clone();
-
-    // This thread will sleep for 2000ms at the critical moment
-    let t1 = thread::spawn(move || assert!(s1.send(42).is_err()));
-
-    // Give some time for thread 1 to reach the critical state
-    thread::sleep(Duration::from_millis(100));
-    // Send another value which see the tail is not null and will just advance the tail offset to 1
-    // and write the value.
-    s2.send(42).unwrap();
-
-    // Now drop the receiver which will attempt to drop a message by reading it since head != tail
-    // but head is still a null pointer because the thread t1 is still preempted leading to a
-    // segfault.
-    drop(r);
-
-    t1.join().unwrap();
-}
-
-#[test]
 fn smoke() {
     let (s, r) = unbounded();
     s.try_send(7).unwrap();

--- a/crossbeam-channel/tests/list.rs
+++ b/crossbeam-channel/tests/list.rs
@@ -17,6 +17,28 @@ fn ms(ms: u64) -> Duration {
 }
 
 #[test]
+fn gh_971() {
+    let (s1, r) = unbounded::<u64>();
+    let s2 = s1.clone();
+
+    // This thread will sleep for 2000ms at the critical moment
+    let t1 = thread::spawn(move || assert!(s1.send(42).is_err()));
+
+    // Give some time for thread 1 to reach the critical state
+    thread::sleep(Duration::from_millis(100));
+    // Send another value which see the tail is not null and will just advance the tail offset to 1
+    // and write the value.
+    s2.send(42).unwrap();
+
+    // Now drop the receiver which will attempt to drop a message by reading it since head != tail
+    // but head is still a null pointer because the thread t1 is still preempted leading to a
+    // segfault.
+    drop(r);
+
+    t1.join().unwrap();
+}
+
+#[test]
 fn smoke() {
     let (s, r) = unbounded();
     s.try_send(7).unwrap();


### PR DESCRIPTION
Receiver disconnection relies on the incorrect assumption that `head.index != tail.index` implies that the channel is initialized (i.e `head.block` and `tail.block` point to allocated blocks). However, it can happen that `head.index != tail.index` and `head.block == null` at the same time which leads to a segfault when a channel is dropped in that state.

This can happen because initialization is performed in two steps. First, the tail block is allocated and the `tail.block` is set. If that is successful `head.block` is set to the same pointer. Importantly, initialization is skipped if `tail.block` is not null.

Therefore we can have the following situation:

1. Thread A starts to send the first value of the channel, observes that `tail.block` is null and begins initialization. It sets `tail.block` to point to a newly allocated block and then gets preempted. `head.block` is still null at this point.
2. Thread B starts to send the second value of the channel, observes that `tail.block` *is not* null and proceeds with writing its value in the allocated tail block and sets `tail.index` to 1.
3. Thread B drops the receiver of the channel which observes that `head.index != tail.index` (0 and 1 respectively), therefore there must be messages to drop. It starts traversing the linked list from `head.block` which is still a null pointer, leading to a segfault.

The first commit of this PR includes a reproduction of this scenario.

This PR fixes this problem by waiting for initialization to complete when `head.index != tail.index` and the `head.block` is still null. A similar check exists in `start_recv` for similar reasons.

Fixes #971 