### PR TITLE
AtomicCell: Use atomic-maybe-uninit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,10 @@ jobs:
           - rust: nightly
             os: ubuntu-latest
             target: armv5te-unknown-linux-gnueabi
+          # Test target without stable inline asm support.
+          - rust: stable
+            os: ubuntu-latest
+            target: sparc64-unknown-linux-gnu
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -26,9 +26,10 @@ std = []
 
 # Enable `atomic` module.
 # This requires Rust 1.60.
-atomic = []
+atomic = ["atomic-maybe-uninit"]
 
 [dependencies]
+atomic-maybe-uninit = { version = "0.3.4", optional = true }
 
 # Enable the use of loom for concurrency testing.
 #

--- a/crossbeam-utils/build.rs
+++ b/crossbeam-utils/build.rs
@@ -17,7 +17,7 @@ include!("build-common.rs");
 
 fn main() {
     println!("cargo:rerun-if-changed=no_atomic.rs");
-    println!("cargo:rustc-check-cfg=cfg(crossbeam_no_atomic,crossbeam_sanitize_thread)");
+    println!("cargo:rustc-check-cfg=cfg(crossbeam_no_atomic,crossbeam_sanitize_thread,crossbeam_atomic_cell_force_fallback)");
 
     let target = match env::var("TARGET") {
         Ok(target) => convert_custom_linux_target(target),
@@ -39,8 +39,10 @@ fn main() {
     }
 
     // `cfg(sanitize = "..")` is not stabilized.
-    let sanitize = env::var("CARGO_CFG_SANITIZE").unwrap_or_default();
-    if sanitize.contains("thread") {
-        println!("cargo:rustc-cfg=crossbeam_sanitize_thread");
+    if let Ok(sanitize) = env::var("CARGO_CFG_SANITIZE") {
+        if sanitize.contains("thread") {
+            println!("cargo:rustc-cfg=crossbeam_sanitize_thread");
+        }
+        println!("cargo:rustc-cfg=crossbeam_atomic_cell_force_fallback");
     }
 }

--- a/crossbeam-utils/tests/atomic_cell.rs
+++ b/crossbeam-utils/tests/atomic_cell.rs
@@ -4,48 +4,69 @@ use std::sync::atomic::Ordering::SeqCst;
 
 use crossbeam_utils::atomic::AtomicCell;
 
+// Always use fallback for now on environments that do not support inline assembly.
+fn always_use_fallback() -> bool {
+    atomic_maybe_uninit::cfg_has_atomic_cas! {
+        cfg!(any(
+            miri,
+            crossbeam_loom,
+            crossbeam_atomic_cell_force_fallback,
+        ))
+    }
+    atomic_maybe_uninit::cfg_no_atomic_cas! { true }
+}
+
 #[test]
 fn is_lock_free() {
+    let always_use_fallback = always_use_fallback();
+
     struct UsizeWrap(#[allow(dead_code)] usize);
     struct U8Wrap(#[allow(dead_code)] bool);
     struct I16Wrap(#[allow(dead_code)] i16);
     #[repr(align(8))]
     struct U64Align8(#[allow(dead_code)] u64);
 
-    assert!(AtomicCell::<usize>::is_lock_free());
-    assert!(AtomicCell::<isize>::is_lock_free());
-    assert!(AtomicCell::<UsizeWrap>::is_lock_free());
+    assert_eq!(AtomicCell::<usize>::is_lock_free(), !always_use_fallback);
+    assert_eq!(AtomicCell::<isize>::is_lock_free(), !always_use_fallback);
+    assert_eq!(
+        AtomicCell::<UsizeWrap>::is_lock_free(),
+        !always_use_fallback
+    );
 
     assert!(AtomicCell::<()>::is_lock_free());
 
-    assert!(AtomicCell::<u8>::is_lock_free());
-    assert!(AtomicCell::<i8>::is_lock_free());
-    assert!(AtomicCell::<bool>::is_lock_free());
-    assert!(AtomicCell::<U8Wrap>::is_lock_free());
+    assert_eq!(AtomicCell::<u8>::is_lock_free(), !always_use_fallback);
+    assert_eq!(AtomicCell::<i8>::is_lock_free(), !always_use_fallback);
+    assert_eq!(AtomicCell::<bool>::is_lock_free(), !always_use_fallback);
+    assert_eq!(AtomicCell::<U8Wrap>::is_lock_free(), !always_use_fallback);
 
-    assert!(AtomicCell::<u16>::is_lock_free());
-    assert!(AtomicCell::<i16>::is_lock_free());
-    assert!(AtomicCell::<I16Wrap>::is_lock_free());
+    assert_eq!(AtomicCell::<u16>::is_lock_free(), !always_use_fallback);
+    assert_eq!(AtomicCell::<i16>::is_lock_free(), !always_use_fallback);
+    assert_eq!(AtomicCell::<I16Wrap>::is_lock_free(), !always_use_fallback);
 
-    assert!(AtomicCell::<u32>::is_lock_free());
-    assert!(AtomicCell::<i32>::is_lock_free());
+    assert_eq!(AtomicCell::<u32>::is_lock_free(), !always_use_fallback);
+    assert_eq!(AtomicCell::<i32>::is_lock_free(), !always_use_fallback);
 
     // Sizes of both types must be equal, and the alignment of `u64` must be greater or equal than
     // that of `AtomicU64`. In i686-unknown-linux-gnu, the alignment of `u64` is `4` and alignment
     // of `AtomicU64` is `8`, so `AtomicCell<u64>` is not lock-free.
     assert_eq!(
         AtomicCell::<u64>::is_lock_free(),
-        cfg!(target_has_atomic = "64") && std::mem::align_of::<u64>() == 8
+        cfg!(target_has_atomic = "64") && std::mem::align_of::<u64>() == 8 && !always_use_fallback
     );
     assert_eq!(mem::size_of::<U64Align8>(), 8);
     assert_eq!(mem::align_of::<U64Align8>(), 8);
     assert_eq!(
         AtomicCell::<U64Align8>::is_lock_free(),
-        cfg!(target_has_atomic = "64")
+        cfg!(target_has_atomic = "64") && !always_use_fallback
     );
 
-    // AtomicU128 is unstable
-    assert!(!AtomicCell::<u128>::is_lock_free());
+    assert_eq!(
+        AtomicCell::<u128>::is_lock_free(),
+        cfg!(target_has_atomic = "128")
+            && std::mem::align_of::<u128>() == 16
+            && !always_use_fallback
+    );
 }
 
 #[test]
@@ -320,7 +341,7 @@ fn issue_748() {
     assert_eq!(mem::size_of::<Test>(), 8);
     assert_eq!(
         AtomicCell::<Test>::is_lock_free(),
-        cfg!(target_has_atomic = "64")
+        cfg!(target_has_atomic = "64") && !always_use_fallback()
     );
     let x = AtomicCell::new(Test::FieldLess);
     assert_eq!(x.load(), Test::FieldLess);


### PR DESCRIPTION
This fixes UB when lock-free and the value has uninitialized bytes, by using [atomic-maybe-uninit](https://github.com/taiki-e/atomic-maybe-uninit) crate.
Fixes #315
Fixes #748

Also, this makes 128-bit atomics lock-free on some platforms.
Closes https://github.com/crossbeam-rs/rfcs/issues/13

Currently, this patch always uses fallback (seqlock) on environments that do not support inline assembly, such as Miri.
It is possible to use atomic-maybe-uninit crate to fix UB of concurrent access with volatile read/write in seqlock/deque (#744, #859), but that is not included in this PR and is left to subsequent PRs.

---

cc @RalfJung 