### PR TITLE
v0.8: Prepare for the next release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
               echo "::set-output name=success::false"
           fi
         if: github.repository_owner == 'crossbeam-rs' && github.event_name == 'schedule'
-      - uses: taiki-e/create-pull-request@v3
+      - uses: peter-evans/create-pull-request@v5
         with:
           title: Update no_atomic.rs
           body: |

--- a/ci/tsan
+++ b/ci/tsan
@@ -10,4 +10,4 @@ race:crossbeam_deque*push
 race:crossbeam_deque*steal
 
 # Non-lock-free AtomicCell uses SeqLock which uses fences.
-race:crossbeam_utils::atomic::atomic_cell::AtomicCell<T>::compare_exchange
+race:crossbeam_utils::atomic::atomic_cell::atomic_compare_exchange_weak

--- a/crossbeam-channel/tests/mpsc.rs
+++ b/crossbeam-channel/tests/mpsc.rs
@@ -20,11 +20,7 @@
 //!   - https://github.com/rust-lang/rust/blob/master/COPYRIGHT
 //!   - https://www.rust-lang.org/en-US/legal.html
 
-#![allow(
-    dropping_copy_types,
-    clippy::match_single_binding,
-    clippy::redundant_clone
-)]
+#![allow(clippy::match_single_binding, clippy::redundant_clone)]
 
 use std::sync::mpsc::{RecvError, RecvTimeoutError, TryRecvError};
 use std::sync::mpsc::{SendError, TrySendError};

--- a/crossbeam-channel/tests/mpsc.rs
+++ b/crossbeam-channel/tests/mpsc.rs
@@ -21,7 +21,7 @@
 //!   - https://www.rust-lang.org/en-US/legal.html
 
 #![allow(
-    clippy::drop_copy,
+    dropping_copy_types,
     clippy::match_single_binding,
     clippy::redundant_clone
 )]

--- a/crossbeam-channel/tests/ready.rs
+++ b/crossbeam-channel/tests/ready.rs
@@ -1,7 +1,5 @@
 //! Tests for channel readiness using the `Select` struct.
 
-#![allow(dropping_copy_types)]
-
 use std::any::Any;
 use std::cell::Cell;
 use std::thread;

--- a/crossbeam-channel/tests/ready.rs
+++ b/crossbeam-channel/tests/ready.rs
@@ -1,6 +1,6 @@
 //! Tests for channel readiness using the `Select` struct.
 
-#![allow(clippy::drop_copy)]
+#![allow(dropping_copy_types)]
 
 use std::any::Any;
 use std::cell::Cell;

--- a/crossbeam-channel/tests/select.rs
+++ b/crossbeam-channel/tests/select.rs
@@ -1,6 +1,6 @@
 //! Tests for channel selection using the `Select` struct.
 
-#![allow(clippy::drop_copy)]
+#![allow(dropping_copy_types)]
 
 use std::any::Any;
 use std::cell::Cell;

--- a/crossbeam-channel/tests/select.rs
+++ b/crossbeam-channel/tests/select.rs
@@ -1,7 +1,5 @@
 //! Tests for channel selection using the `Select` struct.
 
-#![allow(dropping_copy_types)]
-
 use std::any::Any;
 use std::cell::Cell;
 use std::thread;

--- a/crossbeam-channel/tests/select_macro.rs
+++ b/crossbeam-channel/tests/select_macro.rs
@@ -1,7 +1,7 @@
 //! Tests for the `select!` macro.
 
 #![forbid(unsafe_code)] // select! is safe.
-#![allow(dropping_copy_types, clippy::match_single_binding)]
+#![allow(clippy::match_single_binding)]
 
 use std::any::Any;
 use std::cell::Cell;
