### PR TITLE
Support faster send/recv by not notifying the other side

### DIFF
--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -415,6 +415,13 @@ impl<T> Sender<T> {
     /// This method will either send a message into the channel immediately or return an error if
     /// the channel is full or disconnected. The returned error contains the original message.
     ///
+    /// Omitting notification makes the send operation complete faster. However, this means
+    /// receiver won't be notified about the existence of new message immediately. This means the
+    /// sole use of this call for a given channel could cause receivers to be blocked indefinitely.
+    /// Thus, this call must be accompanied with some explicit mechanism to wake up the receiver
+    /// like mixed use of notifying send operations or receive operations with retry or
+    /// timeout/deadline.
+    ///
     /// If called on a zero-capacity channel, this method will send the message only if there
     /// happens to be a receive operation on the other side of the channel at the same time. This
     /// means this is equivalent to the [send](Sender::send) operation.

--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -573,13 +573,16 @@ impl<T> Sender<T> {
     /// If called on a zero-capacity channel, this method will wait for a receive operation to
     /// appear on the other side of the channel. This means this is equivalent to the
     /// [send](Sender::send) operation.
-    pub fn send_timeout_unnotified(&self, msg: T, timeout: Duration) -> Result<(), SendTimeoutError<T>> {
+    pub fn send_timeout_unnotified(
+        &self,
+        msg: T,
+        timeout: Duration,
+    ) -> Result<(), SendTimeoutError<T>> {
         match Instant::now().checked_add(timeout) {
             Some(deadline) => self.send_internal(msg, deadline, false),
             None => self.send(msg).map_err(SendTimeoutError::from),
         }
     }
-
 
     /// Waits for a message to be sent into the channel, but only until a given deadline.
     ///
@@ -640,11 +643,20 @@ impl<T> Sender<T> {
     /// If called on a zero-capacity channel, this method will wait for a receive operation to
     /// appear on the other side of the channel. This means this is equivalent to the
     /// [send](Sender::send) operation.
-    pub fn send_deadline_unnotified(&self, msg: T, deadline: Instant) -> Result<(), SendTimeoutError<T>> {
+    pub fn send_deadline_unnotified(
+        &self,
+        msg: T,
+        deadline: Instant,
+    ) -> Result<(), SendTimeoutError<T>> {
         self.send_internal(msg, deadline, false)
     }
 
-    fn send_internal(&self, msg: T, deadline: Instant, notify: bool) -> Result<(), SendTimeoutError<T>> {
+    fn send_internal(
+        &self,
+        msg: T,
+        deadline: Instant,
+        notify: bool,
+    ) -> Result<(), SendTimeoutError<T>> {
         match &self.flavor {
             SenderFlavor::Array(chan) => chan.send(msg, Some(deadline), notify),
             SenderFlavor::List(chan) => chan.send(msg, Some(deadline), notify),

--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -498,7 +498,7 @@ impl<T> Sender<T> {
     ///     // This sleep is crucial; otherwise `.recv()` could block indefinitely!
     ///     thread::sleep(Duration::from_secs(1));
     ///     assert_eq!(r.recv(), Ok(1));
-    /// });
+    /// }).join().unwrap();
     /// ```
     pub fn send_unnotified(&self, msg: T) -> Result<(), SendError<T>> {
         match &self.flavor {

--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -424,7 +424,7 @@ impl<T> Sender<T> {
     ///
     /// If called on a zero-capacity channel, this method will send the message only if there
     /// happens to be a receive operation on the other side of the channel at the same time. This
-    /// means this is equivalent to the [send](Sender::send) operation.
+    /// means this is equivalent to the [try_send](Sender::try_send) operation.
     pub fn try_send_unnotified(&self, msg: T) -> Result<(), TrySendError<T>> {
         match &self.flavor {
             SenderFlavor::Array(chan) => chan.try_send(msg, false),
@@ -579,7 +579,7 @@ impl<T> Sender<T> {
     ///
     /// If called on a zero-capacity channel, this method will wait for a receive operation to
     /// appear on the other side of the channel. This means this is equivalent to the
-    /// [send](Sender::send) operation.
+    /// [send_timeout](Sender::send_timeout) operation.
     pub fn send_timeout_unnotified(
         &self,
         msg: T,
@@ -649,7 +649,7 @@ impl<T> Sender<T> {
     ///
     /// If called on a zero-capacity channel, this method will wait for a receive operation to
     /// appear on the other side of the channel. This means this is equivalent to the
-    /// [send](Sender::send) operation.
+    /// [send_deadline](Sender::send_deadline) operation.
     pub fn send_deadline_unnotified(
         &self,
         msg: T,

--- a/crossbeam-channel/src/flavors/array.rs
+++ b/crossbeam-channel/src/flavors/array.rs
@@ -324,7 +324,10 @@ impl<T> Channel<T> {
     pub(crate) fn try_send(&self, msg: T, notify: bool) -> Result<(), TrySendError<T>> {
         let token = &mut Token::default();
         if self.start_send(token) {
-            unsafe { self.write(token, msg, notify).map_err(TrySendError::Disconnected) }
+            unsafe {
+                self.write(token, msg, notify)
+                    .map_err(TrySendError::Disconnected)
+            }
         } else {
             Err(TrySendError::Full(msg))
         }

--- a/crossbeam-channel/src/flavors/list.rs
+++ b/crossbeam-channel/src/flavors/list.rs
@@ -278,7 +278,7 @@ impl<T> Channel<T> {
     }
 
     /// Writes a message into the channel.
-    pub(crate) unsafe fn write(&self, token: &mut Token, msg: T, notify_buffered: bool) -> Result<(), T> {
+    pub(crate) unsafe fn write(&self, token: &mut Token, msg: T, notify: bool) -> Result<(), T> {
         // If there is no slot, the channel is disconnected.
         if token.list.block.is_null() {
             return Err(msg);
@@ -292,7 +292,7 @@ impl<T> Channel<T> {
         slot.state.fetch_or(WRITE, Ordering::Release);
 
         // Wake a sleeping receiver.
-        if notify_buffered {
+        if notify {
             self.receivers.notify();
         }
         Ok(())
@@ -409,8 +409,8 @@ impl<T> Channel<T> {
     }
 
     /// Attempts to send a message into the channel.
-    pub(crate) fn try_send(&self, msg: T) -> Result<(), TrySendError<T>> {
-        self.send(msg, None).map_err(|err| match err {
+    pub(crate) fn try_send(&self, msg: T, notify: bool) -> Result<(), TrySendError<T>> {
+        self.send(msg, None, notify).map_err(|err| match err {
             SendTimeoutError::Disconnected(msg) => TrySendError::Disconnected(msg),
             SendTimeoutError::Timeout(_) => unreachable!(),
         })
@@ -421,25 +421,12 @@ impl<T> Channel<T> {
         &self,
         msg: T,
         _deadline: Option<Instant>,
+        notify: bool,
     ) -> Result<(), SendTimeoutError<T>> {
         let token = &mut Token::default();
         assert!(self.start_send(token));
         unsafe {
-            self.write(token, msg, true)
-                .map_err(SendTimeoutError::Disconnected)
-        }
-    }
-
-    /// Sends a message into the channel.
-    pub(crate) fn send_buffered(
-        &self,
-        msg: T,
-        _deadline: Option<Instant>,
-    ) -> Result<(), SendTimeoutError<T>> {
-        let token = &mut Token::default();
-        assert!(self.start_send(token));
-        unsafe {
-            self.write(token, msg, false)
+            self.write(token, msg, notify)
                 .map_err(SendTimeoutError::Disconnected)
         }
     }


### PR DESCRIPTION
(this is a draft)

Introduce a new send variant called (`send_buffered()`), which _doesn't notify_ receivers to avoid syscalls/context switches at the cost of increased latency.

sometimes, it's not desirable to incur the potential futex wake syscall cost for each and every message send.

as far as i can tell, there is no way to do like this in the current api:

```rust
// sender thread
// some tight looping
loop {
    ...
    let task = ...;
    if !needs_flush {
        sender.send_buffered(Frame::Payload(task)).unwrap();
    } else {
        sender.send(Frame::Flush).unwrap();
    }
}

// receiver thread
loop {
    // receiver.try_recv() and std::thread::sleep() can't be used
    // because we want Flush to be handled immediately.
    while let Ok(msg) = receier.recv_timeout(Duration::from_millis(20)) {
      ...
    }
}
```

### naming

I haven't decided yet.. considering `.recv()`, `{try_,}send_{timeout_,}unnotified()`/`{try_,}recv_{timeout_,}unnotified()` might be better.