### PR TITLE
Add StaticArrayQueue, a queue that can be used as a global static variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,9 @@ jobs:
       matrix:
         # aarch64/x86_64 macOS and aarch64 Linux are tested on Cirrus CI
         include:
-          - rust: '1.57'
+          - rust: '1.59'
             os: ubuntu-latest
-          - rust: '1.57'
+          - rust: '1.59'
             os: windows-latest
           - rust: stable
             os: ubuntu-latest
@@ -83,7 +83,7 @@ jobs:
       fail-fast: false
       matrix:
         rust:
-          - '1.57'
+          - '1.59'
           - nightly
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,9 @@ jobs:
       matrix:
         # aarch64/x86_64 macOS and aarch64 Linux are tested on Cirrus CI
         include:
-          - rust: '1.56'
+          - rust: '1.57'
             os: ubuntu-latest
-          - rust: '1.56'
+          - rust: '1.57'
             os: windows-latest
           - rust: stable
             os: ubuntu-latest
@@ -83,7 +83,7 @@ jobs:
       fail-fast: false
       matrix:
         rust:
-          - '1.56'
+          - '1.57'
           - nightly
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,9 @@ jobs:
       matrix:
         # aarch64/x86_64 macOS and aarch64 Linux are tested on Cirrus CI
         include:
-          - rust: '1.38'
+          - rust: '1.51'
             os: ubuntu-latest
-          - rust: '1.38'
+          - rust: '1.51'
             os: windows-latest
           - rust: stable
             os: ubuntu-latest
@@ -83,7 +83,7 @@ jobs:
       fail-fast: false
       matrix:
         rust:
-          - '1.38'
+          - '1.51'
           - nightly
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,9 @@ jobs:
       matrix:
         # aarch64/x86_64 macOS and aarch64 Linux are tested on Cirrus CI
         include:
-          - rust: '1.59'
+          - rust: '1.61'
             os: ubuntu-latest
-          - rust: '1.59'
+          - rust: '1.61'
             os: windows-latest
           - rust: stable
             os: ubuntu-latest
@@ -83,7 +83,7 @@ jobs:
       fail-fast: false
       matrix:
         rust:
-          - '1.59'
+          - '1.61'
           - nightly
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,9 @@ jobs:
       matrix:
         # aarch64/x86_64 macOS and aarch64 Linux are tested on Cirrus CI
         include:
-          - rust: '1.51'
+          - rust: '1.56'
             os: ubuntu-latest
-          - rust: '1.51'
+          - rust: '1.56'
             os: windows-latest
           - rust: stable
             os: ubuntu-latest
@@ -83,7 +83,7 @@ jobs:
       fail-fast: false
       matrix:
         rust:
-          - '1.51'
+          - '1.56'
           - nightly
     runs-on: ubuntu-latest
     steps:

--- a/crossbeam-queue/examples/static_queue.rs
+++ b/crossbeam-queue/examples/static_queue.rs
@@ -1,0 +1,22 @@
+use std::{
+    thread::{self, sleep},
+    time::Duration,
+};
+
+use crossbeam_queue::StaticArrayQueue;
+
+static QUEUE: StaticArrayQueue<u32, 10> = StaticArrayQueue::new();
+
+fn main() {
+    thread::spawn(|| loop {
+        while let Some(element) = QUEUE.pop() {
+            println!("Got element: {}", element);
+        }
+        sleep(Duration::from_millis(1));
+    });
+
+    for i in 0..10 {
+        QUEUE.push(i).unwrap();
+        sleep(Duration::from_millis(10));
+    }
+}

--- a/crossbeam-queue/src/array_queue.rs
+++ b/crossbeam-queue/src/array_queue.rs
@@ -1,27 +1,7 @@
-//! The implementation is based on Dmitry Vyukov's bounded MPMC queue.
-//!
-//! Source:
-//!   - <http://www.1024cores.net/home/lock-free-algorithms/queues/bounded-mpmc-queue>
-
 use alloc::boxed::Box;
-use core::cell::UnsafeCell;
 use core::fmt;
-use core::mem::MaybeUninit;
-use core::sync::atomic::{self, AtomicUsize, Ordering};
 
-use crossbeam_utils::{Backoff, CachePadded};
-
-/// A slot in a queue.
-struct Slot<T> {
-    /// The current stamp.
-    ///
-    /// If the stamp equals the tail, this node will be next written to. If it equals head + 1,
-    /// this node will be next read from.
-    stamp: AtomicUsize,
-
-    /// The value in this slot.
-    value: UnsafeCell<MaybeUninit<T>>,
-}
+use super::array_queue_impl::{ArrayQueueImpl, IntoIterImpl, Slot};
 
 /// A bounded multi-producer multi-consumer queue.
 ///
