### PR TITLE
Draft: Add peek to ArrayQueue<T> where T: Copy

### DIFF
--- a/crossbeam-queue/src/array_queue.rs
+++ b/crossbeam-queue/src/array_queue.rs
@@ -532,7 +532,7 @@ where
                         Ordering::Relaxed,
                     ) {
                         Ok(_) => {
-                            let msg = unsafe { slot.value.get().read().assume_init() }.clone();
+                            let msg = unsafe { slot.value.get().read().assume_init() };
 
                             slot.peek_lock.fetch_sub(1, Ordering::SeqCst);
 

--- a/crossbeam-queue/tests/array_queue.rs
+++ b/crossbeam-queue/tests/array_queue.rs
@@ -169,7 +169,9 @@ fn spsc_ring_buffer() {
                 0 if q.is_empty() => break,
 
                 _ => {
+                    q.peek();
                     while let Some(n) = q.pop() {
+                        q.peek();
                         v[n].fetch_add(1, Ordering::SeqCst);
                     }
                 }
@@ -209,7 +211,9 @@ fn mpmc() {
             scope.spawn(|_| {
                 for _ in 0..COUNT {
                     let n = loop {
+                        q.peek();
                         if let Some(x) = q.pop() {
+                            q.peek();
                             break x;
                         }
                     };
@@ -251,7 +255,9 @@ fn mpmc_ring_buffer() {
                     0 if q.is_empty() => break,
 
                     _ => {
+                        q.peek();
                         while let Some(n) = q.pop() {
+                            q.peek();
                             v[n].fetch_add(1, Ordering::SeqCst);
                         }
                     }


### PR DESCRIPTION
Hi 👋 , I'm not sure if there is appetite in general for this feature but I personally found it useful. I would be happy to add the symmetric method to `SegQueue` as well. I noticed issue #30 but I figured it does not apply to this specialization. Also happy to just leave this be if it's not useful to anyone.