### PR TITLE
Reduce backoff spinning/usage

### DIFF
--- a/crossbeam-channel/src/context.rs
+++ b/crossbeam-channel/src/context.rs
@@ -138,21 +138,6 @@ impl Context {
     /// If the deadline is reached, `Selected::Aborted` will be selected.
     #[inline]
     pub fn wait_until(&self, deadline: Option<Instant>) -> Selected {
-        // Spin for a short time, waiting until an operation is selected.
-        let backoff = Backoff::new();
-        loop {
-            let sel = Selected::from(self.inner.select.load(Ordering::Acquire));
-            if sel != Selected::Waiting {
-                return sel;
-            }
-
-            if backoff.is_completed() {
-                break;
-            } else {
-                backoff.snooze();
-            }
-        }
-
         loop {
             // Check whether an operation has been selected.
             let sel = Selected::from(self.inner.select.load(Ordering::Acquire));

--- a/crossbeam-utils/src/backoff.rs
+++ b/crossbeam-utils/src/backoff.rs
@@ -3,7 +3,8 @@ use core::cell::Cell;
 use core::fmt;
 
 const SPIN_LIMIT: u32 = 6;
-const YIELD_LIMIT: u32 = 10;
+const PRE_SNOOZE_SPIN_LIMIT: u32 = 3;
+const YIELD_LIMIT: u32 = 6;
 
 /// Performs exponential backoff in spin loops.
 ///
@@ -205,7 +206,7 @@ impl Backoff {
     /// [`AtomicBool`]: std::sync::atomic::AtomicBool
     #[inline]
     pub fn snooze(&self) {
-        if self.step.get() <= SPIN_LIMIT {
+        if self.step.get() <= PRE_SNOOZE_SPIN_LIMIT {
             for _ in 0..1 << self.step.get() {
                 hint::spin_loop();
             }

--- a/crossbeam-utils/src/backoff.rs
+++ b/crossbeam-utils/src/backoff.rs
@@ -2,8 +2,8 @@ use crate::primitive::hint;
 use core::cell::Cell;
 use core::fmt;
 
-const SPIN_LIMIT: u32 = 6;
-const PRE_SNOOZE_SPIN_LIMIT: u32 = 3;
+// https://github.com/oneapi-src/oneTBB/blob/v2021.5.0/include/oneapi/tbb/detail/_utils.h#L46-L48
+const SPIN_LIMIT: u32 = 4;
 const YIELD_LIMIT: u32 = 6;
 
 /// Performs exponential backoff in spin loops.
@@ -206,7 +206,7 @@ impl Backoff {
     /// [`AtomicBool`]: std::sync::atomic::AtomicBool
     #[inline]
     pub fn snooze(&self) {
-        if self.step.get() <= PRE_SNOOZE_SPIN_LIMIT {
+        if self.step.get() <= SPIN_LIMIT {
             for _ in 0..1 << self.step.get() {
                 hint::spin_loop();
             }


### PR DESCRIPTION
This PR is a first step to reducing a lot of the spinning-related issues that have cropped up. It does two things:
- Remove optimistic spinning completely from `Context::wait_until`. There are already spin loops in `recv`/`send`, so another set of spins after entering the park queue is excessive.
- Reduce the amount of spinning in `Backoff::snooze`. As seen in https://github.com/crossbeam-rs/crossbeam/issues/821#issuecomment-1776524621, the amount of `PAUSE` instructions issued is quite high. This change reduces it from 6 to 3, similar to [parking-lot](https://github.com/Amanieu/parking_lot/blob/fa859df5893f28df3e7b32224bb237a0efaf71a2/core/src/spinwait.rs#L53-L57). It also reduces the amount of total amount of spinning, reducing `YIELD_LIMIT` to 6. This differs from parking-lot as it is common for a channel, unlike a mutex, to remain empty/full for long periods of times, and so if yielding doesn't allow progress after a few times it is likely better to park properly.