@@ -47,34 +27,11 @@ struct Slot<T> {
 /// assert_eq!(q.pop(), Some('a'));
 /// ```
 pub struct ArrayQueue<T> {
-    /// The head of the queue.
-    ///
-    /// This value is a "stamp" consisting of an index into the buffer and a lap, but packed into a
-    /// single `usize`. The lower bits represent the index, while the upper bits represent the lap.
-    ///
-    /// Elements are popped from the head of the queue.
-    head: CachePadded<AtomicUsize>,
-
-    /// The tail of the queue.
-    ///
-    /// This value is a "stamp" consisting of an index into the buffer and a lap, but packed into a
-    /// single `usize`. The lower bits represent the index, while the upper bits represent the lap.
-    ///
-    /// Elements are pushed into the tail of the queue.
-    tail: CachePadded<AtomicUsize>,
-
-    /// The buffer holding slots.
-    buffer: Box<[Slot<T>]>,
-
-    /// The queue capacity.
-    cap: usize,
-
-    /// A stamp with the value of `{ lap: 1, index: 0 }`.
-    one_lap: usize,
+    /// The queue implementation.
+    queue: ArrayQueueImpl<T, Box<[Slot<T>]>>,
 }
 
 unsafe impl<T: Send> Sync for ArrayQueue<T> {}
-unsafe impl<T: Send> Send for ArrayQueue<T> {}
 
 impl<T> ArrayQueue<T> {
     /// Creates a new bounded queue with the given capacity.
@@ -91,96 +48,12 @@ impl<T> ArrayQueue<T> {
     /// let q = ArrayQueue::<i32>::new(100);
     /// ```
     pub fn new(cap: usize) -> ArrayQueue<T> {
-        assert!(cap > 0, "capacity must be non-zero");
-
-        // Head is initialized to `{ lap: 0, index: 0 }`.
-        // Tail is initialized to `{ lap: 0, index: 0 }`.
-        let head = 0;
-        let tail = 0;
-
         // Allocate a buffer of `cap` slots initialized
         // with stamps.
-        let buffer: Box<[Slot<T>]> = (0..cap)
-            .map(|i| {
-                // Set the stamp to `{ lap: 0, index: i }`.
-                Slot {
-                    stamp: AtomicUsize::new(i),
-                    value: UnsafeCell::new(MaybeUninit::uninit()),
-                }
-            })
-            .collect();
-
-        // One lap is the smallest power of two greater than `cap`.
-        let one_lap = (cap + 1).next_power_of_two();
+        let buffer: Box<[Slot<T>]> = (0..cap).map(Slot::new).collect();
 
         ArrayQueue {
-            buffer,
-            cap,
-            one_lap,
-            head: CachePadded::new(AtomicUsize::new(head)),
-            tail: CachePadded::new(AtomicUsize::new(tail)),
-        }
-    }
-
-    fn push_or_else<F>(&self, mut value: T, f: F) -> Result<(), T>
-    where
-        F: Fn(T, usize, usize, &Slot<T>) -> Result<T, T>,
-    {
-        let backoff = Backoff::new();
-        let mut tail = self.tail.load(Ordering::Relaxed);
-
-        loop {
-            // Deconstruct the tail.
-            let index = tail & (self.one_lap - 1);
-            let lap = tail & !(self.one_lap - 1);
-
-            let new_tail = if index + 1 < self.cap {
-                // Same lap, incremented index.
-                // Set to `{ lap: lap, index: index + 1 }`.
-                tail + 1
-            } else {
-                // One lap forward, index wraps around to zero.
-                // Set to `{ lap: lap.wrapping_add(1), index: 0 }`.
-                lap.wrapping_add(self.one_lap)
-            };
-
-            // Inspect the corresponding slot.
-            debug_assert!(index < self.buffer.len());
-            let slot = unsafe { self.buffer.get_unchecked(index) };
-            let stamp = slot.stamp.load(Ordering::Acquire);
-
-            // If the tail and the stamp match, we may attempt to push.
-            if tail == stamp {
-                // Try moving the tail.
-                match self.tail.compare_exchange_weak(
-                    tail,
-                    new_tail,
-                    Ordering::SeqCst,
-                    Ordering::Relaxed,
-                ) {
-                    Ok(_) => {
-                        // Write the value into the slot and update the stamp.
-                        unsafe {
-                            slot.value.get().write(MaybeUninit::new(value));
-                        }
-                        slot.stamp.store(tail + 1, Ordering::Release);
-                        return Ok(());
-                    }
-                    Err(t) => {
-                        tail = t;
-                        backoff.spin();
-                    }
-                }
-            } else if stamp.wrapping_add(self.one_lap) == tail + 1 {
-                atomic::fence(Ordering::SeqCst);
-                value = f(value, tail, new_tail, slot)?;
-                backoff.spin();
-                tail = self.tail.load(Ordering::Relaxed);
-            } else {
-                // Snooze because we need to wait for the stamp to get updated.
-                backoff.snooze();
-                tail = self.tail.load(Ordering::Relaxed);
-            }
+            queue: ArrayQueueImpl::new(buffer, cap),
         }
     }
 
@@ -199,17 +72,7 @@ impl<T> ArrayQueue<T> {
     /// assert_eq!(q.push(20), Err(20));
     /// ```
     pub fn push(&self, value: T) -> Result<(), T> {
-        self.push_or_else(value, |v, tail, _, _| {
-            let head = self.head.load(Ordering::Relaxed);
-
-            // If the head lags one lap behind the tail as well...
-            if head.wrapping_add(self.one_lap) == tail {
-                // ...then the queue is full.
-                Err(v)
-            } else {
-                Ok(v)
-            }
-        })
+        self.queue.push(value)
     }
 
     /// Pushes an element into the queue, replacing the oldest element if necessary.
@@ -230,31 +93,7 @@ impl<T> ArrayQueue<T> {
     /// assert_eq!(q.pop(), Some(20));
     /// ```
     pub fn force_push(&self, value: T) -> Option<T> {
-        self.push_or_else(value, |v, tail, new_tail, slot| {
-            let head = tail.wrapping_sub(self.one_lap);
-            let new_head = new_tail.wrapping_sub(self.one_lap);
-
-            // Try moving the head.
-            if self
-                .head
-                .compare_exchange_weak(head, new_head, Ordering::SeqCst, Ordering::Relaxed)
-                .is_ok()
-            {
-                // Move the tail.
-                self.tail.store(new_tail, Ordering::SeqCst);
-
-                // Swap the previous value.
-                let old = unsafe { slot.value.get().replace(MaybeUninit::new(v)).assume_init() };
-
-                // Update the stamp.
-                slot.stamp.store(tail + 1, Ordering::Release);
-
-                Err(old)
-            } else {
-                Ok(v)
-            }
-        })
-        .err()
+        self.queue.force_push(value)
     }
 
     /// Attempts to pop an element from the queue.
@@ -273,67 +112,7 @@ impl<T> ArrayQueue<T> {
     /// assert!(q.pop().is_none());
     /// ```
     pub fn pop(&self) -> Option<T> {
-        let backoff = Backoff::new();
-        let mut head = self.head.load(Ordering::Relaxed);
-
-        loop {
-            // Deconstruct the head.
-            let index = head & (self.one_lap - 1);
-            let lap = head & !(self.one_lap - 1);
-
-            // Inspect the corresponding slot.
-            debug_assert!(index < self.buffer.len());
-            let slot = unsafe { self.buffer.get_unchecked(index) };
-            let stamp = slot.stamp.load(Ordering::Acquire);
-
-            // If the the stamp is ahead of the head by 1, we may attempt to pop.
-            if head + 1 == stamp {
-                let new = if index + 1 < self.cap {
-                    // Same lap, incremented index.
-                    // Set to `{ lap: lap, index: index + 1 }`.
-                    head + 1
-                } else {
-                    // One lap forward, index wraps around to zero.
-                    // Set to `{ lap: lap.wrapping_add(1), index: 0 }`.
-                    lap.wrapping_add(self.one_lap)
-                };
-
-                // Try moving the head.
-                match self.head.compare_exchange_weak(
-                    head,
-                    new,
-                    Ordering::SeqCst,
-                    Ordering::Relaxed,
-                ) {
-                    Ok(_) => {
-                        // Read the value from the slot and update the stamp.
-                        let msg = unsafe { slot.value.get().read().assume_init() };
-                        slot.stamp
-                            .store(head.wrapping_add(self.one_lap), Ordering::Release);
-                        return Some(msg);
-                    }
-                    Err(h) => {
-                        head = h;
-                        backoff.spin();
-                    }
-                }
-            } else if stamp == head {
-                atomic::fence(Ordering::SeqCst);
-                let tail = self.tail.load(Ordering::Relaxed);
-
-                // If the tail equals the head, that means the channel is empty.
-                if tail == head {
-                    return None;
-                }
-
-                backoff.spin();
-                head = self.head.load(Ordering::Relaxed);
-            } else {
-                // Snooze because we need to wait for the stamp to get updated.
-                backoff.snooze();
-                head = self.head.load(Ordering::Relaxed);
-            }
-        }
+        self.queue.pop()
     }
 
     /// Returns the capacity of the queue.
@@ -348,7 +127,7 @@ impl<T> ArrayQueue<T> {
     /// assert_eq!(q.capacity(), 100);
     /// ```
     pub fn capacity(&self) -> usize {
-        self.cap
+        self.queue.capacity()
     }
 
     /// Returns `true` if the queue is empty.
@@ -365,15 +144,7 @@ impl<T> ArrayQueue<T> {
     /// assert!(!q.is_empty());
     /// ```
     pub fn is_empty(&self) -> bool {
-        let head = self.head.load(Ordering::SeqCst);
-        let tail = self.tail.load(Ordering::SeqCst);
-
-        // Is the tail lagging one lap behind head?
-        // Is the tail equal to the head?
-        //
-        // Note: If the head changes just before we load the tail, that means there was a moment
-        // when the channel was not empty, so it is safe to just return `false`.
-        tail == head
+        self.queue.is_empty()
     }
 
     /// Returns `true` if the queue is full.
@@ -390,14 +161,7 @@ impl<T> ArrayQueue<T> {
     /// assert!(q.is_full());
     /// ```
     pub fn is_full(&self) -> bool {
-        let tail = self.tail.load(Ordering::SeqCst);
-        let head = self.head.load(Ordering::SeqCst);
-
-        // Is the head lagging one lap behind tail?
-        //
-        // Note: If the tail changes just before we load the head, that means there was a moment
-        // when the queue was not full, so it is safe to just return `false`.
-        head.wrapping_add(self.one_lap) == tail
+        self.queue.is_full()
     }
 
     /// Returns the number of elements in the queue.
@@ -417,65 +181,7 @@ impl<T> ArrayQueue<T> {
     /// assert_eq!(q.len(), 2);
     /// ```
     pub fn len(&self) -> usize {
-        loop {
-            // Load the tail, then load the head.
-            let tail = self.tail.load(Ordering::SeqCst);
-            let head = self.head.load(Ordering::SeqCst);
-
-            // If the tail didn't change, we've got consistent values to work with.
-            if self.tail.load(Ordering::SeqCst) == tail {
-                let hix = head & (self.one_lap - 1);
-                let tix = tail & (self.one_lap - 1);
-
-                return if hix < tix {
-                    tix - hix
-                } else if hix > tix {
-                    self.cap - hix + tix
-                } else if tail == head {
-                    0
-                } else {
-                    self.cap
-                };
-            }
-        }
-    }
-}
-
-impl<T> Drop for ArrayQueue<T> {
-    fn drop(&mut self) {
-        // Get the index of the head.
-        let head = *self.head.get_mut();
-        let tail = *self.tail.get_mut();
-
-        let hix = head & (self.one_lap - 1);
-        let tix = tail & (self.one_lap - 1);
-
-        let len = if hix < tix {
-            tix - hix
-        } else if hix > tix {
-            self.cap - hix + tix
-        } else if tail == head {
-            0
-        } else {
-            self.cap
-        };
-
-        // Loop over all slots that hold a message and drop them.
-        for i in 0..len {
-            // Compute the index of the next slot holding a message.
-            let index = if hix + i < self.cap {
-                hix + i
-            } else {
-                hix + i - self.cap
-            };
-
-            unsafe {
-                debug_assert!(index < self.buffer.len());
-                let slot = self.buffer.get_unchecked_mut(index);
-                let value = &mut *slot.value.get();
-                value.as_mut_ptr().drop_in_place();
-            }
-        }
+        self.queue.len()
     }
 }
 
@@ -504,33 +210,6 @@ impl<T> Iterator for IntoIter<T> {
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let value = &mut self.value;
-        let head = *value.head.get_mut();
-        if value.head.get_mut() != value.tail.get_mut() {
-            let index = head & (value.one_lap - 1);
-            let lap = head & !(value.one_lap - 1);
-            // SAFETY: We have mutable access to this, so we can read without
-            // worrying about concurrency. Furthermore, we know this is
-            // initialized because it is the value pointed at by `value.head`
-            // and this is a non-empty queue.
-            let val = unsafe {
-                debug_assert!(index < value.buffer.len());
-                let slot = value.buffer.get_unchecked_mut(index);
-                slot.value.get().read().assume_init()
-            };
-            let new = if index + 1 < value.cap {
-                // Same lap, incremented index.
-                // Set to `{ lap: lap, index: index + 1 }`.
-                head + 1
-            } else {
-                // One lap forward, index wraps around to zero.
-                // Set to `{ lap: lap.wrapping_add(1), index: 0 }`.
-                lap.wrapping_add(value.one_lap)
-            };
-            *value.head.get_mut() = new;
-            Some(val)
-        } else {
-            None
-        }
+        IntoIterImpl::new(&mut self.value.queue).next()
     }
 }

--- a/crossbeam-queue/src/array_queue_impl.rs
+++ b/crossbeam-queue/src/array_queue_impl.rs
@@ -1,0 +1,521 @@
+//! The implementation is based on Dmitry Vyukov's bounded MPMC queue.
+//!
+//! Source:
+//!   - <http://www.1024cores.net/home/lock-free-algorithms/queues/bounded-mpmc-queue>
+
+use core::cell::UnsafeCell;
+use core::mem::MaybeUninit;
+use core::sync::atomic::{self, AtomicUsize, Ordering};
+
+use crossbeam_utils::{Backoff, CachePadded};
+
+/// A slot in a queue.
+pub(crate) struct Slot<T> {
+    /// The current stamp.
+    ///
+    /// If the stamp equals the tail, this node will be next written to. If it equals head + 1,
+    /// this node will be next read from.
+    stamp: AtomicUsize,
+
+    /// The value in this slot.
+    value: UnsafeCell<MaybeUninit<T>>,
+}
+
+impl<T> Slot<T> {
+    pub(crate) const fn new(array_pos: usize) -> Self {
+        // Set the stamp to `{ lap: 0, index: i }`.
+        Self {
+            stamp: AtomicUsize::new(array_pos),
+            value: UnsafeCell::new(MaybeUninit::uninit()),
+        }
+    }
+}
+
+/// A bounded multi-producer multi-consumer queue.
+///
+/// This queue allocates a fixed-capacity buffer on construction, which is used to store pushed
+/// elements. The queue cannot hold more elements than the buffer allows. Attempting to push an
+/// element into a full queue will fail. Alternatively, [`force_push`] makes it possible for
+/// this queue to be used as a ring-buffer. Having a buffer allocated upfront makes this queue
+/// a bit faster than [`SegQueue`].
+///
+/// [`force_push`]: ArrayQueue::force_push
+/// [`SegQueue`]: super::SegQueue
+///
+/// # Examples
+///
+/// ```
+/// use crossbeam_queue::ArrayQueue;
+///
+/// let q = ArrayQueue::new(2);
+///
+/// assert_eq!(q.push('a'), Ok(()));
+/// assert_eq!(q.push('b'), Ok(()));
+/// assert_eq!(q.push('c'), Err('c'));
+/// assert_eq!(q.pop(), Some('a'));
+/// ```
+pub(crate) struct ArrayQueueImpl<T, B: AsRef<[Slot<T>]> + AsMut<[Slot<T>]>> {
+    /// The head of the queue.
+    ///
+    /// This value is a "stamp" consisting of an index into the buffer and a lap, but packed into a
+    /// single `usize`. The lower bits represent the index, while the upper bits represent the lap.
+    ///
+    /// Elements are popped from the head of the queue.
+    head: CachePadded<AtomicUsize>,
+
+    /// The tail of the queue.
+    ///
+    /// This value is a "stamp" consisting of an index into the buffer and a lap, but packed into a
+    /// single `usize`. The lower bits represent the index, while the upper bits represent the lap.
+    ///
+    /// Elements are pushed into the tail of the queue.
+    tail: CachePadded<AtomicUsize>,
+
+    /// The buffer holding slots.
+    buffer: B,
+
+    /// The queue capacity.
+    cap: usize,
+
+    /// A stamp with the value of `{ lap: 1, index: 0 }`.
+    one_lap: usize,
+
+    _p: core::marker::PhantomData<T>,
+}
+
+impl<T, B: AsRef<[Slot<T>]> + AsMut<[Slot<T>]>> ArrayQueueImpl<T, B> {
+    /// Creates a new bounded queue with the given capacity.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the capacity is zero.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_queue::ArrayQueue;
+    ///
+    /// let q = ArrayQueue::<i32>::new(100);
+    /// ```
+    pub(crate) const fn new(buffer: B, cap: usize) -> ArrayQueueImpl<T, B> {
+        assert!(cap > 0, "capacity must be non-zero");
+
+        // Head is initialized to `{ lap: 0, index: 0 }`.
+        // Tail is initialized to `{ lap: 0, index: 0 }`.
+        let head = 0;
+        let tail = 0;
+
+        // One lap is the smallest power of two greater than `cap`.
+        let one_lap = (cap + 1).next_power_of_two();
+
+        ArrayQueueImpl {
+            buffer,
+            cap,
+            one_lap,
+            head: CachePadded::new(AtomicUsize::new(head)),
+            tail: CachePadded::new(AtomicUsize::new(tail)),
+            _p: core::marker::PhantomData,
+        }
+    }
+
+    fn push_or_else<F>(&self, mut value: T, f: F) -> Result<(), T>
+    where
+        F: Fn(T, usize, usize, &Slot<T>) -> Result<T, T>,
+    {
+        let backoff = Backoff::new();
+        let mut tail = self.tail.load(Ordering::Relaxed);
+
+        loop {
+            // Deconstruct the tail.
+            let index = tail & (self.one_lap - 1);
+            let lap = tail & !(self.one_lap - 1);
+
+            let new_tail = if index + 1 < self.cap {
+                // Same lap, incremented index.
+                // Set to `{ lap: lap, index: index + 1 }`.
+                tail + 1
+            } else {
+                // One lap forward, index wraps around to zero.
+                // Set to `{ lap: lap.wrapping_add(1), index: 0 }`.
+                lap.wrapping_add(self.one_lap)
+            };
+
+            // Inspect the corresponding slot.
+            debug_assert!(index < self.buffer.as_ref().len());
+            let slot = unsafe { self.buffer.as_ref().get_unchecked(index) };
+            let stamp = slot.stamp.load(Ordering::Acquire);
+
+            // If the tail and the stamp match, we may attempt to push.
+            if tail == stamp {
+                // Try moving the tail.
+                match self.tail.compare_exchange_weak(
+                    tail,
+                    new_tail,
+                    Ordering::SeqCst,
+                    Ordering::Relaxed,
+                ) {
+                    Ok(_) => {
+                        // Write the value into the slot and update the stamp.
+                        unsafe {
+                            slot.value.get().write(MaybeUninit::new(value));
+                        }
+                        slot.stamp.store(tail + 1, Ordering::Release);
+                        return Ok(());
+                    }
+                    Err(t) => {
+                        tail = t;
+                        backoff.spin();
+                    }
+                }
+            } else if stamp.wrapping_add(self.one_lap) == tail + 1 {
+                atomic::fence(Ordering::SeqCst);
+                value = f(value, tail, new_tail, slot)?;
+                backoff.spin();
+                tail = self.tail.load(Ordering::Relaxed);
+            } else {
+                // Snooze because we need to wait for the stamp to get updated.
+                backoff.snooze();
+                tail = self.tail.load(Ordering::Relaxed);
+            }
+        }
+    }
+
+    /// Attempts to push an element into the queue.
+    ///
+    /// If the queue is full, the element is returned back as an error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_queue::ArrayQueue;
+    ///
+    /// let q = ArrayQueue::new(1);
+    ///
+    /// assert_eq!(q.push(10), Ok(()));
+    /// assert_eq!(q.push(20), Err(20));
+    /// ```
+    pub(crate) fn push(&self, value: T) -> Result<(), T> {
+        self.push_or_else(value, |v, tail, _, _| {
+            let head = self.head.load(Ordering::Relaxed);
+
+            // If the head lags one lap behind the tail as well...
+            if head.wrapping_add(self.one_lap) == tail {
+                // ...then the queue is full.
+                Err(v)
+            } else {
+                Ok(v)
+            }
+        })
+    }
+
+    /// Pushes an element into the queue, replacing the oldest element if necessary.
+    ///
+    /// If the queue is full, the oldest element is replaced and returned,
+    /// otherwise `None` is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_queue::ArrayQueue;
+    ///
+    /// let q = ArrayQueue::new(2);
+    ///
+    /// assert_eq!(q.force_push(10), None);
+    /// assert_eq!(q.force_push(20), None);
+    /// assert_eq!(q.force_push(30), Some(10));
+    /// assert_eq!(q.pop(), Some(20));
+    /// ```
+    pub(crate) fn force_push(&self, value: T) -> Option<T> {
+        self.push_or_else(value, |v, tail, new_tail, slot| {
+            let head = tail.wrapping_sub(self.one_lap);
+            let new_head = new_tail.wrapping_sub(self.one_lap);
+
+            // Try moving the head.
+            if self
+                .head
+                .compare_exchange_weak(head, new_head, Ordering::SeqCst, Ordering::Relaxed)
+                .is_ok()
+            {
+                // Move the tail.
+                self.tail.store(new_tail, Ordering::SeqCst);
+
+                // Swap the previous value.
+                let old = unsafe { slot.value.get().replace(MaybeUninit::new(v)).assume_init() };
+
+                // Update the stamp.
+                slot.stamp.store(tail + 1, Ordering::Release);
+
+                Err(old)
+            } else {
+                Ok(v)
+            }
+        })
+        .err()
+    }
+
+    /// Attempts to pop an element from the queue.
+    ///
+    /// If the queue is empty, `None` is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_queue::ArrayQueue;
+    ///
+    /// let q = ArrayQueue::new(1);
+    /// assert_eq!(q.push(10), Ok(()));
+    ///
+    /// assert_eq!(q.pop(), Some(10));
+    /// assert!(q.pop().is_none());
+    /// ```
+    pub(crate) fn pop(&self) -> Option<T> {
+        let backoff = Backoff::new();
+        let mut head = self.head.load(Ordering::Relaxed);
+
+        loop {
+            // Deconstruct the head.
+            let index = head & (self.one_lap - 1);
+            let lap = head & !(self.one_lap - 1);
+
+            // Inspect the corresponding slot.
+            debug_assert!(index < self.buffer.as_ref().len());
+            let slot = unsafe { self.buffer.as_ref().get_unchecked(index) };
+            let stamp = slot.stamp.load(Ordering::Acquire);
+
+            // If the the stamp is ahead of the head by 1, we may attempt to pop.
+            if head + 1 == stamp {
+                let new = if index + 1 < self.cap {
+                    // Same lap, incremented index.
+                    // Set to `{ lap: lap, index: index + 1 }`.
+                    head + 1
+                } else {
+                    // One lap forward, index wraps around to zero.
+                    // Set to `{ lap: lap.wrapping_add(1), index: 0 }`.
+                    lap.wrapping_add(self.one_lap)
+                };
+
+                // Try moving the head.
+                match self.head.compare_exchange_weak(
+                    head,
+                    new,
+                    Ordering::SeqCst,
+                    Ordering::Relaxed,
+                ) {
+                    Ok(_) => {
+                        // Read the value from the slot and update the stamp.
+                        let msg = unsafe { slot.value.get().read().assume_init() };
+                        slot.stamp
+                            .store(head.wrapping_add(self.one_lap), Ordering::Release);
+                        return Some(msg);
+                    }
+                    Err(h) => {
+                        head = h;
+                        backoff.spin();
+                    }
+                }
+            } else if stamp == head {
+                atomic::fence(Ordering::SeqCst);
+                let tail = self.tail.load(Ordering::Relaxed);
+
+                // If the tail equals the head, that means the channel is empty.
+                if tail == head {
+                    return None;
+                }
+
+                backoff.spin();
+                head = self.head.load(Ordering::Relaxed);
+            } else {
+                // Snooze because we need to wait for the stamp to get updated.
+                backoff.snooze();
+                head = self.head.load(Ordering::Relaxed);
+            }
+        }
+    }
+
+    /// Returns the capacity of the queue.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_queue::ArrayQueue;
+    ///
+    /// let q = ArrayQueue::<i32>::new(100);
+    ///
+    /// assert_eq!(q.capacity(), 100);
+    /// ```
+    pub(crate) fn capacity(&self) -> usize {
+        self.cap
+    }
+
+    /// Returns `true` if the queue is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_queue::ArrayQueue;
+    ///
+    /// let q = ArrayQueue::new(100);
+    ///
+    /// assert!(q.is_empty());
+    /// q.push(1).unwrap();
+    /// assert!(!q.is_empty());
+    /// ```
+    pub(crate) fn is_empty(&self) -> bool {
+        let head = self.head.load(Ordering::SeqCst);
+        let tail = self.tail.load(Ordering::SeqCst);
+
+        // Is the tail lagging one lap behind head?
+        // Is the tail equal to the head?
+        //
+        // Note: If the head changes just before we load the tail, that means there was a moment
+        // when the channel was not empty, so it is safe to just return `false`.
+        tail == head
+    }
+
+    /// Returns `true` if the queue is full.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_queue::ArrayQueue;
+    ///
+    /// let q = ArrayQueue::new(1);
+    ///
+    /// assert!(!q.is_full());
+    /// q.push(1).unwrap();
+    /// assert!(q.is_full());
+    /// ```
+    pub(crate) fn is_full(&self) -> bool {
+        let tail = self.tail.load(Ordering::SeqCst);
+        let head = self.head.load(Ordering::SeqCst);
+
+        // Is the head lagging one lap behind tail?
+        //
+        // Note: If the tail changes just before we load the head, that means there was a moment
+        // when the queue was not full, so it is safe to just return `false`.
+        head.wrapping_add(self.one_lap) == tail
+    }
+
+    /// Returns the number of elements in the queue.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_queue::ArrayQueue;
+    ///
+    /// let q = ArrayQueue::new(100);
+    /// assert_eq!(q.len(), 0);
+    ///
+    /// q.push(10).unwrap();
+    /// assert_eq!(q.len(), 1);
+    ///
+    /// q.push(20).unwrap();
+    /// assert_eq!(q.len(), 2);
+    /// ```
+    pub(crate) fn len(&self) -> usize {
+        loop {
+            // Load the tail, then load the head.
+            let tail = self.tail.load(Ordering::SeqCst);
+            let head = self.head.load(Ordering::SeqCst);
+
+            // If the tail didn't change, we've got consistent values to work with.
+            if self.tail.load(Ordering::SeqCst) == tail {
+                let hix = head & (self.one_lap - 1);
+                let tix = tail & (self.one_lap - 1);
+
+                return if hix < tix {
+                    tix - hix
+                } else if hix > tix {
+                    self.cap - hix + tix
+                } else if tail == head {
+                    0
+                } else {
+                    self.cap
+                };
+            }
+        }
+    }
+}
+
+impl<T, B: AsRef<[Slot<T>]> + AsMut<[Slot<T>]>> Drop for ArrayQueueImpl<T, B> {
+    fn drop(&mut self) {
+        // Get the index of the head.
+        let head = *self.head.get_mut();
+        let tail = *self.tail.get_mut();
+
+        let hix = head & (self.one_lap - 1);
+        let tix = tail & (self.one_lap - 1);
+
+        let len = if hix < tix {
+            tix - hix
+        } else if hix > tix {
+            self.cap - hix + tix
+        } else if tail == head {
+            0
+        } else {
+            self.cap
+        };
+
+        // Loop over all slots that hold a message and drop them.
+        for i in 0..len {
+            // Compute the index of the next slot holding a message.
+            let index = if hix + i < self.cap {
+                hix + i
+            } else {
+                hix + i - self.cap
+            };
+
+            unsafe {
+                debug_assert!(index < self.buffer.as_ref().len());
+                let slot = self.buffer.as_mut().get_unchecked_mut(index);
+                let value = &mut *slot.value.get();
+                value.as_mut_ptr().drop_in_place();
+            }
+        }
+    }
+}
+
+pub(crate) struct IntoIterImpl<'a, T, B: AsRef<[Slot<T>]> + AsMut<[Slot<T>]>> {
+    value: &'a mut ArrayQueueImpl<T, B>,
+}
+
+impl<'a, T, B: AsRef<[Slot<T>]> + AsMut<[Slot<T>]>> IntoIterImpl<'a, T, B> {
+    pub(crate) fn new(value: &'a mut ArrayQueueImpl<T, B>) -> Self {
+        Self { value }
+    }
+}
+
+impl<T, B: AsRef<[Slot<T>]> + AsMut<[Slot<T>]>> Iterator for IntoIterImpl<'_, T, B> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let value = &mut self.value;
+        let head = *value.head.get_mut();
+        if value.head.get_mut() != value.tail.get_mut() {
+            let index = head & (value.one_lap - 1);
+            let lap = head & !(value.one_lap - 1);
+            // SAFETY: We have mutable access to this, so we can read without
+            // worrying about concurrency. Furthermore, we know this is
+            // initialized because it is the value pointed at by `value.head`
+            // and this is a non-empty queue.
+            let val = unsafe {
+                debug_assert!(index < value.buffer.as_ref().len());
+                let slot = value.buffer.as_mut().get_unchecked_mut(index);
+                slot.value.get().read().assume_init()
+            };
+            let new = if index + 1 < value.cap {
+                // Same lap, incremented index.
+                // Set to `{ lap: lap, index: index + 1 }`.
+                head + 1
+            } else {
+                // One lap forward, index wraps around to zero.
+                // Set to `{ lap: lap.wrapping_add(1), index: 0 }`.
+                lap.wrapping_add(value.one_lap)
+            };
+            *value.head.get_mut() = new;
+            Some(val)
+        } else {
+            None
+        }
+    }
+}

--- a/crossbeam-queue/src/lib.rs
+++ b/crossbeam-queue/src/lib.rs
@@ -5,9 +5,6 @@
 //! * [`ArrayQueue`], a bounded MPMC queue that allocates a fixed-capacity buffer on construction.
 //! * [`SegQueue`], an unbounded MPMC queue that allocates small buffers, segments, on demand.
 
-#![feature(inline_const)]
-#![feature(maybe_uninit_array_assume_init)]
-#![feature(const_maybe_uninit_array_assume_init)]
 #![doc(test(
     no_crate_inject,
     attr(

--- a/crossbeam-queue/src/lib.rs
+++ b/crossbeam-queue/src/lib.rs
@@ -5,6 +5,8 @@
 //! * [`ArrayQueue`], a bounded MPMC queue that allocates a fixed-capacity buffer on construction.
 //! * [`SegQueue`], an unbounded MPMC queue that allocates small buffers, segments, on demand.
 
+#![feature(maybe_uninit_array_assume_init)]
+#![feature(const_maybe_uninit_array_assume_init)]
 #![doc(test(
     no_crate_inject,
     attr(
@@ -32,3 +34,8 @@ cfg_if::cfg_if! {
         pub use self::seg_queue::SegQueue;
     }
 }
+
+#[cfg(not(crossbeam_no_atomic_cas))]
+mod static_array_queue;
+#[cfg(not(crossbeam_no_atomic_cas))]
+pub use self::static_array_queue::StaticArrayQueue;

--- a/crossbeam-queue/src/lib.rs
+++ b/crossbeam-queue/src/lib.rs
@@ -23,6 +23,15 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(not(crossbeam_no_atomic_cas))]
+mod array_queue_impl;
+
+#[cfg(not(crossbeam_no_atomic_cas))]
+mod static_array_queue;
+
+#[cfg(not(crossbeam_no_atomic_cas))]
+pub use self::static_array_queue::StaticArrayQueue;
+
+#[cfg(not(crossbeam_no_atomic_cas))]
 cfg_if::cfg_if! {
     if #[cfg(feature = "alloc")] {
         extern crate alloc;
@@ -34,8 +43,3 @@ cfg_if::cfg_if! {
         pub use self::seg_queue::SegQueue;
     }
 }
-
-#[cfg(not(crossbeam_no_atomic_cas))]
-mod static_array_queue;
-#[cfg(not(crossbeam_no_atomic_cas))]
-pub use self::static_array_queue::StaticArrayQueue;

--- a/crossbeam-queue/src/lib.rs
+++ b/crossbeam-queue/src/lib.rs
@@ -5,6 +5,7 @@
 //! * [`ArrayQueue`], a bounded MPMC queue that allocates a fixed-capacity buffer on construction.
 //! * [`SegQueue`], an unbounded MPMC queue that allocates small buffers, segments, on demand.
 
+#![feature(inline_const)]
 #![feature(maybe_uninit_array_assume_init)]
 #![feature(const_maybe_uninit_array_assume_init)]
 #![doc(test(

--- a/crossbeam-queue/src/static_array_queue.rs
+++ b/crossbeam-queue/src/static_array_queue.rs
@@ -48,7 +48,7 @@ impl<T, const N: usize> StaticArrayQueue<T, N> {
     pub const fn new() -> StaticArrayQueue<T, N> {
         assert!(N > 0, "capacity must be non-zero");
 
-        let mut buffer: [MaybeUninit<Slot<T>>; N] = unsafe { MaybeUninit::uninit().assume_init() };
+        let mut buffer = [const { MaybeUninit::<Slot<T>>::uninit() }; N];
 
         {
             // const for's are not stabilized yet, so use a loop

--- a/crossbeam-queue/src/static_array_queue.rs
+++ b/crossbeam-queue/src/static_array_queue.rs
@@ -1,26 +1,7 @@
-//! The implementation is based on Dmitry Vyukov's bounded MPMC queue.
-//!
-//! Source:
-//!   - <http://www.1024cores.net/home/lock-free-algorithms/queues/bounded-mpmc-queue>
-
-use core::cell::UnsafeCell;
 use core::fmt;
 use core::mem::MaybeUninit;
-use core::sync::atomic::{self, AtomicUsize, Ordering};
 
-use crossbeam_utils::{Backoff, CachePadded};
-
-/// A slot in a queue.
-struct Slot<T> {
-    /// The current stamp.
-    ///
-    /// If the stamp equals the tail, this node will be next written to. If it equals head + 1,
-    /// this node will be next read from.
-    stamp: AtomicUsize,
-
-    /// The value in this slot.
-    value: UnsafeCell<MaybeUninit<T>>,
-}
+use super::array_queue_impl::{ArrayQueueImpl, IntoIterImpl, Slot};
 
 /// A bounded multi-producer multi-consumer queue.
 ///
@@ -48,34 +29,11 @@ struct Slot<T> {
 /// assert_eq!(q.pop(), Some('a'));
 /// ```
 pub struct StaticArrayQueue<T, const N: usize> {
-    /// The head of the queue.
-    ///
-    /// This value is a "stamp" consisting of an index into the buffer and a lap, but packed into a
-    /// single `usize`. The lower bits represent the index, while the upper bits represent the lap.
-    ///
-    /// Elements are popped from the head of the queue.
-    head: CachePadded<AtomicUsize>,
-
-    /// The tail of the queue.
-    ///
-    /// This value is a "stamp" consisting of an index into the buffer and a lap, but packed into a
-    /// single `usize`. The lower bits represent the index, while the upper bits represent the lap.
-    ///
-    /// Elements are pushed into the tail of the queue.
-    tail: CachePadded<AtomicUsize>,
-
-    /// The buffer holding slots.
-    buffer: [Slot<T>; N],
-
-    /// The queue capacity.
-    cap: usize,
-
-    /// A stamp with the value of `{ lap: 1, index: 0 }`.
-    one_lap: usize,
+    /// The queue implementation.
+    queue: ArrayQueueImpl<T, [Slot<T>; N]>,
 }
 
 unsafe impl<T: Send, const N: usize> Sync for StaticArrayQueue<T, N> {}
-unsafe impl<T: Send, const N: usize> Send for StaticArrayQueue<T, N> {}
 
 impl<T, const N: usize> StaticArrayQueue<T, N> {
     /// Creates a new bounded queue with the given capacity.
@@ -90,11 +48,6 @@ impl<T, const N: usize> StaticArrayQueue<T, N> {
     pub const fn new() -> StaticArrayQueue<T, N> {
         assert!(N > 0, "capacity must be non-zero");
 
-        // Head is initialized to `{ lap: 0, index: 0 }`.
-        // Tail is initialized to `{ lap: 0, index: 0 }`.
-        let head = 0;
-        let tail = 0;
-
         let mut buffer: [MaybeUninit<Slot<T>>; N] = unsafe { MaybeUninit::uninit().assume_init() };
 
         {
@@ -102,10 +55,7 @@ impl<T, const N: usize> StaticArrayQueue<T, N> {
             let mut i = 0;
             while i < N {
                 // Set the stamp to `{ lap: 0, index: i }`.
-                buffer[i] = MaybeUninit::new(Slot {
-                    stamp: AtomicUsize::new(i),
-                    value: UnsafeCell::new(MaybeUninit::uninit()),
-                });
+                buffer[i] = MaybeUninit::new(Slot::new(i));
 
                 i += 1;
             }
@@ -115,77 +65,8 @@ impl<T, const N: usize> StaticArrayQueue<T, N> {
         // with stamps.
         let buffer: [Slot<T>; N] = unsafe { MaybeUninit::array_assume_init(buffer) };
 
-        // One lap is the smallest power of two greater than `cap`.
-        let one_lap = (N + 1).next_power_of_two();
-
         StaticArrayQueue {
-            buffer,
-            cap: N,
-            one_lap,
-            head: CachePadded::new(AtomicUsize::new(head)),
-            tail: CachePadded::new(AtomicUsize::new(tail)),
-        }
-    }
-
-    fn push_or_else<F>(&self, mut value: T, f: F) -> Result<(), T>
-    where
-        F: Fn(T, usize, usize, &Slot<T>) -> Result<T, T>,
-    {
-        let backoff = Backoff::new();
-        let mut tail = self.tail.load(Ordering::Relaxed);
-
-        loop {
-            // Deconstruct the tail.
-            let index = tail & (self.one_lap - 1);
-            let lap = tail & !(self.one_lap - 1);
-
-            let new_tail = if index + 1 < self.cap {
-                // Same lap, incremented index.
-                // Set to `{ lap: lap, index: index + 1 }`.
-                tail + 1
-            } else {
-                // One lap forward, index wraps around to zero.
-                // Set to `{ lap: lap.wrapping_add(1), index: 0 }`.
-                lap.wrapping_add(self.one_lap)
-            };
-
-            // Inspect the corresponding slot.
-            debug_assert!(index < self.buffer.len());
-            let slot = unsafe { self.buffer.get_unchecked(index) };
-            let stamp = slot.stamp.load(Ordering::Acquire);
-
-            // If the tail and the stamp match, we may attempt to push.
-            if tail == stamp {
-                // Try moving the tail.
-                match self.tail.compare_exchange_weak(
-                    tail,
-                    new_tail,
-                    Ordering::SeqCst,
-                    Ordering::Relaxed,
-                ) {
-                    Ok(_) => {
-                        // Write the value into the slot and update the stamp.
-                        unsafe {
-                            slot.value.get().write(MaybeUninit::new(value));
-                        }
-                        slot.stamp.store(tail + 1, Ordering::Release);
-                        return Ok(());
-                    }
-                    Err(t) => {
-                        tail = t;
-                        backoff.spin();
-                    }
-                }
-            } else if stamp.wrapping_add(self.one_lap) == tail + 1 {
-                atomic::fence(Ordering::SeqCst);
-                value = f(value, tail, new_tail, slot)?;
-                backoff.spin();
-                tail = self.tail.load(Ordering::Relaxed);
-            } else {
-                // Snooze because we need to wait for the stamp to get updated.
-                backoff.snooze();
-                tail = self.tail.load(Ordering::Relaxed);
-            }
+            queue: ArrayQueueImpl::new(buffer, N),
         }
     }
 
@@ -204,17 +85,7 @@ impl<T, const N: usize> StaticArrayQueue<T, N> {
     /// assert_eq!(q.push(20), Err(20));
     /// ```
     pub fn push(&self, value: T) -> Result<(), T> {
-        self.push_or_else(value, |v, tail, _, _| {
-            let head = self.head.load(Ordering::Relaxed);
-
-            // If the head lags one lap behind the tail as well...
-            if head.wrapping_add(self.one_lap) == tail {
-                // ...then the queue is full.
-                Err(v)
-            } else {
-                Ok(v)
-            }
-        })
+        self.queue.push(value)
     }
 
     /// Pushes an element into the queue, replacing the oldest element if necessary.
@@ -235,31 +106,7 @@ impl<T, const N: usize> StaticArrayQueue<T, N> {
     /// assert_eq!(q.pop(), Some(20));
     /// ```
     pub fn force_push(&self, value: T) -> Option<T> {
-        self.push_or_else(value, |v, tail, new_tail, slot| {
-            let head = tail.wrapping_sub(self.one_lap);
-            let new_head = new_tail.wrapping_sub(self.one_lap);
-
-            // Try moving the head.
-            if self
-                .head
-                .compare_exchange_weak(head, new_head, Ordering::SeqCst, Ordering::Relaxed)
-                .is_ok()
-            {
-                // Move the tail.
-                self.tail.store(new_tail, Ordering::SeqCst);
-
-                // Swap the previous value.
-                let old = unsafe { slot.value.get().replace(MaybeUninit::new(v)).assume_init() };
-
-                // Update the stamp.
-                slot.stamp.store(tail + 1, Ordering::Release);
-
-                Err(old)
-            } else {
-                Ok(v)
-            }
-        })
-        .err()
+        self.queue.force_push(value)
     }
 
     /// Attempts to pop an element from the queue.
@@ -278,67 +125,7 @@ impl<T, const N: usize> StaticArrayQueue<T, N> {
     /// assert!(q.pop().is_none());
     /// ```
     pub fn pop(&self) -> Option<T> {
-        let backoff = Backoff::new();
-        let mut head = self.head.load(Ordering::Relaxed);
-
-        loop {
-            // Deconstruct the head.
-            let index = head & (self.one_lap - 1);
-            let lap = head & !(self.one_lap - 1);
-
-            // Inspect the corresponding slot.
-            debug_assert!(index < self.buffer.len());
-            let slot = unsafe { self.buffer.get_unchecked(index) };
-            let stamp = slot.stamp.load(Ordering::Acquire);
-
-            // If the the stamp is ahead of the head by 1, we may attempt to pop.
-            if head + 1 == stamp {
-                let new = if index + 1 < self.cap {
-                    // Same lap, incremented index.
-                    // Set to `{ lap: lap, index: index + 1 }`.
-                    head + 1
-                } else {
-                    // One lap forward, index wraps around to zero.
-                    // Set to `{ lap: lap.wrapping_add(1), index: 0 }`.
-                    lap.wrapping_add(self.one_lap)
-                };
-
-                // Try moving the head.
-                match self.head.compare_exchange_weak(
-                    head,
-                    new,
-                    Ordering::SeqCst,
-                    Ordering::Relaxed,
-                ) {
-                    Ok(_) => {
-                        // Read the value from the slot and update the stamp.
-                        let msg = unsafe { slot.value.get().read().assume_init() };
-                        slot.stamp
-                            .store(head.wrapping_add(self.one_lap), Ordering::Release);
-                        return Some(msg);
-                    }
-                    Err(h) => {
-                        head = h;
-                        backoff.spin();
-                    }
-                }
-            } else if stamp == head {
-                atomic::fence(Ordering::SeqCst);
-                let tail = self.tail.load(Ordering::Relaxed);
-
-                // If the tail equals the head, that means the channel is empty.
-                if tail == head {
-                    return None;
-                }
-
-                backoff.spin();
-                head = self.head.load(Ordering::Relaxed);
-            } else {
-                // Snooze because we need to wait for the stamp to get updated.
-                backoff.snooze();
-                head = self.head.load(Ordering::Relaxed);
-            }
-        }
+        self.queue.pop()
     }
 
     /// Returns the capacity of the queue.
@@ -353,7 +140,7 @@ impl<T, const N: usize> StaticArrayQueue<T, N> {
     /// assert_eq!(q.capacity(), 100);
     /// ```
     pub fn capacity(&self) -> usize {
-        self.cap
+        self.queue.capacity()
     }
 
     /// Returns `true` if the queue is empty.
@@ -370,15 +157,7 @@ impl<T, const N: usize> StaticArrayQueue<T, N> {
     /// assert!(!q.is_empty());
     /// ```
     pub fn is_empty(&self) -> bool {
-        let head = self.head.load(Ordering::SeqCst);
-        let tail = self.tail.load(Ordering::SeqCst);
-
-        // Is the tail lagging one lap behind head?
-        // Is the tail equal to the head?
-        //
-        // Note: If the head changes just before we load the tail, that means there was a moment
-        // when the channel was not empty, so it is safe to just return `false`.
-        tail == head
+        self.queue.is_empty()
     }
 
     /// Returns `true` if the queue is full.
@@ -395,14 +174,7 @@ impl<T, const N: usize> StaticArrayQueue<T, N> {
     /// assert!(q.is_full());
     /// ```
     pub fn is_full(&self) -> bool {
-        let tail = self.tail.load(Ordering::SeqCst);
-        let head = self.head.load(Ordering::SeqCst);
-
-        // Is the head lagging one lap behind tail?
-        //
-        // Note: If the tail changes just before we load the head, that means there was a moment
-        // when the queue was not full, so it is safe to just return `false`.
-        head.wrapping_add(self.one_lap) == tail
+        self.queue.is_full()
     }
 
     /// Returns the number of elements in the queue.
@@ -422,65 +194,7 @@ impl<T, const N: usize> StaticArrayQueue<T, N> {
     /// assert_eq!(q.len(), 2);
     /// ```
     pub fn len(&self) -> usize {
-        loop {
-            // Load the tail, then load the head.
-            let tail = self.tail.load(Ordering::SeqCst);
-            let head = self.head.load(Ordering::SeqCst);
-
-            // If the tail didn't change, we've got consistent values to work with.
-            if self.tail.load(Ordering::SeqCst) == tail {
-                let hix = head & (self.one_lap - 1);
-                let tix = tail & (self.one_lap - 1);
-
-                return if hix < tix {
-                    tix - hix
-                } else if hix > tix {
-                    self.cap - hix + tix
-                } else if tail == head {
-                    0
-                } else {
-                    self.cap
-                };
-            }
-        }
-    }
-}
-
-impl<T, const N: usize> Drop for StaticArrayQueue<T, N> {
-    fn drop(&mut self) {
-        // Get the index of the head.
-        let head = *self.head.get_mut();
-        let tail = *self.tail.get_mut();
-
-        let hix = head & (self.one_lap - 1);
-        let tix = tail & (self.one_lap - 1);
-
-        let len = if hix < tix {
-            tix - hix
-        } else if hix > tix {
-            self.cap - hix + tix
-        } else if tail == head {
-            0
-        } else {
-            self.cap
-        };
-
-        // Loop over all slots that hold a message and drop them.
-        for i in 0..len {
-            // Compute the index of the next slot holding a message.
-            let index = if hix + i < self.cap {
-                hix + i
-            } else {
-                hix + i - self.cap
-            };
-
-            unsafe {
-                debug_assert!(index < self.buffer.len());
-                let slot = self.buffer.get_unchecked_mut(index);
-                let value = &mut *slot.value.get();
-                value.as_mut_ptr().drop_in_place();
-            }
-        }
+        self.queue.len()
     }
 }
 
@@ -509,33 +223,6 @@ impl<T, const N: usize> Iterator for IntoIter<T, N> {
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let value = &mut self.value;
-        let head = *value.head.get_mut();
-        if value.head.get_mut() != value.tail.get_mut() {
-            let index = head & (value.one_lap - 1);
-            let lap = head & !(value.one_lap - 1);
-            // SAFETY: We have mutable access to this, so we can read without
-            // worrying about concurrency. Furthermore, we know this is
-            // initialized because it is the value pointed at by `value.head`
-            // and this is a non-empty queue.
-            let val = unsafe {
-                debug_assert!(index < value.buffer.len());
-                let slot = value.buffer.get_unchecked_mut(index);
-                slot.value.get().read().assume_init()
-            };
-            let new = if index + 1 < value.cap {
-                // Same lap, incremented index.
-                // Set to `{ lap: lap, index: index + 1 }`.
-                head + 1
-            } else {
-                // One lap forward, index wraps around to zero.
-                // Set to `{ lap: lap.wrapping_add(1), index: 0 }`.
-                lap.wrapping_add(value.one_lap)
-            };
-            *value.head.get_mut() = new;
-            Some(val)
-        } else {
-            None
-        }
+        IntoIterImpl::new(&mut self.value.queue).next()
     }
 }

--- a/crossbeam-queue/src/static_array_queue.rs
+++ b/crossbeam-queue/src/static_array_queue.rs
@@ -1,0 +1,541 @@
+//! The implementation is based on Dmitry Vyukov's bounded MPMC queue.
+//!
+//! Source:
+//!   - <http://www.1024cores.net/home/lock-free-algorithms/queues/bounded-mpmc-queue>
+
+use core::cell::UnsafeCell;
+use core::fmt;
+use core::mem::MaybeUninit;
+use core::sync::atomic::{self, AtomicUsize, Ordering};
+
+use crossbeam_utils::{Backoff, CachePadded};
+
+/// A slot in a queue.
+struct Slot<T> {
+    /// The current stamp.
+    ///
+    /// If the stamp equals the tail, this node will be next written to. If it equals head + 1,
+    /// this node will be next read from.
+    stamp: AtomicUsize,
+
+    /// The value in this slot.
+    value: UnsafeCell<MaybeUninit<T>>,
+}
+
+/// A bounded multi-producer multi-consumer queue.
+///
+/// Contrary to [`ArrayQueue`], this queue does not require the `alloc` feature and its
+/// constructor is `const`, which makes it ideal for usage as a `static` variable.
+///
+/// This queue contains a fixed-size array, which is used to store pushed elements.
+/// The queue cannot hold more elements than the array allows. Attempting to push an
+/// element into a full queue will fail. Alternatively, [`force_push`] makes it possible for
+/// this queue to be used as a ring-buffer.
+///
+/// [`force_push`]: StaticArrayQueue::force_push
+/// [`ArrayQueue`]: super::ArrayQueue
+///
+/// # Examples
+///
+/// ```
+/// use crossbeam_queue::StaticArrayQueue;
+///
+/// let q = StaticArrayQueue::<char, 2>::new();
+///
+/// assert_eq!(q.push('a'), Ok(()));
+/// assert_eq!(q.push('b'), Ok(()));
+/// assert_eq!(q.push('c'), Err('c'));
+/// assert_eq!(q.pop(), Some('a'));
+/// ```
+pub struct StaticArrayQueue<T, const N: usize> {
+    /// The head of the queue.
+    ///
+    /// This value is a "stamp" consisting of an index into the buffer and a lap, but packed into a
+    /// single `usize`. The lower bits represent the index, while the upper bits represent the lap.
+    ///
+    /// Elements are popped from the head of the queue.
+    head: CachePadded<AtomicUsize>,
+
+    /// The tail of the queue.
+    ///
+    /// This value is a "stamp" consisting of an index into the buffer and a lap, but packed into a
+    /// single `usize`. The lower bits represent the index, while the upper bits represent the lap.
+    ///
+    /// Elements are pushed into the tail of the queue.
+    tail: CachePadded<AtomicUsize>,
+
+    /// The buffer holding slots.
+    buffer: [Slot<T>; N],
+
+    /// The queue capacity.
+    cap: usize,
+
+    /// A stamp with the value of `{ lap: 1, index: 0 }`.
+    one_lap: usize,
+}
+
+unsafe impl<T: Send, const N: usize> Sync for StaticArrayQueue<T, N> {}
+unsafe impl<T: Send, const N: usize> Send for StaticArrayQueue<T, N> {}
+
+impl<T, const N: usize> StaticArrayQueue<T, N> {
+    /// Creates a new bounded queue with the given capacity.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_queue::StaticArrayQueue;
+    ///
+    /// let q = StaticArrayQueue::<i32, 100>::new();
+    /// ```
+    pub const fn new() -> StaticArrayQueue<T, N> {
+        assert!(N > 0, "capacity must be non-zero");
+
+        // Head is initialized to `{ lap: 0, index: 0 }`.
+        // Tail is initialized to `{ lap: 0, index: 0 }`.
+        let head = 0;
+        let tail = 0;
+
+        let mut buffer: [MaybeUninit<Slot<T>>; N] = unsafe { MaybeUninit::uninit().assume_init() };
+
+        {
+            // const for's are not stabilized yet, so use a loop
+            let mut i = 0;
+            while i < N {
+                // Set the stamp to `{ lap: 0, index: i }`.
+                buffer[i] = MaybeUninit::new(Slot {
+                    stamp: AtomicUsize::new(i),
+                    value: UnsafeCell::new(MaybeUninit::uninit()),
+                });
+
+                i += 1;
+            }
+        }
+
+        // Allocate a buffer of `cap` slots initialized
+        // with stamps.
+        let buffer: [Slot<T>; N] = unsafe { MaybeUninit::array_assume_init(buffer) };
+
+        // One lap is the smallest power of two greater than `cap`.
+        let one_lap = (N + 1).next_power_of_two();
+
+        StaticArrayQueue {
+            buffer,
+            cap: N,
+            one_lap,
+            head: CachePadded::new(AtomicUsize::new(head)),
+            tail: CachePadded::new(AtomicUsize::new(tail)),
+        }
+    }
+
+    fn push_or_else<F>(&self, mut value: T, f: F) -> Result<(), T>
+    where
+        F: Fn(T, usize, usize, &Slot<T>) -> Result<T, T>,
+    {
+        let backoff = Backoff::new();
+        let mut tail = self.tail.load(Ordering::Relaxed);
+
+        loop {
+            // Deconstruct the tail.
+            let index = tail & (self.one_lap - 1);
+            let lap = tail & !(self.one_lap - 1);
+
+            let new_tail = if index + 1 < self.cap {
+                // Same lap, incremented index.
+                // Set to `{ lap: lap, index: index + 1 }`.
+                tail + 1
+            } else {
+                // One lap forward, index wraps around to zero.
+                // Set to `{ lap: lap.wrapping_add(1), index: 0 }`.
+                lap.wrapping_add(self.one_lap)
+            };
+
+            // Inspect the corresponding slot.
+            debug_assert!(index < self.buffer.len());
+            let slot = unsafe { self.buffer.get_unchecked(index) };
+            let stamp = slot.stamp.load(Ordering::Acquire);
+
+            // If the tail and the stamp match, we may attempt to push.
+            if tail == stamp {
+                // Try moving the tail.
+                match self.tail.compare_exchange_weak(
+                    tail,
+                    new_tail,
+                    Ordering::SeqCst,
+                    Ordering::Relaxed,
+                ) {
+                    Ok(_) => {
+                        // Write the value into the slot and update the stamp.
+                        unsafe {
+                            slot.value.get().write(MaybeUninit::new(value));
+                        }
+                        slot.stamp.store(tail + 1, Ordering::Release);
+                        return Ok(());
+                    }
+                    Err(t) => {
+                        tail = t;
+                        backoff.spin();
+                    }
+                }
+            } else if stamp.wrapping_add(self.one_lap) == tail + 1 {
+                atomic::fence(Ordering::SeqCst);
+                value = f(value, tail, new_tail, slot)?;
+                backoff.spin();
+                tail = self.tail.load(Ordering::Relaxed);
+            } else {
+                // Snooze because we need to wait for the stamp to get updated.
+                backoff.snooze();
+                tail = self.tail.load(Ordering::Relaxed);
+            }
+        }
+    }
+
+    /// Attempts to push an element into the queue.
+    ///
+    /// If the queue is full, the element is returned back as an error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_queue::StaticArrayQueue;
+    ///
+    /// let q = StaticArrayQueue::<_, 1>::new();
+    ///
+    /// assert_eq!(q.push(10), Ok(()));
+    /// assert_eq!(q.push(20), Err(20));
+    /// ```
+    pub fn push(&self, value: T) -> Result<(), T> {
+        self.push_or_else(value, |v, tail, _, _| {
+            let head = self.head.load(Ordering::Relaxed);
+
+            // If the head lags one lap behind the tail as well...
+            if head.wrapping_add(self.one_lap) == tail {
+                // ...then the queue is full.
+                Err(v)
+            } else {
+                Ok(v)
+            }
+        })
+    }
+
+    /// Pushes an element into the queue, replacing the oldest element if necessary.
+    ///
+    /// If the queue is full, the oldest element is replaced and returned,
+    /// otherwise `None` is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_queue::StaticArrayQueue;
+    ///
+    /// let q = StaticArrayQueue::<_, 2>::new();
+    ///
+    /// assert_eq!(q.force_push(10), None);
+    /// assert_eq!(q.force_push(20), None);
+    /// assert_eq!(q.force_push(30), Some(10));
+    /// assert_eq!(q.pop(), Some(20));
+    /// ```
+    pub fn force_push(&self, value: T) -> Option<T> {
+        self.push_or_else(value, |v, tail, new_tail, slot| {
+            let head = tail.wrapping_sub(self.one_lap);
+            let new_head = new_tail.wrapping_sub(self.one_lap);
+
+            // Try moving the head.
+            if self
+                .head
+                .compare_exchange_weak(head, new_head, Ordering::SeqCst, Ordering::Relaxed)
+                .is_ok()
+            {
+                // Move the tail.
+                self.tail.store(new_tail, Ordering::SeqCst);
+
+                // Swap the previous value.
+                let old = unsafe { slot.value.get().replace(MaybeUninit::new(v)).assume_init() };
+
+                // Update the stamp.
+                slot.stamp.store(tail + 1, Ordering::Release);
+
+                Err(old)
+            } else {
+                Ok(v)
+            }
+        })
+        .err()
+    }
+
+    /// Attempts to pop an element from the queue.
+    ///
+    /// If the queue is empty, `None` is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_queue::StaticArrayQueue;
+    ///
+    /// let q = StaticArrayQueue::<_, 1>::new();
+    /// assert_eq!(q.push(10), Ok(()));
+    ///
+    /// assert_eq!(q.pop(), Some(10));
+    /// assert!(q.pop().is_none());
+    /// ```
+    pub fn pop(&self) -> Option<T> {
+        let backoff = Backoff::new();
+        let mut head = self.head.load(Ordering::Relaxed);
+
+        loop {
+            // Deconstruct the head.
+            let index = head & (self.one_lap - 1);
+            let lap = head & !(self.one_lap - 1);
+
+            // Inspect the corresponding slot.
+            debug_assert!(index < self.buffer.len());
+            let slot = unsafe { self.buffer.get_unchecked(index) };
+            let stamp = slot.stamp.load(Ordering::Acquire);
+
+            // If the the stamp is ahead of the head by 1, we may attempt to pop.
+            if head + 1 == stamp {
+                let new = if index + 1 < self.cap {
+                    // Same lap, incremented index.
+                    // Set to `{ lap: lap, index: index + 1 }`.
+                    head + 1
+                } else {
+                    // One lap forward, index wraps around to zero.
+                    // Set to `{ lap: lap.wrapping_add(1), index: 0 }`.
+                    lap.wrapping_add(self.one_lap)
+                };
+
+                // Try moving the head.
+                match self.head.compare_exchange_weak(
+                    head,
+                    new,
+                    Ordering::SeqCst,
+                    Ordering::Relaxed,
+                ) {
+                    Ok(_) => {
+                        // Read the value from the slot and update the stamp.
+                        let msg = unsafe { slot.value.get().read().assume_init() };
+                        slot.stamp
+                            .store(head.wrapping_add(self.one_lap), Ordering::Release);
+                        return Some(msg);
+                    }
+                    Err(h) => {
+                        head = h;
+                        backoff.spin();
+                    }
+                }
+            } else if stamp == head {
+                atomic::fence(Ordering::SeqCst);
+                let tail = self.tail.load(Ordering::Relaxed);
+
+                // If the tail equals the head, that means the channel is empty.
+                if tail == head {
+                    return None;
+                }
+
+                backoff.spin();
+                head = self.head.load(Ordering::Relaxed);
+            } else {
+                // Snooze because we need to wait for the stamp to get updated.
+                backoff.snooze();
+                head = self.head.load(Ordering::Relaxed);
+            }
+        }
+    }
+
+    /// Returns the capacity of the queue.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_queue::StaticArrayQueue;
+    ///
+    /// let q = StaticArrayQueue::<i32, 100>::new();
+    ///
+    /// assert_eq!(q.capacity(), 100);
+    /// ```
+    pub fn capacity(&self) -> usize {
+        self.cap
+    }
+
+    /// Returns `true` if the queue is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_queue::StaticArrayQueue;
+    ///
+    /// let q = StaticArrayQueue::<_, 100>::new();
+    ///
+    /// assert!(q.is_empty());
+    /// q.push(1).unwrap();
+    /// assert!(!q.is_empty());
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        let head = self.head.load(Ordering::SeqCst);
+        let tail = self.tail.load(Ordering::SeqCst);
+
+        // Is the tail lagging one lap behind head?
+        // Is the tail equal to the head?
+        //
+        // Note: If the head changes just before we load the tail, that means there was a moment
+        // when the channel was not empty, so it is safe to just return `false`.
+        tail == head
+    }
+
+    /// Returns `true` if the queue is full.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_queue::StaticArrayQueue;
+    ///
+    /// let q = StaticArrayQueue::<_, 1>::new();
+    ///
+    /// assert!(!q.is_full());
+    /// q.push(1).unwrap();
+    /// assert!(q.is_full());
+    /// ```
+    pub fn is_full(&self) -> bool {
+        let tail = self.tail.load(Ordering::SeqCst);
+        let head = self.head.load(Ordering::SeqCst);
+
+        // Is the head lagging one lap behind tail?
+        //
+        // Note: If the tail changes just before we load the head, that means there was a moment
+        // when the queue was not full, so it is safe to just return `false`.
+        head.wrapping_add(self.one_lap) == tail
+    }
+
+    /// Returns the number of elements in the queue.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_queue::StaticArrayQueue;
+    ///
+    /// let q = StaticArrayQueue::<_, 100>::new();
+    /// assert_eq!(q.len(), 0);
+    ///
+    /// q.push(10).unwrap();
+    /// assert_eq!(q.len(), 1);
+    ///
+    /// q.push(20).unwrap();
+    /// assert_eq!(q.len(), 2);
+    /// ```
+    pub fn len(&self) -> usize {
+        loop {
+            // Load the tail, then load the head.
+            let tail = self.tail.load(Ordering::SeqCst);
+            let head = self.head.load(Ordering::SeqCst);
+
+            // If the tail didn't change, we've got consistent values to work with.
+            if self.tail.load(Ordering::SeqCst) == tail {
+                let hix = head & (self.one_lap - 1);
+                let tix = tail & (self.one_lap - 1);
+
+                return if hix < tix {
+                    tix - hix
+                } else if hix > tix {
+                    self.cap - hix + tix
+                } else if tail == head {
+                    0
+                } else {
+                    self.cap
+                };
+            }
+        }
+    }
+}
+
+impl<T, const N: usize> Drop for StaticArrayQueue<T, N> {
+    fn drop(&mut self) {
+        // Get the index of the head.
+        let head = *self.head.get_mut();
+        let tail = *self.tail.get_mut();
+
+        let hix = head & (self.one_lap - 1);
+        let tix = tail & (self.one_lap - 1);
+
+        let len = if hix < tix {
+            tix - hix
+        } else if hix > tix {
+            self.cap - hix + tix
+        } else if tail == head {
+            0
+        } else {
+            self.cap
+        };
+
+        // Loop over all slots that hold a message and drop them.
+        for i in 0..len {
+            // Compute the index of the next slot holding a message.
+            let index = if hix + i < self.cap {
+                hix + i
+            } else {
+                hix + i - self.cap
+            };
+
+            unsafe {
+                debug_assert!(index < self.buffer.len());
+                let slot = self.buffer.get_unchecked_mut(index);
+                let value = &mut *slot.value.get();
+                value.as_mut_ptr().drop_in_place();
+            }
+        }
+    }
+}
+
+impl<T, const N: usize> fmt::Debug for StaticArrayQueue<T, N> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad("StaticArrayQueue { .. }")
+    }
+}
+
+impl<T, const N: usize> IntoIterator for StaticArrayQueue<T, N> {
+    type Item = T;
+
+    type IntoIter = IntoIter<T, N>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter { value: self }
+    }
+}
+
+#[derive(Debug)]
+pub struct IntoIter<T, const N: usize> {
+    value: StaticArrayQueue<T, N>,
+}
+
+impl<T, const N: usize> Iterator for IntoIter<T, N> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let value = &mut self.value;
+        let head = *value.head.get_mut();
+        if value.head.get_mut() != value.tail.get_mut() {
+            let index = head & (value.one_lap - 1);
+            let lap = head & !(value.one_lap - 1);
+            // SAFETY: We have mutable access to this, so we can read without
+            // worrying about concurrency. Furthermore, we know this is
+            // initialized because it is the value pointed at by `value.head`
+            // and this is a non-empty queue.
+            let val = unsafe {
+                debug_assert!(index < value.buffer.len());
+                let slot = value.buffer.get_unchecked_mut(index);
+                slot.value.get().read().assume_init()
+            };
+            let new = if index + 1 < value.cap {
+                // Same lap, incremented index.
+                // Set to `{ lap: lap, index: index + 1 }`.
+                head + 1
+            } else {
+                // One lap forward, index wraps around to zero.
+                // Set to `{ lap: lap.wrapping_add(1), index: 0 }`.
+                lap.wrapping_add(value.one_lap)
+            };
+            *value.head.get_mut() = new;
+            Some(val)
+        } else {
+            None
+        }
+    }
+}

--- a/crossbeam-queue/tests/array_queue.rs
+++ b/crossbeam-queue/tests/array_queue.rs
@@ -372,3 +372,11 @@ fn into_iter() {
         assert_eq!(i, j);
     }
 }
+
+#[test]
+fn send_and_sync() {
+    fn is_send_and_sync<T: Send + Sync>() {}
+
+    // Cell is only Send, but not Sync.
+    is_send_and_sync::<ArrayQueue<core::cell::Cell<i32>>>();
+}

--- a/crossbeam-queue/tests/static_array_queue.rs
+++ b/crossbeam-queue/tests/static_array_queue.rs
@@ -380,3 +380,11 @@ fn into_iter() {
         assert_eq!(i, j);
     }
 }
+
+#[test]
+fn send_and_sync() {
+    fn is_send_and_sync<T: Send + Sync>() {}
+
+    // Cell is only Send, but not Sync.
+    is_send_and_sync::<StaticArrayQueue<core::cell::Cell<i32>, 10>>();
+}

--- a/crossbeam-queue/tests/static_array_queue.rs
+++ b/crossbeam-queue/tests/static_array_queue.rs
@@ -1,0 +1,382 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use crossbeam_queue::StaticArrayQueue;
+use crossbeam_utils::thread::scope;
+use rand::{thread_rng, Rng};
+
+#[test]
+fn smoke() {
+    let q = StaticArrayQueue::<_, 1>::new();
+
+    q.push(7).unwrap();
+    assert_eq!(q.pop(), Some(7));
+
+    q.push(8).unwrap();
+    assert_eq!(q.pop(), Some(8));
+    assert!(q.pop().is_none());
+}
+
+#[test]
+fn capacity() {
+    {
+        let q = StaticArrayQueue::<i32, 1>::new();
+        assert_eq!(q.capacity(), 1);
+    }
+    {
+        let q = StaticArrayQueue::<i32, 3>::new();
+        assert_eq!(q.capacity(), 3);
+    }
+    {
+        let q = StaticArrayQueue::<i32, 10>::new();
+        assert_eq!(q.capacity(), 10);
+    }
+}
+
+#[test]
+#[should_panic(expected = "capacity must be non-zero")]
+fn zero_capacity() {
+    let _ = StaticArrayQueue::<i32, 0>::new();
+}
+
+#[test]
+fn len_empty_full() {
+    let q = StaticArrayQueue::<_, 2>::new();
+
+    assert_eq!(q.len(), 0);
+    assert!(q.is_empty());
+    assert!(!q.is_full());
+
+    q.push(()).unwrap();
+
+    assert_eq!(q.len(), 1);
+    assert!(!q.is_empty());
+    assert!(!q.is_full());
+
+    q.push(()).unwrap();
+
+    assert_eq!(q.len(), 2);
+    assert!(!q.is_empty());
+    assert!(q.is_full());
+
+    q.pop().unwrap();
+
+    assert_eq!(q.len(), 1);
+    assert!(!q.is_empty());
+    assert!(!q.is_full());
+}
+
+#[test]
+fn len() {
+    #[cfg(miri)]
+    const COUNT: usize = 30;
+    #[cfg(not(miri))]
+    const COUNT: usize = 25_000;
+    #[cfg(miri)]
+    const CAP: usize = 40;
+    #[cfg(not(miri))]
+    const CAP: usize = 1000;
+    const ITERS: usize = CAP / 20;
+
+    let q = StaticArrayQueue::<_, CAP>::new();
+    assert_eq!(q.len(), 0);
+
+    for _ in 0..CAP / 10 {
+        for i in 0..ITERS {
+            q.push(i).unwrap();
+            assert_eq!(q.len(), i + 1);
+        }
+
+        for i in 0..ITERS {
+            q.pop().unwrap();
+            assert_eq!(q.len(), ITERS - i - 1);
+        }
+    }
+    assert_eq!(q.len(), 0);
+
+    for i in 0..CAP {
+        q.push(i).unwrap();
+        assert_eq!(q.len(), i + 1);
+    }
+
+    for _ in 0..CAP {
+        q.pop().unwrap();
+    }
+    assert_eq!(q.len(), 0);
+
+    scope(|scope| {
+        scope.spawn(|_| {
+            for i in 0..COUNT {
+                loop {
+                    if let Some(x) = q.pop() {
+                        assert_eq!(x, i);
+                        break;
+                    }
+                }
+                let len = q.len();
+                assert!(len <= CAP);
+            }
+        });
+
+        scope.spawn(|_| {
+            for i in 0..COUNT {
+                while q.push(i).is_err() {}
+                let len = q.len();
+                assert!(len <= CAP);
+            }
+        });
+    })
+    .unwrap();
+    assert_eq!(q.len(), 0);
+}
+
+#[test]
+fn spsc() {
+    #[cfg(miri)]
+    const COUNT: usize = 50;
+    #[cfg(not(miri))]
+    const COUNT: usize = 100_000;
+
+    let q = StaticArrayQueue::<_, 3>::new();
+
+    scope(|scope| {
+        scope.spawn(|_| {
+            for i in 0..COUNT {
+                loop {
+                    if let Some(x) = q.pop() {
+                        assert_eq!(x, i);
+                        break;
+                    }
+                }
+            }
+            assert!(q.pop().is_none());
+        });
+
+        scope.spawn(|_| {
+            for i in 0..COUNT {
+                while q.push(i).is_err() {}
+            }
+        });
+    })
+    .unwrap();
+}
+
+#[test]
+fn spsc_ring_buffer() {
+    #[cfg(miri)]
+    const COUNT: usize = 50;
+    #[cfg(not(miri))]
+    const COUNT: usize = 100_000;
+
+    let t = AtomicUsize::new(1);
+    let q = StaticArrayQueue::<usize, 3>::new();
+    let v = (0..COUNT).map(|_| AtomicUsize::new(0)).collect::<Vec<_>>();
+
+    scope(|scope| {
+        scope.spawn(|_| loop {
+            match t.load(Ordering::SeqCst) {
+                0 if q.is_empty() => break,
+
+                _ => {
+                    while let Some(n) = q.pop() {
+                        v[n].fetch_add(1, Ordering::SeqCst);
+                    }
+                }
+            }
+        });
+
+        scope.spawn(|_| {
+            for i in 0..COUNT {
+                if let Some(n) = q.force_push(i) {
+                    v[n].fetch_add(1, Ordering::SeqCst);
+                }
+            }
+
+            t.fetch_sub(1, Ordering::SeqCst);
+        });
+    })
+    .unwrap();
+
+    for c in v {
+        assert_eq!(c.load(Ordering::SeqCst), 1);
+    }
+}
+
+#[test]
+fn mpmc() {
+    #[cfg(miri)]
+    const COUNT: usize = 50;
+    #[cfg(not(miri))]
+    const COUNT: usize = 25_000;
+    const THREADS: usize = 4;
+
+    let q = StaticArrayQueue::<usize, 3>::new();
+    let v = (0..COUNT).map(|_| AtomicUsize::new(0)).collect::<Vec<_>>();
+
+    scope(|scope| {
+        for _ in 0..THREADS {
+            scope.spawn(|_| {
+                for _ in 0..COUNT {
+                    let n = loop {
+                        if let Some(x) = q.pop() {
+                            break x;
+                        }
+                    };
+                    v[n].fetch_add(1, Ordering::SeqCst);
+                }
+            });
+        }
+        for _ in 0..THREADS {
+            scope.spawn(|_| {
+                for i in 0..COUNT {
+                    while q.push(i).is_err() {}
+                }
+            });
+        }
+    })
+    .unwrap();
+
+    for c in v {
+        assert_eq!(c.load(Ordering::SeqCst), THREADS);
+    }
+}
+
+#[test]
+fn mpmc_ring_buffer() {
+    #[cfg(miri)]
+    const COUNT: usize = 50;
+    #[cfg(not(miri))]
+    const COUNT: usize = 25_000;
+    const THREADS: usize = 4;
+
+    let t = AtomicUsize::new(THREADS);
+    let q = StaticArrayQueue::<usize, 3>::new();
+    let v = (0..COUNT).map(|_| AtomicUsize::new(0)).collect::<Vec<_>>();
+
+    scope(|scope| {
+        for _ in 0..THREADS {
+            scope.spawn(|_| loop {
+                match t.load(Ordering::SeqCst) {
+                    0 if q.is_empty() => break,
+
+                    _ => {
+                        while let Some(n) = q.pop() {
+                            v[n].fetch_add(1, Ordering::SeqCst);
+                        }
+                    }
+                }
+            });
+        }
+
+        for _ in 0..THREADS {
+            scope.spawn(|_| {
+                for i in 0..COUNT {
+                    if let Some(n) = q.force_push(i) {
+                        v[n].fetch_add(1, Ordering::SeqCst);
+                    }
+                }
+
+                t.fetch_sub(1, Ordering::SeqCst);
+            });
+        }
+    })
+    .unwrap();
+
+    for c in v {
+        assert_eq!(c.load(Ordering::SeqCst), THREADS);
+    }
+}
+
+#[test]
+fn drops() {
+    let runs: usize = if cfg!(miri) { 3 } else { 100 };
+    let steps: usize = if cfg!(miri) { 50 } else { 10_000 };
+    let additional: usize = if cfg!(miri) { 10 } else { 50 };
+
+    static DROPS: AtomicUsize = AtomicUsize::new(0);
+
+    #[derive(Debug, PartialEq)]
+    struct DropCounter;
+
+    impl Drop for DropCounter {
+        fn drop(&mut self) {
+            DROPS.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    let mut rng = thread_rng();
+
+    for _ in 0..runs {
+        let steps = rng.gen_range(0..steps);
+        let additional = rng.gen_range(0..additional);
+
+        DROPS.store(0, Ordering::SeqCst);
+        let q = StaticArrayQueue::<_, 50>::new();
+
+        scope(|scope| {
+            scope.spawn(|_| {
+                for _ in 0..steps {
+                    while q.pop().is_none() {}
+                }
+            });
+
+            scope.spawn(|_| {
+                for _ in 0..steps {
+                    while q.push(DropCounter).is_err() {
+                        DROPS.fetch_sub(1, Ordering::SeqCst);
+                    }
+                }
+            });
+        })
+        .unwrap();
+
+        for _ in 0..additional {
+            q.push(DropCounter).unwrap();
+        }
+
+        assert_eq!(DROPS.load(Ordering::SeqCst), steps);
+        drop(q);
+        assert_eq!(DROPS.load(Ordering::SeqCst), steps + additional);
+    }
+}
+
+#[test]
+fn linearizable() {
+    #[cfg(miri)]
+    const COUNT: usize = 100;
+    #[cfg(not(miri))]
+    const COUNT: usize = 25_000;
+    const THREADS: usize = 4;
+
+    let q = StaticArrayQueue::<_, THREADS>::new();
+
+    scope(|scope| {
+        for _ in 0..THREADS / 2 {
+            scope.spawn(|_| {
+                for _ in 0..COUNT {
+                    while q.push(0).is_err() {}
+                    q.pop().unwrap();
+                }
+            });
+
+            scope.spawn(|_| {
+                for _ in 0..COUNT {
+                    if q.force_push(0).is_none() {
+                        q.pop().unwrap();
+                    }
+                }
+            });
+        }
+    })
+    .unwrap();
+}
+
+#[test]
+fn into_iter() {
+    let q = StaticArrayQueue::<_, 100>::new();
+    for i in 0..100 {
+        q.push(i).unwrap();
+    }
+    for (i, j) in q.into_iter().enumerate() {
+        assert_eq!(i, j);
+    }
+}


### PR DESCRIPTION
# Motivation

Currently there is no queue (that I could find) that fulfills all the following criteria:
- `no_std` compatible (without `alloc`)
- lock-free
- usable as a static variable

`crossbeam_queue::ArrayQueue` is very close, but has the following problems:
- Not usable as a static variable (`new()` function isn't `const`)
- Requires `alloc`

# Content

This change introduces `StaticArrayQueue`, which is identical to `ArrayQueue` except that it contains the array unboxed as a member and has a `const` constructor.

This allows the following pattern:
```rust
use std::{
    thread::{self, sleep},
    time::Duration,
};

use crossbeam_queue::StaticArrayQueue;

static QUEUE: StaticArrayQueue<u32, 10> = StaticArrayQueue::new();

fn main() {
    thread::spawn(|| loop {
        while let Some(element) = QUEUE.pop() {
            println!("Got element: {}", element);
        }
        sleep(Duration::from_millis(1));
    });

    for i in 0..10 {
        QUEUE.push(i).unwrap();
        sleep(Duration::from_millis(10));
    }
}
```

# Open questions/tasks

- [ ] Const generics are not supported by Rust `1.38`. Bump MSRV? Publish as external crate? (in its current state, the code requires Rust `1.61`. So most likely publish this as an external crate)
