### PR TITLE
Miri: Use -Zmiri-tree-borrows instead of -Zmiri-disable-stacked-borrows

### DIFF
--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -19,26 +19,22 @@ MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-retag
     cargo miri test \
     -p crossbeam-channel 2>&1 | ts -i '%.s  '
 
-# -Zmiri-disable-stacked-borrows is needed for https://github.com/crossbeam-rs/crossbeam/issues/545
-MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-retag-fields -Zmiri-disable-isolation -Zmiri-disable-stacked-borrows" \
+# Use Tree Borrows instead of Stacked Borrows because epoch is not compatible with Stacked Borrows: https://github.com/crossbeam-rs/crossbeam/issues/545#issuecomment-1192785003
+MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-retag-fields -Zmiri-disable-isolation -Zmiri-tree-borrows" \
     cargo miri test \
-    -p crossbeam-epoch 2>&1 | ts -i '%.s  '
+    -p crossbeam-epoch \
+    -p crossbeam 2>&1 | ts -i '%.s  '
 
+# Use Tree Borrows instead of Stacked Borrows because epoch is not compatible with Stacked Borrows: https://github.com/crossbeam-rs/crossbeam/issues/545#issuecomment-1192785003
 # -Zmiri-ignore-leaks is needed for https://github.com/crossbeam-rs/crossbeam/issues/614
-# -Zmiri-disable-stacked-borrows is needed for https://github.com/crossbeam-rs/crossbeam/issues/545
-MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-retag-fields -Zmiri-disable-isolation -Zmiri-disable-stacked-borrows -Zmiri-ignore-leaks" \
+MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-retag-fields -Zmiri-disable-isolation -Zmiri-tree-borrows -Zmiri-ignore-leaks" \
     cargo miri test \
     -p crossbeam-skiplist 2>&1 | ts -i '%.s  '
 
-# -Zmiri-disable-stacked-borrows is needed for https://github.com/crossbeam-rs/crossbeam/issues/545
+# Use Tree Borrows instead of Stacked Borrows because epoch is not compatible with Stacked Borrows: https://github.com/crossbeam-rs/crossbeam/issues/545#issuecomment-1192785003
 # -Zmiri-compare-exchange-weak-failure-rate=0.0 is needed because some sequential tests (e.g.,
 # doctest of Stealer::steal) incorrectly assume that sequential weak CAS will never fail.
 # -Zmiri-preemption-rate=0 is needed because this code technically has UB and Miri catches that.
-MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-retag-fields -Zmiri-disable-stacked-borrows -Zmiri-compare-exchange-weak-failure-rate=0.0 -Zmiri-preemption-rate=0" \
+MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-retag-fields -Zmiri-disable-isolation -Zmiri-tree-borrows -Zmiri-compare-exchange-weak-failure-rate=0.0 -Zmiri-preemption-rate=0" \
     cargo miri test \
     -p crossbeam-deque 2>&1 | ts -i '%.s  '
-
-# -Zmiri-disable-stacked-borrows is needed for https://github.com/crossbeam-rs/crossbeam/issues/545
-MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-retag-fields -Zmiri-disable-stacked-borrows" \
-    cargo miri test \
-    -p crossbeam 2>&1 | ts -i '%.s  '

--- a/crossbeam-epoch/build.rs
+++ b/crossbeam-epoch/build.rs
@@ -18,6 +18,8 @@ include!("no_atomic.rs");
 include!("build-common.rs");
 
 fn main() {
+    println!("cargo:rerun-if-changed=no_atomic.rs");
+
     let target = match env::var("TARGET") {
         Ok(target) => convert_custom_linux_target(target),
         Err(e) => {
@@ -52,6 +54,4 @@ fn main() {
     if !cfg.probe_rustc_version(1, 61) {
         println!("cargo:rustc-cfg=crossbeam_no_const_fn_trait_bound");
     }
-
-    println!("cargo:rerun-if-changed=no_atomic.rs");
 }

--- a/crossbeam-queue/build.rs
+++ b/crossbeam-queue/build.rs
@@ -18,6 +18,8 @@ include!("no_atomic.rs");
 include!("build-common.rs");
 
 fn main() {
+    println!("cargo:rerun-if-changed=no_atomic.rs");
+
     let target = match env::var("TARGET") {
         Ok(target) => convert_custom_linux_target(target),
         Err(e) => {
@@ -36,6 +38,4 @@ fn main() {
     if NO_ATOMIC_CAS.contains(&&*target) {
         println!("cargo:rustc-cfg=crossbeam_no_atomic_cas");
     }
-
-    println!("cargo:rerun-if-changed=no_atomic.rs");
 }

--- a/crossbeam-skiplist/build.rs
+++ b/crossbeam-skiplist/build.rs
@@ -18,6 +18,8 @@ include!("no_atomic.rs");
 include!("build-common.rs");
 
 fn main() {
+    println!("cargo:rerun-if-changed=no_atomic.rs");
+
     let target = match env::var("TARGET") {
         Ok(target) => convert_custom_linux_target(target),
         Err(e) => {
@@ -36,6 +38,4 @@ fn main() {
     if NO_ATOMIC_CAS.contains(&&*target) {
         println!("cargo:rustc-cfg=crossbeam_no_atomic_cas");
     }
-
-    println!("cargo:rerun-if-changed=no_atomic.rs");
 }

--- a/crossbeam-utils/build.rs
+++ b/crossbeam-utils/build.rs
@@ -30,6 +30,8 @@ include!("no_atomic.rs");
 include!("build-common.rs");
 
 fn main() {
+    println!("cargo:rerun-if-changed=no_atomic.rs");
+
     let target = match env::var("TARGET") {
         Ok(target) => convert_custom_linux_target(target),
         Err(e) => {
@@ -57,5 +59,9 @@ fn main() {
         // Otherwise, assuming `"max-atomic-width" == 64` or `"max-atomic-width" == 128`.
     }
 
-    println!("cargo:rerun-if-changed=no_atomic.rs");
+    // `cfg(sanitize = "..")` is not stabilized.
+    let sanitize = env::var("CARGO_CFG_SANITIZE").unwrap_or_default();
+    if sanitize.contains("thread") {
+        println!("cargo:rustc-cfg=crossbeam_sanitize_thread");
+    }
 }


### PR DESCRIPTION
epoch is not compatible with SB but compatible with TB.

cc https://github.com/crossbeam-rs/crossbeam/pull/871 https://github.com/crossbeam-rs/crossbeam/issues/545 https://github.com/crossbeam-rs/crossbeam/issues/878