@@ -1212,32 +1212,32 @@ fn result_types() {
     let (_, r) = bounded::<i32>(0);
 
     select! {
-        recv(r) -> res => drop::<Result<i32, RecvError>>(res),
+        recv(r) -> res => { let _: Result<i32, RecvError> = res; },
     }
     select! {
-        recv(r) -> res => drop::<Result<i32, RecvError>>(res),
+        recv(r) -> res =>  { let _: Result<i32, RecvError> = res; },
         default => {}
     }
     select! {
-        recv(r) -> res => drop::<Result<i32, RecvError>>(res),
+        recv(r) -> res =>  { let _: Result<i32, RecvError> = res; },
         default(ms(0)) => {}
     }
 
     select! {
-        send(s, 0) -> res => drop::<Result<(), SendError<i32>>>(res),
+        send(s, 0) -> res => { let _: Result<(), SendError<i32>> = res; },
     }
     select! {
-        send(s, 0) -> res => drop::<Result<(), SendError<i32>>>(res),
+        send(s, 0) -> res =>  { let _: Result<(), SendError<i32>> = res; },
         default => {}
     }
     select! {
-        send(s, 0) -> res => drop::<Result<(), SendError<i32>>>(res),
+        send(s, 0) -> res =>  { let _: Result<(), SendError<i32>> = res; },
         default(ms(0)) => {}
     }
 
     select! {
-        send(s, 0) -> res => drop::<Result<(), SendError<i32>>>(res),
-        recv(r) -> res => drop::<Result<i32, RecvError>>(res),
+        send(s, 0) -> res =>  { let _: Result<(), SendError<i32>> = res; },
+        recv(r) -> res => { let _: Result<i32, RecvError> = res; },
     }
 }
 

--- a/crossbeam-channel/tests/select_macro.rs
+++ b/crossbeam-channel/tests/select_macro.rs
@@ -1,7 +1,7 @@
 //! Tests for the `select!` macro.
 
 #![forbid(unsafe_code)] // select! is safe.
-#![allow(clippy::drop_copy, clippy::match_single_binding)]
+#![allow(dropping_copy_types, clippy::match_single_binding)]
 
 use std::any::Any;
 use std::cell::Cell;

