### PR TITLE
epoch: bump `memoffset` to v0.9

### DIFF
--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -38,7 +38,7 @@ autocfg = "1"
 
 [dependencies]
 cfg-if = "1"
-memoffset = "0.8"
+memoffset = "0.9"
 scopeguard = { version = "1.1", default-features = false }
 
 # Enable the use of loom for concurrency testing.


### PR DESCRIPTION
CC: https://github.com/rust-lang/rust/issues/111839