### PR TITLE
Remove timing assumptions from `wait_and_drop` test

### DIFF
--- a/crossbeam-utils/tests/wait_group.rs
+++ b/crossbeam-utils/tests/wait_group.rs
@@ -36,25 +36,27 @@ fn wait() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)] // this test makes timing assumptions, but Miri is so slow it violates them
 fn wait_and_drop() {
     let wg = WaitGroup::new();
+    let wg2 = WaitGroup::new();
     let (tx, rx) = mpsc::channel();
 
     for _ in 0..THREADS {
         let wg = wg.clone();
+        let wg2 = wg2.clone();
         let tx = tx.clone();
 
         thread::spawn(move || {
-            thread::sleep(Duration::from_millis(100));
+            wg2.wait();
             tx.send(()).unwrap();
             drop(wg);
         });
     }
 
-    // At this point, all spawned threads should be in `thread::sleep`, so we shouldn't get anything
-    // from the channel.
+    // At this point, no thread has gotten past `wg2.wait()`, so we shouldn't get anything from the
+    // channel.
     assert!(rx.try_recv().is_err());
+    drop(wg2);
 
     wg.wait();
 


### PR DESCRIPTION
This test failed in Android's CI system.