--- a/crossbeam-epoch/CHANGELOG.md
+++ b/crossbeam-epoch/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.9.15
+
+- Update `memoffset` to 0.9. (#981)
+
 # Version 0.9.14
 
 - Update `memoffset` to 0.8. (#955)

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-epoch"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-epoch-X.Y.Z" git tag
-version = "0.9.14"
+version = "0.9.15"
 edition = "2018"
 rust-version = "1.38"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -47,7 +47,7 @@ autocfg = "1"
 
 [dependencies]
 cfg-if = "1"
-memoffset = "0.8"
+memoffset = "0.9"
 scopeguard = { version = "1.1", default-features = false }
 
 # Enable the use of loom for concurrency testing.

--- a/crossbeam-epoch/src/deferred.rs
+++ b/crossbeam-epoch/src/deferred.rs
@@ -89,7 +89,7 @@ impl Deferred {
 
 #[cfg(all(test, not(crossbeam_loom)))]
 mod tests {
-    #![allow(clippy::drop_copy)]
+    #![allow(dropping_copy_types)]
 
     use super::Deferred;
     use std::cell::Cell;

--- a/crossbeam-epoch/src/deferred.rs
+++ b/crossbeam-epoch/src/deferred.rs
@@ -89,10 +89,9 @@ impl Deferred {
 
 #[cfg(all(test, not(crossbeam_loom)))]
 mod tests {
-    #![allow(dropping_copy_types)]
-
     use super::Deferred;
     use std::cell::Cell;
+    use std::convert::identity;
 
     #[test]
     fn on_stack() {
@@ -100,7 +99,7 @@ mod tests {
         let a = [0usize; 1];
 
         let d = Deferred::new(move || {
-            drop(a);
+            let _ = identity(a);
             fired.set(true);
         });
 
@@ -115,7 +114,7 @@ mod tests {
         let a = [0usize; 10];
 
         let d = Deferred::new(move || {
-            drop(a);
+            let _ = identity(a);
             fired.set(true);
         });
 

--- a/crossbeam-skiplist/src/base.rs
+++ b/crossbeam-skiplist/src/base.rs
@@ -1768,10 +1768,10 @@ impl<'a, K: 'a, V: 'a> RefIter<'a, K, V> {
     /// Decrements the reference count of `RefEntry` owned by the iterator.
     pub fn drop_impl(&mut self, guard: &Guard) {
         self.parent.check_guard(guard);
-        if let Some(e) = mem::replace(&mut self.head, None) {
+        if let Some(e) = self.head.take() {
             unsafe { e.node.decrement(guard) };
         }
-        if let Some(e) = mem::replace(&mut self.tail, None) {
+        if let Some(e) = self.tail.take() {
             unsafe { e.node.decrement(guard) };
         }
     }
@@ -1985,10 +1985,10 @@ where
     /// Decrements a reference count owned by this iterator.
     pub fn drop_impl(&mut self, guard: &Guard) {
         self.parent.check_guard(guard);
-        if let Some(e) = mem::replace(&mut self.head, None) {
+        if let Some(e) = self.head.take() {
             unsafe { e.node.decrement(guard) };
         }
-        if let Some(e) = mem::replace(&mut self.tail, None) {
+        if let Some(e) = self.tail.take() {
             unsafe { e.node.decrement(guard) };
         }
     }

--- a/crossbeam-utils/CHANGELOG.md
+++ b/crossbeam-utils/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.8.16
+
+- Improve implementation of `CachePadded`. (#967)
+
 # Version 0.8.15
 
 - Add `#[clippy::has_significant_drop]` to `ShardedLock{Read,Write}Guard`. (#958)

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-utils"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-utils-X.Y.Z" git tag
-version = "0.8.15"
+version = "0.8.16"
 edition = "2018"
 rust-version = "1.38"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-utils/src/cache_padded.rs
+++ b/crossbeam-utils/src/cache_padded.rs
@@ -14,7 +14,8 @@ use core::ops::{Deref, DerefMut};
 /// Cache lines are assumed to be N bytes long, depending on the architecture:
 ///
 /// * On x86-64, aarch64, and powerpc64, N = 128.
-/// * On arm, mips, mips64, and riscv64, N = 32.
+/// * On arm, mips, mips64, riscv32, riscv64, sparc, and hexagon, N = 32.
+/// * On m68k, N = 16.
 /// * On s390x, N = 256.
 /// * On all others, N = 64.
 ///
@@ -83,7 +84,7 @@ use core::ops::{Deref, DerefMut};
     ),
     repr(align(128))
 )]
-// arm, mips, mips64, and riscv64 have 32-byte cache line size.
+// arm, mips, mips64, riscv64, sparc, and hexagon have 32-byte cache line size.
 //
 // Sources:
 // - https://github.com/golang/go/blob/3dd58676054223962cd915bb0934d1f9f489d4d2/src/internal/cpu/cpu_arm.go#L7
@@ -91,25 +92,39 @@ use core::ops::{Deref, DerefMut};
 // - https://github.com/golang/go/blob/3dd58676054223962cd915bb0934d1f9f489d4d2/src/internal/cpu/cpu_mipsle.go#L7
 // - https://github.com/golang/go/blob/3dd58676054223962cd915bb0934d1f9f489d4d2/src/internal/cpu/cpu_mips64x.go#L9
 // - https://github.com/golang/go/blob/3dd58676054223962cd915bb0934d1f9f489d4d2/src/internal/cpu/cpu_riscv64.go#L7
+// - https://github.com/torvalds/linux/blob/3516bd729358a2a9b090c1905bd2a3fa926e24c6/arch/sparc/include/asm/cache.h#L17
+// - https://github.com/torvalds/linux/blob/3516bd729358a2a9b090c1905bd2a3fa926e24c6/arch/hexagon/include/asm/cache.h#L12
+//
+// riscv32 is assumed not to exceed the cache line size of riscv64.
 #[cfg_attr(
     any(
         target_arch = "arm",
         target_arch = "mips",
         target_arch = "mips64",
+        target_arch = "riscv32",
         target_arch = "riscv64",
+        target_arch = "sparc",
+        target_arch = "hexagon",
     ),
     repr(align(32))
 )]
+// m68k has 16-byte cache line size.
+//
+// Sources:
+// - https://github.com/torvalds/linux/blob/3516bd729358a2a9b090c1905bd2a3fa926e24c6/arch/m68k/include/asm/cache.h#L9
+#[cfg_attr(target_arch = "m68k", repr(align(16)))]
 // s390x has 256-byte cache line size.
 //
 // Sources:
 // - https://github.com/golang/go/blob/3dd58676054223962cd915bb0934d1f9f489d4d2/src/internal/cpu/cpu_s390x.go#L7
+// - https://github.com/torvalds/linux/blob/3516bd729358a2a9b090c1905bd2a3fa926e24c6/arch/s390/include/asm/cache.h#L13
 #[cfg_attr(target_arch = "s390x", repr(align(256)))]
-// x86 and wasm have 64-byte cache line size.
+// x86, wasm, and sparc64 have 64-byte cache line size.
 //
 // Sources:
 // - https://github.com/golang/go/blob/dda2991c2ea0c5914714469c4defc2562a907230/src/internal/cpu/cpu_x86.go#L9
 // - https://github.com/golang/go/blob/3dd58676054223962cd915bb0934d1f9f489d4d2/src/internal/cpu/cpu_wasm.go#L7
+// - https://github.com/torvalds/linux/blob/3516bd729358a2a9b090c1905bd2a3fa926e24c6/arch/sparc/include/asm/cache.h#L19
 //
 // All others are assumed to have 64-byte cache line size.
 #[cfg_attr(
@@ -120,7 +135,11 @@ use core::ops::{Deref, DerefMut};
         target_arch = "arm",
         target_arch = "mips",
         target_arch = "mips64",
+        target_arch = "riscv32",
         target_arch = "riscv64",
+        target_arch = "sparc",
+        target_arch = "hexagon",
+        target_arch = "m68k",
         target_arch = "s390x",
     )),
     repr(align(64))

--- a/crossbeam-utils/src/sync/sharded_lock.rs
+++ b/crossbeam-utils/src/sync/sharded_lock.rs
@@ -356,7 +356,7 @@ impl<T: ?Sized> ShardedLock<T> {
             for shard in self.shards[0..i].iter().rev() {
                 unsafe {
                     let dest: *mut _ = shard.write_guard.get();
-                    let guard = mem::replace(&mut *dest, None);
+                    let guard = (*dest).take();
                     drop(guard);
                 }
             }
@@ -526,7 +526,7 @@ impl<T: ?Sized> Drop for ShardedLockWriteGuard<'_, T> {
         for shard in self.lock.shards.iter().rev() {
             unsafe {
                 let dest: *mut _ = shard.write_guard.get();
-                let guard = mem::replace(&mut *dest, None);
+                let guard = (*dest).take();
                 drop(guard);
             }
         }

--- a/no_atomic.rs
+++ b/no_atomic.rs
@@ -19,8 +19,6 @@ const NO_ATOMIC_CAS: &[&str] = &[
 #[allow(dead_code)] // Only crossbeam-utils uses this.
 const NO_ATOMIC_64: &[&str] = &[
     "arm-linux-androideabi",
-    "armebv7r-none-eabi",
-    "armebv7r-none-eabihf",
     "armv4t-none-eabi",
     "armv4t-unknown-linux-gnueabi",
     "armv5te-none-eabi",
@@ -28,9 +26,6 @@ const NO_ATOMIC_64: &[&str] = &[
     "armv5te-unknown-linux-musleabi",
     "armv5te-unknown-linux-uclibceabi",
     "armv6k-nintendo-3ds",
-    "armv7-sony-vita-newlibeabihf",
-    "armv7r-none-eabi",
-    "armv7r-none-eabihf",
     "avr-unknown-gnu-atmega328",
     "hexagon-unknown-linux-musl",
     "m68k-unknown-linux-gnu",


### PR DESCRIPTION
- crossbeam-epoch 0.9.14 -> 0.9.15
  - Update `memoffset` to 0.9. (#981)
- crossbeam-utils 0.8.15 -> 0.8.16
  - Improve implementation of `CachePadded`. (#967)

Closes #986 