### PR TITLE
Various cleanups

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,9 @@ default-features = false
 [dev-dependencies]
 rand = "0.8"
 
+[lints]
+workspace = true
+
 [workspace]
 resolver = "2"
 members = [
@@ -80,3 +83,8 @@ members = [
   "crossbeam-skiplist",
   "crossbeam-utils",
 ]
+
+[workspace.lints.rust]
+missing_debug_implementations = "warn"
+rust_2018_idioms = "warn"
+unreachable_pub = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,4 +87,5 @@ members = [
 [workspace.lints.rust]
 missing_debug_implementations = "warn"
 rust_2018_idioms = "warn"
+single_use_lifetimes = "warn"
 unreachable_pub = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "crossbeam"
 # - Update README.md
 # - Create "crossbeam-X.Y.Z" git tag
 version = "0.8.2"
-edition = "2018"
+edition = "2021"
 rust-version = "1.61"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ default-features = false
 rand = "0.8"
 
 [workspace]
+resolver = "2"
 members = [
   ".",
   "crossbeam-channel",

--- a/crossbeam-channel/Cargo.toml
+++ b/crossbeam-channel/Cargo.toml
@@ -5,7 +5,7 @@ name = "crossbeam-channel"
 # - Update README.md
 # - Create "crossbeam-channel-X.Y.Z" git tag
 version = "0.5.8"
-edition = "2018"
+edition = "2021"
 rust-version = "1.61"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"

--- a/crossbeam-channel/Cargo.toml
+++ b/crossbeam-channel/Cargo.toml
@@ -36,3 +36,6 @@ optional = true
 num_cpus = "1.13.0"
 rand = "0.8"
 signal-hook = "0.3"
+
+[lints]
+workspace = true

--- a/crossbeam-channel/benchmarks/Cargo.toml
+++ b/crossbeam-channel/benchmarks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "benchmarks"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/crossbeam-channel/benchmarks/Cargo.toml
+++ b/crossbeam-channel/benchmarks/Cargo.toml
@@ -69,3 +69,6 @@ doc = false
 name = "mpmc"
 path = "mpmc.rs"
 doc = false
+
+[lints]
+workspace = true

--- a/crossbeam-channel/benchmarks/message.rs
+++ b/crossbeam-channel/benchmarks/message.rs
@@ -3,7 +3,7 @@ use std::fmt;
 const LEN: usize = 1;
 
 #[derive(Clone, Copy)]
-pub struct Message(pub [usize; LEN]);
+pub(crate) struct Message(pub(crate) [usize; LEN]);
 
 impl fmt::Debug for Message {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -12,6 +12,6 @@ impl fmt::Debug for Message {
 }
 
 #[inline]
-pub fn new(num: usize) -> Message {
+pub(crate) fn new(num: usize) -> Message {
     Message([num; LEN])
 }

--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -648,7 +648,7 @@ impl<T> Sender<T> {
     /// let (s3, _) = unbounded();
     /// assert!(!s.same_channel(&s3));
     /// ```
-    pub fn same_channel(&self, other: &Sender<T>) -> bool {
+    pub fn same_channel(&self, other: &Self) -> bool {
         match (&self.flavor, &other.flavor) {
             (SenderFlavor::Array(ref a), SenderFlavor::Array(ref b)) => a == b,
             (SenderFlavor::List(ref a), SenderFlavor::List(ref b)) => a == b,
@@ -678,7 +678,7 @@ impl<T> Clone for Sender<T> {
             SenderFlavor::Zero(chan) => SenderFlavor::Zero(chan.acquire()),
         };
 
-        Sender { flavor }
+        Self { flavor }
     }
 }
 
@@ -1142,7 +1142,7 @@ impl<T> Receiver<T> {
     /// let (_, r3) = unbounded();
     /// assert!(!r.same_channel(&r3));
     /// ```
-    pub fn same_channel(&self, other: &Receiver<T>) -> bool {
+    pub fn same_channel(&self, other: &Self) -> bool {
         match (&self.flavor, &other.flavor) {
             (ReceiverFlavor::Array(a), ReceiverFlavor::Array(b)) => a == b,
             (ReceiverFlavor::List(a), ReceiverFlavor::List(b)) => a == b,
@@ -1181,7 +1181,7 @@ impl<T> Clone for Receiver<T> {
             ReceiverFlavor::Never(_) => ReceiverFlavor::Never(flavors::never::Channel::new()),
         };
 
-        Receiver { flavor }
+        Self { flavor }
     }
 }
 

--- a/crossbeam-channel/src/counter.rs
+++ b/crossbeam-channel/src/counter.rs
@@ -45,7 +45,7 @@ impl<C> Sender<C> {
     }
 
     /// Acquires another sender reference.
-    pub(crate) fn acquire(&self) -> Sender<C> {
+    pub(crate) fn acquire(&self) -> Self {
         let count = self.counter().senders.fetch_add(1, Ordering::Relaxed);
 
         // Cloning senders and calling `mem::forget` on the clones could potentially overflow the
@@ -55,7 +55,7 @@ impl<C> Sender<C> {
             process::abort();
         }
 
-        Sender {
+        Self {
             counter: self.counter,
         }
     }
@@ -83,7 +83,7 @@ impl<C> ops::Deref for Sender<C> {
 }
 
 impl<C> PartialEq for Sender<C> {
-    fn eq(&self, other: &Sender<C>) -> bool {
+    fn eq(&self, other: &Self) -> bool {
         self.counter == other.counter
     }
 }
@@ -100,7 +100,7 @@ impl<C> Receiver<C> {
     }
 
     /// Acquires another receiver reference.
-    pub(crate) fn acquire(&self) -> Receiver<C> {
+    pub(crate) fn acquire(&self) -> Self {
         let count = self.counter().receivers.fetch_add(1, Ordering::Relaxed);
 
         // Cloning receivers and calling `mem::forget` on the clones could potentially overflow the
@@ -110,7 +110,7 @@ impl<C> Receiver<C> {
             process::abort();
         }
 
-        Receiver {
+        Self {
             counter: self.counter,
         }
     }
@@ -138,7 +138,7 @@ impl<C> ops::Deref for Receiver<C> {
 }
 
 impl<C> PartialEq for Receiver<C> {
-    fn eq(&self, other: &Receiver<C>) -> bool {
+    fn eq(&self, other: &Self) -> bool {
         self.counter == other.counter
     }
 }

--- a/crossbeam-channel/src/err.rs
+++ b/crossbeam-channel/src/err.rs
@@ -152,8 +152,8 @@ impl<T> SendError<T> {
 impl<T> fmt::Debug for TrySendError<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            TrySendError::Full(..) => "Full(..)".fmt(f),
-            TrySendError::Disconnected(..) => "Disconnected(..)".fmt(f),
+            Self::Full(..) => "Full(..)".fmt(f),
+            Self::Disconnected(..) => "Disconnected(..)".fmt(f),
         }
     }
 }
@@ -161,8 +161,8 @@ impl<T> fmt::Debug for TrySendError<T> {
 impl<T> fmt::Display for TrySendError<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            TrySendError::Full(..) => "sending on a full channel".fmt(f),
-            TrySendError::Disconnected(..) => "sending on a disconnected channel".fmt(f),
+            Self::Full(..) => "sending on a full channel".fmt(f),
+            Self::Disconnected(..) => "sending on a disconnected channel".fmt(f),
         }
     }
 }
@@ -170,9 +170,9 @@ impl<T> fmt::Display for TrySendError<T> {
 impl<T: Send> error::Error for TrySendError<T> {}
 
 impl<T> From<SendError<T>> for TrySendError<T> {
-    fn from(err: SendError<T>) -> TrySendError<T> {
+    fn from(err: SendError<T>) -> Self {
         match err {
-            SendError(t) => TrySendError::Disconnected(t),
+            SendError(t) => Self::Disconnected(t),
         }
     }
 }
@@ -193,19 +193,19 @@ impl<T> TrySendError<T> {
     /// ```
     pub fn into_inner(self) -> T {
         match self {
-            TrySendError::Full(v) => v,
-            TrySendError::Disconnected(v) => v,
+            Self::Full(v) => v,
+            Self::Disconnected(v) => v,
         }
     }
 
     /// Returns `true` if the send operation failed because the channel is full.
     pub fn is_full(&self) -> bool {
-        matches!(self, TrySendError::Full(_))
+        matches!(self, Self::Full(_))
     }
 
     /// Returns `true` if the send operation failed because the channel is disconnected.
     pub fn is_disconnected(&self) -> bool {
-        matches!(self, TrySendError::Disconnected(_))
+        matches!(self, Self::Disconnected(_))
     }
 }
 
@@ -218,8 +218,8 @@ impl<T> fmt::Debug for SendTimeoutError<T> {
 impl<T> fmt::Display for SendTimeoutError<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            SendTimeoutError::Timeout(..) => "timed out waiting on send operation".fmt(f),
-            SendTimeoutError::Disconnected(..) => "sending on a disconnected channel".fmt(f),
+            Self::Timeout(..) => "timed out waiting on send operation".fmt(f),
+            Self::Disconnected(..) => "sending on a disconnected channel".fmt(f),
         }
     }
 }
@@ -227,9 +227,9 @@ impl<T> fmt::Display for SendTimeoutError<T> {
 impl<T: Send> error::Error for SendTimeoutError<T> {}
 
 impl<T> From<SendError<T>> for SendTimeoutError<T> {
-    fn from(err: SendError<T>) -> SendTimeoutError<T> {
+    fn from(err: SendError<T>) -> Self {
         match err {
-            SendError(e) => SendTimeoutError::Disconnected(e),
+            SendError(e) => Self::Disconnected(e),
         }
     }
 }
@@ -251,19 +251,19 @@ impl<T> SendTimeoutError<T> {
     /// ```
     pub fn into_inner(self) -> T {
         match self {
-            SendTimeoutError::Timeout(v) => v,
-            SendTimeoutError::Disconnected(v) => v,
+            Self::Timeout(v) => v,
+            Self::Disconnected(v) => v,
         }
     }
 
     /// Returns `true` if the send operation timed out.
     pub fn is_timeout(&self) -> bool {
-        matches!(self, SendTimeoutError::Timeout(_))
+        matches!(self, Self::Timeout(_))
     }
 
     /// Returns `true` if the send operation failed because the channel is disconnected.
     pub fn is_disconnected(&self) -> bool {
-        matches!(self, SendTimeoutError::Disconnected(_))
+        matches!(self, Self::Disconnected(_))
     }
 }
 
@@ -278,8 +278,8 @@ impl error::Error for RecvError {}
 impl fmt::Display for TryRecvError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            TryRecvError::Empty => "receiving on an empty channel".fmt(f),
-            TryRecvError::Disconnected => "receiving on an empty and disconnected channel".fmt(f),
+            Self::Empty => "receiving on an empty channel".fmt(f),
+            Self::Disconnected => "receiving on an empty and disconnected channel".fmt(f),
         }
     }
 }
@@ -287,9 +287,9 @@ impl fmt::Display for TryRecvError {
 impl error::Error for TryRecvError {}
 
 impl From<RecvError> for TryRecvError {
-    fn from(err: RecvError) -> TryRecvError {
+    fn from(err: RecvError) -> Self {
         match err {
-            RecvError => TryRecvError::Disconnected,
+            RecvError => Self::Disconnected,
         }
     }
 }
@@ -297,20 +297,20 @@ impl From<RecvError> for TryRecvError {
 impl TryRecvError {
     /// Returns `true` if the receive operation failed because the channel is empty.
     pub fn is_empty(&self) -> bool {
-        matches!(self, TryRecvError::Empty)
+        matches!(self, Self::Empty)
     }
 
     /// Returns `true` if the receive operation failed because the channel is disconnected.
     pub fn is_disconnected(&self) -> bool {
-        matches!(self, TryRecvError::Disconnected)
+        matches!(self, Self::Disconnected)
     }
 }
 
 impl fmt::Display for RecvTimeoutError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            RecvTimeoutError::Timeout => "timed out waiting on receive operation".fmt(f),
-            RecvTimeoutError::Disconnected => "channel is empty and disconnected".fmt(f),
+            Self::Timeout => "timed out waiting on receive operation".fmt(f),
+            Self::Disconnected => "channel is empty and disconnected".fmt(f),
         }
     }
 }
@@ -318,9 +318,9 @@ impl fmt::Display for RecvTimeoutError {
 impl error::Error for RecvTimeoutError {}
 
 impl From<RecvError> for RecvTimeoutError {
-    fn from(err: RecvError) -> RecvTimeoutError {
+    fn from(err: RecvError) -> Self {
         match err {
-            RecvError => RecvTimeoutError::Disconnected,
+            RecvError => Self::Disconnected,
         }
     }
 }
@@ -328,12 +328,12 @@ impl From<RecvError> for RecvTimeoutError {
 impl RecvTimeoutError {
     /// Returns `true` if the receive operation timed out.
     pub fn is_timeout(&self) -> bool {
-        matches!(self, RecvTimeoutError::Timeout)
+        matches!(self, Self::Timeout)
     }
 
     /// Returns `true` if the receive operation failed because the channel is disconnected.
     pub fn is_disconnected(&self) -> bool {
-        matches!(self, RecvTimeoutError::Disconnected)
+        matches!(self, Self::Disconnected)
     }
 }
 

--- a/crossbeam-channel/src/flavors/array.rs
+++ b/crossbeam-channel/src/flavors/array.rs
@@ -43,7 +43,7 @@ pub(crate) struct ArrayToken {
 impl Default for ArrayToken {
     #[inline]
     fn default() -> Self {
-        ArrayToken {
+        Self {
             slot: ptr::null(),
             stamp: 0,
         }
@@ -115,7 +115,7 @@ impl<T> Channel<T> {
             })
             .collect();
 
-        Channel {
+        Self {
             buffer,
             cap,
             one_lap,

--- a/crossbeam-channel/src/flavors/at.rs
+++ b/crossbeam-channel/src/flavors/at.rs
@@ -27,7 +27,7 @@ impl Channel {
     /// Creates a channel that delivers a message at a certain instant in time.
     #[inline]
     pub(crate) fn new_deadline(when: Instant) -> Self {
-        Channel {
+        Self {
             delivery_time: when,
             received: AtomicBool::new(false),
         }

--- a/crossbeam-channel/src/flavors/list.rs
+++ b/crossbeam-channel/src/flavors/list.rs
@@ -76,7 +76,7 @@ struct Block<T> {
 
 impl<T> Block<T> {
     /// Creates an empty block.
-    fn new() -> Block<T> {
+    fn new() -> Self {
         Self {
             next: AtomicPtr::new(ptr::null_mut()),
             slots: [Slot::UNINIT; BLOCK_CAP],
@@ -84,7 +84,7 @@ impl<T> Block<T> {
     }
 
     /// Waits until the next pointer is set.
-    fn wait_next(&self) -> *mut Block<T> {
+    fn wait_next(&self) -> *mut Self {
         let backoff = Backoff::new();
         loop {
             let next = self.next.load(Ordering::Acquire);
@@ -96,7 +96,7 @@ impl<T> Block<T> {
     }
 
     /// Sets the `DESTROY` bit in slots starting from `start` and destroys the block.
-    unsafe fn destroy(this: *mut Block<T>, start: usize) {
+    unsafe fn destroy(this: *mut Self, start: usize) {
         // It is not necessary to set the `DESTROY` bit in the last slot because that slot has
         // begun destruction of the block.
         for i in start..BLOCK_CAP - 1 {
@@ -139,7 +139,7 @@ pub(crate) struct ListToken {
 impl Default for ListToken {
     #[inline]
     fn default() -> Self {
-        ListToken {
+        Self {
             block: ptr::null(),
             offset: 0,
         }
@@ -170,7 +170,7 @@ pub(crate) struct Channel<T> {
 impl<T> Channel<T> {
     /// Creates a new unbounded channel.
     pub(crate) fn new() -> Self {
-        Channel {
+        Self {
             head: CachePadded::new(Position {
                 block: AtomicPtr::new(ptr::null_mut()),
                 index: AtomicUsize::new(0),

--- a/crossbeam-channel/src/flavors/never.rs
+++ b/crossbeam-channel/src/flavors/never.rs
@@ -22,7 +22,7 @@ impl<T> Channel<T> {
     /// Creates a channel that never delivers messages.
     #[inline]
     pub(crate) fn new() -> Self {
-        Channel {
+        Self {
             _marker: PhantomData,
         }
     }

--- a/crossbeam-channel/src/flavors/tick.rs
+++ b/crossbeam-channel/src/flavors/tick.rs
@@ -27,7 +27,7 @@ impl Channel {
     /// Creates a channel that delivers messages periodically.
     #[inline]
     pub(crate) fn new(delivery_time: Instant, dur: Duration) -> Self {
-        Channel {
+        Self {
             delivery_time: AtomicCell::new(delivery_time),
             duration: dur,
         }

--- a/crossbeam-channel/src/flavors/zero.rs
+++ b/crossbeam-channel/src/flavors/zero.rs
@@ -45,8 +45,8 @@ struct Packet<T> {
 
 impl<T> Packet<T> {
     /// Creates an empty packet on the stack.
-    fn empty_on_stack() -> Packet<T> {
-        Packet {
+    fn empty_on_stack() -> Self {
+        Self {
             on_stack: true,
             ready: AtomicBool::new(false),
             msg: UnsafeCell::new(None),
@@ -54,8 +54,8 @@ impl<T> Packet<T> {
     }
 
     /// Creates an empty packet on the heap.
-    fn empty_on_heap() -> Box<Packet<T>> {
-        Box::new(Packet {
+    fn empty_on_heap() -> Box<Self> {
+        Box::new(Self {
             on_stack: false,
             ready: AtomicBool::new(false),
             msg: UnsafeCell::new(None),
@@ -63,8 +63,8 @@ impl<T> Packet<T> {
     }
 
     /// Creates a packet on the stack, containing a message.
-    fn message_on_stack(msg: T) -> Packet<T> {
-        Packet {
+    fn message_on_stack(msg: T) -> Self {
+        Self {
             on_stack: true,
             ready: AtomicBool::new(false),
             msg: UnsafeCell::new(Some(msg)),
@@ -104,7 +104,7 @@ pub(crate) struct Channel<T> {
 impl<T> Channel<T> {
     /// Constructs a new zero-capacity channel.
     pub(crate) fn new() -> Self {
-        Channel {
+        Self {
             inner: Mutex::new(Inner {
                 senders: Waker::new(),
                 receivers: Waker::new(),

--- a/crossbeam-channel/src/lib.rs
+++ b/crossbeam-channel/src/lib.rs
@@ -332,12 +332,7 @@
         allow(dead_code, unused_assignments, unused_variables)
     )
 ))]
-#![warn(
-    missing_docs,
-    missing_debug_implementations,
-    rust_2018_idioms,
-    unreachable_pub
-)]
+#![warn(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use cfg_if::cfg_if;

--- a/crossbeam-channel/src/lib.rs
+++ b/crossbeam-channel/src/lib.rs
@@ -328,7 +328,7 @@
 #![doc(test(
     no_crate_inject,
     attr(
-        deny(warnings, rust_2018_idioms),
+        deny(warnings, rust_2018_idioms, single_use_lifetimes),
         allow(dead_code, unused_assignments, unused_variables)
     )
 ))]

--- a/crossbeam-channel/src/select.rs
+++ b/crossbeam-channel/src/select.rs
@@ -42,12 +42,12 @@ impl Operation {
     /// reference should point to a variable that is specific to the thread and the operation,
     /// and is alive for the entire duration of select or blocking operation.
     #[inline]
-    pub fn hook<T>(r: &mut T) -> Operation {
+    pub fn hook<T>(r: &mut T) -> Self {
         let val = r as *mut T as usize;
         // Make sure that the pointer address doesn't equal the numerical representation of
         // `Selected::{Waiting, Aborted, Disconnected}`.
         assert!(val > 2);
-        Operation(val)
+        Self(val)
     }
 }
 
@@ -69,12 +69,12 @@ pub enum Selected {
 
 impl From<usize> for Selected {
     #[inline]
-    fn from(val: usize) -> Selected {
+    fn from(val: usize) -> Self {
         match val {
-            0 => Selected::Waiting,
-            1 => Selected::Aborted,
-            2 => Selected::Disconnected,
-            oper => Selected::Operation(Operation(oper)),
+            0 => Self::Waiting,
+            1 => Self::Aborted,
+            2 => Self::Disconnected,
+            oper => Self::Operation(Operation(oper)),
         }
     }
 }
@@ -618,8 +618,8 @@ impl<'a> Select<'a> {
     /// // The list of operations is empty, which means no operation can be selected.
     /// assert!(sel.try_select().is_err());
     /// ```
-    pub fn new() -> Select<'a> {
-        Select {
+    pub fn new() -> Self {
+        Self {
             handles: Vec::with_capacity(4),
             next_index: 0,
         }
@@ -1128,18 +1128,18 @@ impl<'a> Select<'a> {
     }
 }
 
-impl<'a> Clone for Select<'a> {
-    fn clone(&self) -> Select<'a> {
-        Select {
+impl Clone for Select<'_> {
+    fn clone(&self) -> Self {
+        Self {
             handles: self.handles.clone(),
             next_index: self.next_index,
         }
     }
 }
 
-impl<'a> Default for Select<'a> {
-    fn default() -> Select<'a> {
-        Select::new()
+impl Default for Select<'_> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/crossbeam-channel/src/select_macro.rs
+++ b/crossbeam-channel/src/select_macro.rs
@@ -685,7 +685,7 @@ macro_rules! crossbeam_channel_internal {
         $default:tt
     ) => {{
         const _LEN: usize = $crate::crossbeam_channel_internal!(@count ($($cases)*));
-        let _handle: &$crate::internal::SelectHandle = &$crate::never::<()>();
+        let _handle: &dyn $crate::internal::SelectHandle = &$crate::never::<()>();
 
         #[allow(unused_mut)]
         let mut _sel = [(_handle, 0, ::std::ptr::null()); _LEN];

--- a/crossbeam-channel/src/waker.rs
+++ b/crossbeam-channel/src/waker.rs
@@ -36,7 +36,7 @@ impl Waker {
     /// Creates a new `Waker`.
     #[inline]
     pub(crate) fn new() -> Self {
-        Waker {
+        Self {
             selectors: Vec::new(),
             observers: Vec::new(),
         }
@@ -186,7 +186,7 @@ impl SyncWaker {
     /// Creates a new `SyncWaker`.
     #[inline]
     pub(crate) fn new() -> Self {
-        SyncWaker {
+        Self {
             inner: Mutex::new(Waker::new()),
             is_empty: AtomicBool::new(true),
         }

--- a/crossbeam-channel/tests/golang.rs
+++ b/crossbeam-channel/tests/golang.rs
@@ -123,7 +123,7 @@ impl<T> Iterator for Chan<T> {
     }
 }
 
-impl<'a, T> IntoIterator for &'a Chan<T> {
+impl<T> IntoIterator for &Chan<T> {
     type Item = T;
     type IntoIter = Chan<T>;
 

--- a/crossbeam-channel/tests/golang.rs
+++ b/crossbeam-channel/tests/golang.rs
@@ -42,8 +42,8 @@ struct ChanInner<T> {
 }
 
 impl<T> Clone for Chan<T> {
-    fn clone(&self) -> Chan<T> {
-        Chan {
+    fn clone(&self) -> Self {
+        Self {
             inner: self.inner.clone(),
         }
     }
@@ -169,8 +169,8 @@ struct WaitGroupInner {
 }
 
 impl WaitGroup {
-    fn new() -> WaitGroup {
-        WaitGroup(Arc::new(WaitGroupInner {
+    fn new() -> Self {
+        Self(Arc::new(WaitGroupInner {
             cond: Condvar::new(),
             count: Mutex::new(0),
         }))
@@ -1621,7 +1621,7 @@ mod chan {
 
     impl ChanWithVals {
         fn with_capacity(capacity: usize) -> Self {
-            ChanWithVals {
+            Self {
                 chan: make(capacity),
                 sv: Arc::new(AtomicI32::new(0)),
                 rv: Arc::new(AtomicI32::new(0)),
@@ -1629,7 +1629,7 @@ mod chan {
         }
 
         fn closed() -> Self {
-            let ch = ChanWithVals::with_capacity(0);
+            let ch = Self::with_capacity(0);
             ch.chan.close_r();
             ch.chan.close_s();
             ch
@@ -1674,7 +1674,7 @@ mod chan {
 
     impl Clone for ChanWithVals {
         fn clone(&self) -> Self {
-            ChanWithVals {
+            Self {
                 chan: self.chan.clone(),
                 sv: self.sv.clone(),
                 rv: self.rv.clone(),
@@ -1702,7 +1702,7 @@ mod chan {
 
     impl Clone for Context {
         fn clone(&self) -> Self {
-            Context {
+            Self {
                 nproc: self.nproc.clone(),
                 cval: self.cval.clone(),
                 tot: self.tot.clone(),

--- a/crossbeam-channel/tests/mpsc.rs
+++ b/crossbeam-channel/tests/mpsc.rs
@@ -40,8 +40,8 @@ impl<T> Sender<T> {
 }
 
 impl<T> Clone for Sender<T> {
-    fn clone(&self) -> Sender<T> {
-        Sender {
+    fn clone(&self) -> Self {
+        Self {
             inner: self.inner.clone(),
         }
     }
@@ -65,8 +65,8 @@ impl<T> SyncSender<T> {
 }
 
 impl<T> Clone for SyncSender<T> {
-    fn clone(&self) -> SyncSender<T> {
-        SyncSender {
+    fn clone(&self) -> Self {
+        Self {
             inner: self.inner.clone(),
         }
     }

--- a/crossbeam-channel/tests/mpsc.rs
+++ b/crossbeam-channel/tests/mpsc.rs
@@ -126,7 +126,7 @@ struct TryIter<'a, T> {
     inner: &'a Receiver<T>,
 }
 
-impl<'a, T> Iterator for TryIter<'a, T> {
+impl<T> Iterator for TryIter<'_, T> {
     type Item = T;
 
     fn next(&mut self) -> Option<T> {
@@ -138,7 +138,7 @@ struct Iter<'a, T> {
     inner: &'a Receiver<T>,
 }
 
-impl<'a, T> Iterator for Iter<'a, T> {
+impl<T> Iterator for Iter<'_, T> {
     type Item = T;
 
     fn next(&mut self) -> Option<T> {

--- a/crossbeam-deque/Cargo.toml
+++ b/crossbeam-deque/Cargo.toml
@@ -5,7 +5,7 @@ name = "crossbeam-deque"
 # - Update README.md
 # - Create "crossbeam-deque-X.Y.Z" git tag
 version = "0.8.3"
-edition = "2018"
+edition = "2021"
 rust-version = "1.61"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"

--- a/crossbeam-deque/Cargo.toml
+++ b/crossbeam-deque/Cargo.toml
@@ -40,3 +40,6 @@ optional = true
 
 [dev-dependencies]
 rand = "0.8"
+
+[lints]
+workspace = true

--- a/crossbeam-deque/src/deque.rs
+++ b/crossbeam-deque/src/deque.rs
@@ -1,7 +1,6 @@
 use std::cell::{Cell, UnsafeCell};
 use std::cmp;
 use std::fmt;
-use std::iter::FromIterator;
 use std::marker::PhantomData;
 use std::mem::{self, ManuallyDrop, MaybeUninit};
 use std::ptr;

--- a/crossbeam-deque/src/lib.rs
+++ b/crossbeam-deque/src/lib.rs
@@ -89,12 +89,7 @@
         allow(dead_code, unused_assignments, unused_variables)
     )
 ))]
-#![warn(
-    missing_docs,
-    missing_debug_implementations,
-    rust_2018_idioms,
-    unreachable_pub
-)]
+#![warn(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use cfg_if::cfg_if;

--- a/crossbeam-deque/src/lib.rs
+++ b/crossbeam-deque/src/lib.rs
@@ -85,7 +85,7 @@
 #![doc(test(
     no_crate_inject,
     attr(
-        deny(warnings, rust_2018_idioms),
+        deny(warnings, rust_2018_idioms, single_use_lifetimes),
         allow(dead_code, unused_assignments, unused_variables)
     )
 ))]

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -5,7 +5,7 @@ name = "crossbeam-epoch"
 # - Update README.md
 # - Create "crossbeam-epoch-X.Y.Z" git tag
 version = "0.9.15"
-edition = "2018"
+edition = "2021"
 rust-version = "1.61"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -39,7 +39,6 @@ autocfg = "1"
 [dependencies]
 cfg-if = "1"
 memoffset = "0.9"
-scopeguard = { version = "1.1", default-features = false }
 
 # Enable the use of loom for concurrency testing.
 #

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -55,3 +55,6 @@ default-features = false
 
 [dev-dependencies]
 rand = "0.8"
+
+[lints]
+workspace = true

--- a/crossbeam-epoch/src/atomic.rs
+++ b/crossbeam-epoch/src/atomic.rs
@@ -265,7 +265,7 @@ impl<T> Atomic<T> {
     /// let a = Atomic::new(1234);
     /// # unsafe { drop(a.into_owned()); } // avoid leak
     /// ```
-    pub fn new(init: T) -> Atomic<T> {
+    pub fn new(init: T) -> Self {
         Self::init(init)
     }
 }
@@ -281,7 +281,7 @@ impl<T: ?Sized + Pointable> Atomic<T> {
     /// let a = Atomic::<i32>::init(1234);
     /// # unsafe { drop(a.into_owned()); } // avoid leak
     /// ```
-    pub fn init(init: T::Init) -> Atomic<T> {
+    pub fn init(init: T::Init) -> Self {
         Self::from(Owned::init(init))
     }
 
@@ -303,7 +303,7 @@ impl<T: ?Sized + Pointable> Atomic<T> {
     /// let a = Atomic::<i32>::null();
     /// ```
     #[cfg(not(crossbeam_loom))]
-    pub const fn null() -> Atomic<T> {
+    pub const fn null() -> Self {
         Self {
             data: AtomicPtr::new(ptr::null_mut()),
             _marker: PhantomData,
@@ -311,7 +311,7 @@ impl<T: ?Sized + Pointable> Atomic<T> {
     }
     /// Returns a new null atomic pointer.
     #[cfg(crossbeam_loom)]
-    pub fn null() -> Atomic<T> {
+    pub fn null() -> Self {
         Self {
             data: AtomicPtr::new(ptr::null_mut()),
             _marker: PhantomData,
@@ -846,13 +846,13 @@ impl<T: ?Sized + Pointable> Clone for Atomic<T> {
     /// atomics or fences.
     fn clone(&self) -> Self {
         let data = self.data.load(Ordering::Relaxed);
-        Atomic::from_ptr(data)
+        Self::from_ptr(data)
     }
 }
 
 impl<T: ?Sized + Pointable> Default for Atomic<T> {
     fn default() -> Self {
-        Atomic::null()
+        Self::null()
     }
 }
 
@@ -991,7 +991,7 @@ impl<T> Owned<T> {
     ///
     /// let o = unsafe { Owned::from_raw(Box::into_raw(Box::new(1234))) };
     /// ```
-    pub unsafe fn from_raw(raw: *mut T) -> Owned<T> {
+    pub unsafe fn from_raw(raw: *mut T) -> Self {
         let raw = raw.cast::<()>();
         ensure_aligned::<T>(raw);
         Self::from_ptr(raw)
@@ -1023,7 +1023,7 @@ impl<T> Owned<T> {
     ///
     /// let o = Owned::new(1234);
     /// ```
-    pub fn new(init: T) -> Owned<T> {
+    pub fn new(init: T) -> Self {
         Self::init(init)
     }
 }
@@ -1038,7 +1038,7 @@ impl<T: ?Sized + Pointable> Owned<T> {
     ///
     /// let o = Owned::<i32>::init(1234);
     /// ```
-    pub fn init(init: T::Init) -> Owned<T> {
+    pub fn init(init: T::Init) -> Self {
         unsafe { Self::from_ptr(T::init(init)) }
     }
 
@@ -1086,7 +1086,7 @@ impl<T: ?Sized + Pointable> Owned<T> {
     /// let o = o.with_tag(2);
     /// assert_eq!(o.tag(), 2);
     /// ```
-    pub fn with_tag(self, tag: usize) -> Owned<T> {
+    pub fn with_tag(self, tag: usize) -> Self {
         let data = self.into_ptr();
         unsafe { Self::from_ptr(compose_tag::<T>(data, tag)) }
     }
@@ -1114,7 +1114,7 @@ impl<T: ?Sized + Pointable> fmt::Debug for Owned<T> {
 
 impl<T: Clone> Clone for Owned<T> {
     fn clone(&self) -> Self {
-        Owned::new((**self).clone()).with_tag(self.tag())
+        Self::new((**self).clone()).with_tag(self.tag())
     }
 }
 
@@ -1136,7 +1136,7 @@ impl<T: ?Sized + Pointable> DerefMut for Owned<T> {
 
 impl<T> From<T> for Owned<T> {
     fn from(t: T) -> Self {
-        Owned::new(t)
+        Self::new(t)
     }
 }
 
@@ -1253,8 +1253,8 @@ impl<'g, T: ?Sized + Pointable> Shared<'g, T> {
     /// let p = Shared::<i32>::null();
     /// assert!(p.is_null());
     /// ```
-    pub fn null() -> Shared<'g, T> {
-        Shared {
+    pub fn null() -> Self {
+        Self {
             data: ptr::null_mut(),
             _marker: PhantomData,
         }
@@ -1564,7 +1564,7 @@ impl<T: ?Sized + Pointable> fmt::Pointer for Shared<'_, T> {
 
 impl<T: ?Sized + Pointable> Default for Shared<'_, T> {
     fn default() -> Self {
-        Shared::null()
+        Self::null()
     }
 }
 

--- a/crossbeam-epoch/src/atomic.rs
+++ b/crossbeam-epoch/src/atomic.rs
@@ -1218,7 +1218,7 @@ impl<T: ?Sized + Pointable> Pointer<T> for Shared<'_, T> {
     }
 }
 
-impl<'g, T> Shared<'g, T> {
+impl<T> Shared<'_, T> {
     /// Converts the pointer to a raw pointer (without the tag).
     ///
     /// # Examples

--- a/crossbeam-epoch/src/collector.rs
+++ b/crossbeam-epoch/src/collector.rs
@@ -50,7 +50,7 @@ impl Collector {
 impl Clone for Collector {
     /// Creates another reference to the same garbage collector.
     fn clone(&self) -> Self {
-        Collector {
+        Self {
             global: self.global.clone(),
         }
     }
@@ -64,7 +64,7 @@ impl fmt::Debug for Collector {
 
 impl PartialEq for Collector {
     /// Checks if both handles point to the same collector.
-    fn eq(&self, rhs: &Collector) -> bool {
+    fn eq(&self, rhs: &Self) -> bool {
         Arc::ptr_eq(&self.global, &rhs.global)
     }
 }

--- a/crossbeam-epoch/src/deferred.rs
+++ b/crossbeam-epoch/src/deferred.rs
@@ -53,7 +53,7 @@ impl Deferred {
                     f();
                 }
 
-                Deferred {
+                Self {
                     call: call::<F>,
                     data,
                     _marker: PhantomData,
@@ -70,7 +70,7 @@ impl Deferred {
                     (*b)();
                 }
 
-                Deferred {
+                Self {
                     call: call::<F>,
                     data,
                     _marker: PhantomData,

--- a/crossbeam-epoch/src/epoch.rs
+++ b/crossbeam-epoch/src/epoch.rs
@@ -45,16 +45,16 @@ impl Epoch {
 
     /// Returns the same epoch, but marked as pinned.
     #[inline]
-    pub(crate) fn pinned(self) -> Epoch {
-        Epoch {
+    pub(crate) fn pinned(self) -> Self {
+        Self {
             data: self.data | 1,
         }
     }
 
     /// Returns the same epoch, but marked as unpinned.
     #[inline]
-    pub(crate) fn unpinned(self) -> Epoch {
-        Epoch {
+    pub(crate) fn unpinned(self) -> Self {
+        Self {
             data: self.data & !1,
         }
     }
@@ -63,8 +63,8 @@ impl Epoch {
     ///
     /// The returned epoch will be marked as pinned only if the previous one was as well.
     #[inline]
-    pub(crate) fn successor(self) -> Epoch {
-        Epoch {
+    pub(crate) fn successor(self) -> Self {
+        Self {
             data: self.data.wrapping_add(2),
         }
     }
@@ -83,7 +83,7 @@ impl AtomicEpoch {
     #[inline]
     pub(crate) fn new(epoch: Epoch) -> Self {
         let data = AtomicUsize::new(epoch.data);
-        AtomicEpoch { data }
+        Self { data }
     }
 
     /// Loads a value from the atomic epoch.

--- a/crossbeam-epoch/src/internal.rs
+++ b/crossbeam-epoch/src/internal.rs
@@ -107,7 +107,7 @@ impl Bag {
 
 impl Default for Bag {
     fn default() -> Self {
-        Bag {
+        Self {
             len: 0,
             deferreds: [Deferred::NO_OP; MAX_OBJECTS],
         }
@@ -317,7 +317,7 @@ impl Local {
         unsafe {
             // Since we dereference no pointers in this block, it is safe to use `unprotected`.
 
-            let local = Owned::new(Local {
+            let local = Owned::new(Self {
                 entry: Entry::default(),
                 collector: UnsafeCell::new(ManuallyDrop::new(collector.clone())),
                 bag: UnsafeCell::new(Bag::new()),
@@ -534,20 +534,20 @@ impl Local {
     }
 }
 
-impl IsElement<Local> for Local {
-    fn entry_of(local: &Local) -> &Entry {
+impl IsElement<Self> for Local {
+    fn entry_of(local: &Self) -> &Entry {
         unsafe {
-            let entry_ptr = (local as *const Local as *const u8)
+            let entry_ptr = (local as *const Self as *const u8)
                 .add(offset_of!(Local, entry))
                 .cast::<Entry>();
             &*entry_ptr
         }
     }
 
-    unsafe fn element_of(entry: &Entry) -> &Local {
+    unsafe fn element_of(entry: &Entry) -> &Self {
         let local_ptr = (entry as *const Entry as *const u8)
             .sub(offset_of!(Local, entry))
-            .cast::<Local>();
+            .cast::<Self>();
         &*local_ptr
     }
 

--- a/crossbeam-epoch/src/lib.rs
+++ b/crossbeam-epoch/src/lib.rs
@@ -55,12 +55,7 @@
         allow(dead_code, unused_assignments, unused_variables)
     )
 ))]
-#![warn(
-    missing_docs,
-    missing_debug_implementations,
-    rust_2018_idioms,
-    unreachable_pub
-)]
+#![warn(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(crossbeam_loom)]

--- a/crossbeam-epoch/src/lib.rs
+++ b/crossbeam-epoch/src/lib.rs
@@ -100,8 +100,8 @@ mod primitive {
         // https://github.com/tokio-rs/loom#handling-loom-api-differences
         impl<T> UnsafeCell<T> {
             #[inline]
-            pub(crate) const fn new(data: T) -> UnsafeCell<T> {
-                UnsafeCell(::core::cell::UnsafeCell::new(data))
+            pub(crate) const fn new(data: T) -> Self {
+                Self(::core::cell::UnsafeCell::new(data))
             }
 
             #[inline]

--- a/crossbeam-epoch/src/lib.rs
+++ b/crossbeam-epoch/src/lib.rs
@@ -51,7 +51,7 @@
 #![doc(test(
     no_crate_inject,
     attr(
-        deny(warnings, rust_2018_idioms),
+        deny(warnings, rust_2018_idioms, single_use_lifetimes),
         allow(dead_code, unused_assignments, unused_variables)
     )
 ))]

--- a/crossbeam-epoch/src/sync/list.rs
+++ b/crossbeam-epoch/src/sync/list.rs
@@ -302,12 +302,12 @@ mod tests {
     use crossbeam_utils::thread;
     use std::sync::Barrier;
 
-    impl IsElement<Entry> for Entry {
-        fn entry_of(entry: &Entry) -> &Entry {
+    impl IsElement<Self> for Entry {
+        fn entry_of(entry: &Self) -> &Entry {
             entry
         }
 
-        unsafe fn element_of(entry: &Entry) -> &Entry {
+        unsafe fn element_of(entry: &Entry) -> &Self {
             entry
         }
 

--- a/crossbeam-epoch/src/sync/queue.rs
+++ b/crossbeam-epoch/src/sync/queue.rs
@@ -42,8 +42,8 @@ unsafe impl<T: Send> Send for Queue<T> {}
 
 impl<T> Queue<T> {
     /// Create a new, empty queue.
-    pub(crate) fn new() -> Queue<T> {
-        let q = Queue {
+    pub(crate) fn new() -> Self {
+        let q = Self {
             head: CachePadded::new(Atomic::null()),
             tail: CachePadded::new(Atomic::null()),
         };
@@ -226,8 +226,8 @@ mod test {
     }
 
     impl<T> Queue<T> {
-        pub(crate) fn new() -> Queue<T> {
-            Queue {
+        pub(crate) fn new() -> Self {
+            Self {
                 queue: super::Queue::new(),
             }
         }

--- a/crossbeam-epoch/tests/loom.rs
+++ b/crossbeam-epoch/tests/loom.rs
@@ -51,7 +51,7 @@ fn treiber_stack() {
     ///
     /// Usable with any number of producers and consumers.
     #[derive(Debug)]
-    pub struct TreiberStack<T> {
+    struct TreiberStack<T> {
         head: Atomic<Node<T>>,
     }
 
@@ -63,14 +63,14 @@ fn treiber_stack() {
 
     impl<T> TreiberStack<T> {
         /// Creates a new, empty stack.
-        pub fn new() -> Self {
+        fn new() -> Self {
             Self {
                 head: Atomic::null(),
             }
         }
 
         /// Pushes a value on top of the stack.
-        pub fn push(&self, t: T) {
+        fn push(&self, t: T) {
             let mut n = Owned::new(Node {
                 data: ManuallyDrop::new(t),
                 next: Atomic::null(),
@@ -95,7 +95,7 @@ fn treiber_stack() {
         /// Attempts to pop the top element from the stack.
         ///
         /// Returns `None` if the stack is empty.
-        pub fn pop(&self) -> Option<T> {
+        fn pop(&self) -> Option<T> {
             let guard = epoch::pin();
             loop {
                 let head = self.head.load(Acquire, &guard);
@@ -121,7 +121,7 @@ fn treiber_stack() {
         }
 
         /// Returns `true` if the stack is empty.
-        pub fn is_empty(&self) -> bool {
+        fn is_empty(&self) -> bool {
             let guard = epoch::pin();
             self.head.load(Acquire, &guard).is_null()
         }

--- a/crossbeam-epoch/tests/loom.rs
+++ b/crossbeam-epoch/tests/loom.rs
@@ -63,8 +63,8 @@ fn treiber_stack() {
 
     impl<T> TreiberStack<T> {
         /// Creates a new, empty stack.
-        pub fn new() -> TreiberStack<T> {
-            TreiberStack {
+        pub fn new() -> Self {
+            Self {
                 head: Atomic::null(),
             }
         }

--- a/crossbeam-queue/Cargo.toml
+++ b/crossbeam-queue/Cargo.toml
@@ -5,7 +5,7 @@ name = "crossbeam-queue"
 # - Update README.md
 # - Create "crossbeam-queue-X.Y.Z" git tag
 version = "0.3.8"
-edition = "2018"
+edition = "2021"
 rust-version = "1.61"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"

--- a/crossbeam-queue/Cargo.toml
+++ b/crossbeam-queue/Cargo.toml
@@ -37,3 +37,6 @@ default-features = false
 
 [dev-dependencies]
 rand = "0.8"
+
+[lints]
+workspace = true

--- a/crossbeam-queue/src/array_queue.rs
+++ b/crossbeam-queue/src/array_queue.rs
@@ -90,7 +90,7 @@ impl<T> ArrayQueue<T> {
     ///
     /// let q = ArrayQueue::<i32>::new(100);
     /// ```
-    pub fn new(cap: usize) -> ArrayQueue<T> {
+    pub fn new(cap: usize) -> Self {
         assert!(cap > 0, "capacity must be non-zero");
 
         // Head is initialized to `{ lap: 0, index: 0 }`.
@@ -113,7 +113,7 @@ impl<T> ArrayQueue<T> {
         // One lap is the smallest power of two greater than `cap`.
         let one_lap = (cap + 1).next_power_of_two();
 
-        ArrayQueue {
+        Self {
             buffer,
             cap,
             one_lap,

--- a/crossbeam-queue/src/lib.rs
+++ b/crossbeam-queue/src/lib.rs
@@ -12,12 +12,7 @@
         allow(dead_code, unused_assignments, unused_variables)
     )
 ))]
-#![warn(
-    missing_docs,
-    missing_debug_implementations,
-    rust_2018_idioms,
-    unreachable_pub
-)]
+#![warn(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(target_has_atomic = "ptr")]

--- a/crossbeam-queue/src/lib.rs
+++ b/crossbeam-queue/src/lib.rs
@@ -8,7 +8,7 @@
 #![doc(test(
     no_crate_inject,
     attr(
-        deny(warnings, rust_2018_idioms),
+        deny(warnings, rust_2018_idioms, single_use_lifetimes),
         allow(dead_code, unused_assignments, unused_variables)
     )
 ))]

--- a/crossbeam-queue/src/seg_queue.rs
+++ b/crossbeam-queue/src/seg_queue.rs
@@ -62,7 +62,7 @@ struct Block<T> {
 
 impl<T> Block<T> {
     /// Creates an empty block that starts at `start_index`.
-    fn new() -> Block<T> {
+    fn new() -> Self {
         Self {
             next: AtomicPtr::new(ptr::null_mut()),
             slots: [Slot::UNINIT; BLOCK_CAP],
@@ -70,7 +70,7 @@ impl<T> Block<T> {
     }
 
     /// Waits until the next pointer is set.
-    fn wait_next(&self) -> *mut Block<T> {
+    fn wait_next(&self) -> *mut Self {
         let backoff = Backoff::new();
         loop {
             let next = self.next.load(Ordering::Acquire);
@@ -82,7 +82,7 @@ impl<T> Block<T> {
     }
 
     /// Sets the `DESTROY` bit in slots starting from `start` and destroys the block.
-    unsafe fn destroy(this: *mut Block<T>, start: usize) {
+    unsafe fn destroy(this: *mut Self, start: usize) {
         // It is not necessary to set the `DESTROY` bit in the last slot because that slot has
         // begun destruction of the block.
         for i in start..BLOCK_CAP - 1 {
@@ -158,8 +158,8 @@ impl<T> SegQueue<T> {
     ///
     /// let q = SegQueue::<i32>::new();
     /// ```
-    pub const fn new() -> SegQueue<T> {
-        SegQueue {
+    pub const fn new() -> Self {
+        Self {
             head: CachePadded::new(Position {
                 block: AtomicPtr::new(ptr::null_mut()),
                 index: AtomicUsize::new(0),
@@ -482,8 +482,8 @@ impl<T> fmt::Debug for SegQueue<T> {
 }
 
 impl<T> Default for SegQueue<T> {
-    fn default() -> SegQueue<T> {
-        SegQueue::new()
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/crossbeam-skiplist/Cargo.toml
+++ b/crossbeam-skiplist/Cargo.toml
@@ -5,7 +5,7 @@ name = "crossbeam-skiplist"
 # - Update README.md
 # - Create "crossbeam-skiplist-X.Y.Z" git tag
 version = "0.1.1"
-edition = "2018"
+edition = "2021"
 rust-version = "1.61"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"

--- a/crossbeam-skiplist/Cargo.toml
+++ b/crossbeam-skiplist/Cargo.toml
@@ -41,10 +41,6 @@ version = "0.8.5"
 path = "../crossbeam-utils"
 default-features = false
 
-[dependencies.scopeguard]
-version = "1.1.0"
-default-features = false
-
 [dev-dependencies]
 rand = "0.8"
 

--- a/crossbeam-skiplist/Cargo.toml
+++ b/crossbeam-skiplist/Cargo.toml
@@ -47,3 +47,6 @@ default-features = false
 
 [dev-dependencies]
 rand = "0.8"
+
+[lints]
+workspace = true

--- a/crossbeam-skiplist/src/base.rs
+++ b/crossbeam-skiplist/src/base.rs
@@ -52,9 +52,9 @@ struct Head<K, V> {
 impl<K, V> Head<K, V> {
     /// Initializes a `Head`.
     #[inline]
-    fn new() -> Head<K, V> {
+    fn new() -> Self {
         // Initializing arrays in rust is a pain...
-        Head {
+        Self {
             pointers: Default::default(),
         }
     }
@@ -256,7 +256,7 @@ impl<K, V> Node<K, V> {
         ptr::drop_in_place(&mut (*ptr).value);
 
         // Finally, deallocate the memory occupied by the node.
-        Node::dealloc(ptr);
+        Self::dealloc(ptr);
     }
 }
 
@@ -332,8 +332,8 @@ unsafe impl<K: Send + Sync, V: Send + Sync> Sync for SkipList<K, V> {}
 
 impl<K, V> SkipList<K, V> {
     /// Returns a new, empty skip list.
-    pub fn new(collector: Collector) -> SkipList<K, V> {
-        SkipList {
+    pub fn new(collector: Collector) -> Self {
+        Self {
             head: Head::new(),
             collector,
             hot_data: CachePadded::new(HotData {
@@ -1370,9 +1370,9 @@ where
     }
 }
 
-impl<'a: 'g, 'g, K, V> Clone for Entry<'a, 'g, K, V> {
-    fn clone(&self) -> Entry<'a, 'g, K, V> {
-        Entry {
+impl<K, V> Clone for Entry<'_, '_, K, V> {
+    fn clone(&self) -> Self {
+        Self {
             parent: self.parent,
             node: self.node,
             guard: self.guard,
@@ -1538,13 +1538,13 @@ where
     }
 }
 
-impl<'a, K, V> Clone for RefEntry<'a, K, V> {
-    fn clone(&self) -> RefEntry<'a, K, V> {
+impl<K, V> Clone for RefEntry<'_, K, V> {
+    fn clone(&self) -> Self {
         unsafe {
             // Incrementing will always succeed since we're already holding a reference to the node.
             Node::try_increment(self.node);
         }
-        RefEntry {
+        Self {
             parent: self.parent,
             node: self.node,
         }

--- a/crossbeam-skiplist/src/base.rs
+++ b/crossbeam-skiplist/src/base.rs
@@ -1345,7 +1345,7 @@ impl<'a: 'g, 'g, K: 'a, V: 'a> Entry<'a, 'g, K, V> {
     }
 }
 
-impl<'a: 'g, 'g, K, V> Entry<'a, 'g, K, V>
+impl<K, V> Entry<'_, '_, K, V>
 where
     K: Ord + Send + 'static,
     V: Send + 'static,

--- a/crossbeam-skiplist/src/lib.rs
+++ b/crossbeam-skiplist/src/lib.rs
@@ -231,7 +231,7 @@
 #![doc(test(
     no_crate_inject,
     attr(
-        deny(warnings, rust_2018_idioms),
+        deny(warnings, rust_2018_idioms, single_use_lifetimes),
         allow(dead_code, unused_assignments, unused_variables)
     )
 ))]

--- a/crossbeam-skiplist/src/lib.rs
+++ b/crossbeam-skiplist/src/lib.rs
@@ -235,12 +235,7 @@
         allow(dead_code, unused_assignments, unused_variables)
     )
 ))]
-#![warn(
-    missing_docs,
-    missing_debug_implementations,
-    rust_2018_idioms,
-    unreachable_pub
-)]
+#![warn(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use cfg_if::cfg_if;

--- a/crossbeam-skiplist/src/map.rs
+++ b/crossbeam-skiplist/src/map.rs
@@ -2,7 +2,6 @@
 
 use std::borrow::Borrow;
 use std::fmt;
-use std::iter::FromIterator;
 use std::mem::ManuallyDrop;
 use std::ops::{Bound, RangeBounds};
 use std::ptr;

--- a/crossbeam-skiplist/src/map.rs
+++ b/crossbeam-skiplist/src/map.rs
@@ -712,7 +712,7 @@ impl<K, V> fmt::Debug for Iter<'_, K, V> {
     }
 }
 
-impl<'a, K, V> Drop for Iter<'a, K, V> {
+impl<K, V> Drop for Iter<'_, K, V> {
     fn drop(&mut self) {
         let guard = &epoch::pin();
         self.inner.drop_impl(guard);

--- a/crossbeam-skiplist/src/map.rs
+++ b/crossbeam-skiplist/src/map.rs
@@ -29,8 +29,8 @@ impl<K, V> SkipMap<K, V> {
     ///
     /// let map: SkipMap<i32, &str> = SkipMap::new();
     /// ```
-    pub fn new() -> SkipMap<K, V> {
-        SkipMap {
+    pub fn new() -> Self {
+        Self {
             inner: base::SkipList::new(epoch::default_collector().clone()),
         }
     }
@@ -505,8 +505,8 @@ where
 }
 
 impl<K, V> Default for SkipMap<K, V> {
-    fn default() -> SkipMap<K, V> {
-        SkipMap::new()
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -547,11 +547,11 @@ impl<K, V> FromIterator<(K, V)> for SkipMap<K, V>
 where
     K: Ord,
 {
-    fn from_iter<I>(iter: I) -> SkipMap<K, V>
+    fn from_iter<I>(iter: I) -> Self
     where
         I: IntoIterator<Item = (K, V)>,
     {
-        let s = SkipMap::new();
+        let s = Self::new();
         for (k, v) in iter {
             s.get_or_insert(k, v);
         }
@@ -565,8 +565,8 @@ pub struct Entry<'a, K, V> {
 }
 
 impl<'a, K, V> Entry<'a, K, V> {
-    fn new(inner: base::RefEntry<'a, K, V>) -> Entry<'a, K, V> {
-        Entry {
+    fn new(inner: base::RefEntry<'a, K, V>) -> Self {
+        Self {
             inner: ManuallyDrop::new(inner),
         }
     }
@@ -638,9 +638,9 @@ where
     }
 }
 
-impl<'a, K, V> Clone for Entry<'a, K, V> {
-    fn clone(&self) -> Entry<'a, K, V> {
-        Entry {
+impl<K, V> Clone for Entry<'_, K, V> {
+    fn clone(&self) -> Self {
+        Self {
             inner: self.inner.clone(),
         }
     }

--- a/crossbeam-skiplist/src/set.rs
+++ b/crossbeam-skiplist/src/set.rs
@@ -27,8 +27,8 @@ impl<T> SkipSet<T> {
     ///
     /// let set: SkipSet<i32> = SkipSet::new();
     /// ```
-    pub fn new() -> SkipSet<T> {
-        SkipSet {
+    pub fn new() -> Self {
+        Self {
             inner: map::SkipMap::new(),
         }
     }
@@ -391,8 +391,8 @@ where
 }
 
 impl<T> Default for SkipSet<T> {
-    fn default() -> SkipSet<T> {
-        SkipSet::new()
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -432,11 +432,11 @@ impl<T> FromIterator<T> for SkipSet<T>
 where
     T: Ord,
 {
-    fn from_iter<I>(iter: I) -> SkipSet<T>
+    fn from_iter<I>(iter: I) -> Self
     where
         I: IntoIterator<Item = T>,
     {
-        let s = SkipSet::new();
+        let s = Self::new();
         for t in iter {
             s.get_or_insert(t);
         }
@@ -450,8 +450,8 @@ pub struct Entry<'a, T> {
 }
 
 impl<'a, T> Entry<'a, T> {
-    fn new(inner: map::Entry<'a, T, ()>) -> Entry<'a, T> {
-        Entry { inner }
+    fn new(inner: map::Entry<'a, T, ()>) -> Self {
+        Self { inner }
     }
 
     /// Returns a reference to the value.
@@ -502,9 +502,9 @@ where
     }
 }
 
-impl<'a, T> Clone for Entry<'a, T> {
-    fn clone(&self) -> Entry<'a, T> {
-        Entry {
+impl<T> Clone for Entry<'_, T> {
+    fn clone(&self) -> Self {
+        Self {
             inner: self.inner.clone(),
         }
     }

--- a/crossbeam-skiplist/src/set.rs
+++ b/crossbeam-skiplist/src/set.rs
@@ -2,7 +2,6 @@
 
 use std::borrow::Borrow;
 use std::fmt;
-use std::iter::FromIterator;
 use std::ops::Deref;
 use std::ops::{Bound, RangeBounds};
 

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -33,3 +33,6 @@ loom = { version = "0.7.1", optional = true }
 
 [dev-dependencies]
 rand = "0.8"
+
+[lints]
+workspace = true

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -5,7 +5,7 @@ name = "crossbeam-utils"
 # - Update README.md
 # - Create "crossbeam-utils-X.Y.Z" git tag
 version = "0.8.16"
-edition = "2018"
+edition = "2021"
 rust-version = "1.61"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"

--- a/crossbeam-utils/build.rs
+++ b/crossbeam-utils/build.rs
@@ -10,8 +10,6 @@
 // With the exceptions mentioned above, the rustc-cfg emitted by the build
 // script are *not* public API.
 
-#![warn(rust_2018_idioms)]
-
 use std::env;
 
 include!("no_atomic.rs");

--- a/crossbeam-utils/src/atomic/atomic_cell.rs
+++ b/crossbeam-utils/src/atomic/atomic_cell.rs
@@ -6,11 +6,8 @@ use core::cell::UnsafeCell;
 use core::cmp;
 use core::fmt;
 use core::mem::{self, ManuallyDrop, MaybeUninit};
-
+use core::panic::{RefUnwindSafe, UnwindSafe};
 use core::ptr;
-
-#[cfg(feature = "std")]
-use std::panic::{RefUnwindSafe, UnwindSafe};
 
 use super::seq_lock::SeqLock;
 
@@ -48,9 +45,7 @@ pub struct AtomicCell<T> {
 unsafe impl<T: Send> Send for AtomicCell<T> {}
 unsafe impl<T: Send> Sync for AtomicCell<T> {}
 
-#[cfg(feature = "std")]
 impl<T> UnwindSafe for AtomicCell<T> {}
-#[cfg(feature = "std")]
 impl<T> RefUnwindSafe for AtomicCell<T> {}
 
 impl<T> AtomicCell<T> {

--- a/crossbeam-utils/src/atomic/atomic_cell.rs
+++ b/crossbeam-utils/src/atomic/atomic_cell.rs
@@ -58,8 +58,8 @@ impl<T> AtomicCell<T> {
     ///
     /// let a = AtomicCell::new(7);
     /// ```
-    pub const fn new(val: T) -> AtomicCell<T> {
-        AtomicCell {
+    pub const fn new(val: T) -> Self {
+        Self {
             value: UnsafeCell::new(MaybeUninit::new(val)),
         }
     }
@@ -911,15 +911,15 @@ impl AtomicCell<bool> {
 }
 
 impl<T: Default> Default for AtomicCell<T> {
-    fn default() -> AtomicCell<T> {
-        AtomicCell::new(T::default())
+    fn default() -> Self {
+        Self::new(T::default())
     }
 }
 
 impl<T> From<T> for AtomicCell<T> {
     #[inline]
-    fn from(val: T) -> AtomicCell<T> {
-        AtomicCell::new(val)
+    fn from(val: T) -> Self {
+        Self::new(val)
     }
 }
 

--- a/crossbeam-utils/src/backoff.rs
+++ b/crossbeam-utils/src/backoff.rs
@@ -93,7 +93,7 @@ impl Backoff {
     /// ```
     #[inline]
     pub fn new() -> Self {
-        Backoff { step: Cell::new(0) }
+        Self { step: Cell::new(0) }
     }
 
     /// Resets the `Backoff`.
@@ -283,7 +283,7 @@ impl fmt::Debug for Backoff {
 }
 
 impl Default for Backoff {
-    fn default() -> Backoff {
-        Backoff::new()
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/crossbeam-utils/src/cache_padded.rs
+++ b/crossbeam-utils/src/cache_padded.rs
@@ -160,8 +160,8 @@ impl<T> CachePadded<T> {
     ///
     /// let padded_value = CachePadded::new(1);
     /// ```
-    pub const fn new(t: T) -> CachePadded<T> {
-        CachePadded::<T> { value: t }
+    pub const fn new(t: T) -> Self {
+        Self { value: t }
     }
 
     /// Returns the inner value.
@@ -204,6 +204,6 @@ impl<T: fmt::Debug> fmt::Debug for CachePadded<T> {
 
 impl<T> From<T> for CachePadded<T> {
     fn from(t: T) -> Self {
-        CachePadded::new(t)
+        Self::new(t)
     }
 }

--- a/crossbeam-utils/src/lib.rs
+++ b/crossbeam-utils/src/lib.rs
@@ -31,12 +31,7 @@
         allow(dead_code, unused_assignments, unused_variables)
     )
 ))]
-#![warn(
-    missing_docs,
-    missing_debug_implementations,
-    rust_2018_idioms,
-    unreachable_pub
-)]
+#![warn(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(crossbeam_loom)]

--- a/crossbeam-utils/src/lib.rs
+++ b/crossbeam-utils/src/lib.rs
@@ -27,7 +27,7 @@
 #![doc(test(
     no_crate_inject,
     attr(
-        deny(warnings, rust_2018_idioms),
+        deny(warnings, rust_2018_idioms, single_use_lifetimes),
         allow(dead_code, unused_assignments, unused_variables)
     )
 ))]

--- a/crossbeam-utils/src/sync/parker.rs
+++ b/crossbeam-utils/src/sync/parker.rs
@@ -84,7 +84,7 @@ impl Parker {
     /// let p = Parker::new();
     /// ```
     ///
-    pub fn new() -> Parker {
+    pub fn new() -> Self {
         Self::default()
     }
 
@@ -184,7 +184,7 @@ impl Parker {
     /// let raw = Parker::into_raw(p);
     /// # let _ = unsafe { Parker::from_raw(raw) };
     /// ```
-    pub fn into_raw(this: Parker) -> *const () {
+    pub fn into_raw(this: Self) -> *const () {
         Unparker::into_raw(this.unparker)
     }
 
@@ -203,8 +203,8 @@ impl Parker {
     /// let raw = Parker::into_raw(p);
     /// let p = unsafe { Parker::from_raw(raw) };
     /// ```
-    pub unsafe fn from_raw(ptr: *const ()) -> Parker {
-        Parker {
+    pub unsafe fn from_raw(ptr: *const ()) -> Self {
+        Self {
             unparker: Unparker::from_raw(ptr),
             _marker: PhantomData,
         }
@@ -270,7 +270,7 @@ impl Unparker {
     /// let raw = Unparker::into_raw(u);
     /// # let _ = unsafe { Unparker::from_raw(raw) };
     /// ```
-    pub fn into_raw(this: Unparker) -> *const () {
+    pub fn into_raw(this: Self) -> *const () {
         Arc::into_raw(this.inner).cast::<()>()
     }
 
@@ -291,8 +291,8 @@ impl Unparker {
     /// let raw = Unparker::into_raw(u);
     /// let u = unsafe { Unparker::from_raw(raw) };
     /// ```
-    pub unsafe fn from_raw(ptr: *const ()) -> Unparker {
-        Unparker {
+    pub unsafe fn from_raw(ptr: *const ()) -> Self {
+        Self {
             inner: Arc::from_raw(ptr.cast::<Inner>()),
         }
     }
@@ -305,8 +305,8 @@ impl fmt::Debug for Unparker {
 }
 
 impl Clone for Unparker {
-    fn clone(&self) -> Unparker {
-        Unparker {
+    fn clone(&self) -> Self {
+        Self {
             inner: self.inner.clone(),
         }
     }

--- a/crossbeam-utils/src/sync/sharded_lock.rs
+++ b/crossbeam-utils/src/sync/sharded_lock.rs
@@ -97,8 +97,8 @@ impl<T> ShardedLock<T> {
     ///
     /// let lock = ShardedLock::new(5);
     /// ```
-    pub fn new(value: T) -> ShardedLock<T> {
-        ShardedLock {
+    pub fn new(value: T) -> Self {
+        Self {
             shards: (0..NUM_SHARDS)
                 .map(|_| {
                     CachePadded::new(Shard {
@@ -468,14 +468,14 @@ impl<T: ?Sized + fmt::Debug> fmt::Debug for ShardedLock<T> {
 }
 
 impl<T: Default> Default for ShardedLock<T> {
-    fn default() -> ShardedLock<T> {
-        ShardedLock::new(Default::default())
+    fn default() -> Self {
+        Self::new(Default::default())
     }
 }
 
 impl<T> From<T> for ShardedLock<T> {
     fn from(t: T) -> Self {
-        ShardedLock::new(t)
+        Self::new(t)
     }
 }
 

--- a/crossbeam-utils/src/sync/wait_group.rs
+++ b/crossbeam-utils/src/sync/wait_group.rs
@@ -128,11 +128,11 @@ impl Drop for WaitGroup {
 }
 
 impl Clone for WaitGroup {
-    fn clone(&self) -> WaitGroup {
+    fn clone(&self) -> Self {
         let mut count = self.inner.count.lock().unwrap();
         *count += 1;
 
-        WaitGroup {
+        Self {
             inner: self.inner.clone(),
         }
     }

--- a/crossbeam-utils/src/thread.rs
+++ b/crossbeam-utils/src/thread.rs
@@ -84,7 +84,7 @@
 //! tricky because argument `s` lives *inside* the invocation of `thread::scope()` and as such
 //! cannot be borrowed by scoped threads:
 //!
-//! ```compile_fail,E0373,E0521
+//! ```compile_fail,E0521
 //! use crossbeam_utils::thread;
 //!
 //! thread::scope(|s| {

--- a/crossbeam-utils/tests/atomic_cell.rs
+++ b/crossbeam-utils/tests/atomic_cell.rs
@@ -63,9 +63,9 @@ fn drops_unit() {
     struct Foo();
 
     impl Foo {
-        fn new() -> Foo {
+        fn new() -> Self {
             CNT.fetch_add(1, SeqCst);
-            Foo()
+            Self()
         }
     }
 
@@ -76,8 +76,8 @@ fn drops_unit() {
     }
 
     impl Default for Foo {
-        fn default() -> Foo {
-            Foo::new()
+        fn default() -> Self {
+            Self::new()
         }
     }
 
@@ -105,9 +105,9 @@ fn drops_u8() {
     struct Foo(u8);
 
     impl Foo {
-        fn new(val: u8) -> Foo {
+        fn new(val: u8) -> Self {
             CNT.fetch_add(1, SeqCst);
-            Foo(val)
+            Self(val)
         }
     }
 
@@ -118,8 +118,8 @@ fn drops_u8() {
     }
 
     impl Default for Foo {
-        fn default() -> Foo {
-            Foo::new(0)
+        fn default() -> Self {
+            Self::new(0)
         }
     }
 
@@ -151,9 +151,9 @@ fn drops_usize() {
     struct Foo(usize);
 
     impl Foo {
-        fn new(val: usize) -> Foo {
+        fn new(val: usize) -> Self {
             CNT.fetch_add(1, SeqCst);
-            Foo(val)
+            Self(val)
         }
     }
 
@@ -164,8 +164,8 @@ fn drops_usize() {
     }
 
     impl Default for Foo {
-        fn default() -> Foo {
-            Foo::new(0)
+        fn default() -> Self {
+            Self::new(0)
         }
     }
 
@@ -194,7 +194,7 @@ fn modular_u8() {
     struct Foo(u8);
 
     impl PartialEq for Foo {
-        fn eq(&self, other: &Foo) -> bool {
+        fn eq(&self, other: &Self) -> bool {
             self.0 % 5 == other.0 % 5
         }
     }
@@ -218,7 +218,7 @@ fn modular_usize() {
     struct Foo(usize);
 
     impl PartialEq for Foo {
-        fn eq(&self, other: &Foo) -> bool {
+        fn eq(&self, other: &Self) -> bool {
             self.0 % 5 == other.0 % 5
         }
     }

--- a/crossbeam-utils/tests/cache_padded.rs
+++ b/crossbeam-utils/tests/cache_padded.rs
@@ -99,10 +99,10 @@ fn runs_custom_clone() {
 
     struct Foo<'a>(&'a Cell<usize>);
 
-    impl<'a> Clone for Foo<'a> {
-        fn clone(&self) -> Foo<'a> {
+    impl Clone for Foo<'_> {
+        fn clone(&self) -> Self {
             self.0.set(self.0.get() + 1);
-            Foo::<'a>(self.0)
+            Self(self.0)
         }
     }
 

--- a/crossbeam-utils/tests/cache_padded.rs
+++ b/crossbeam-utils/tests/cache_padded.rs
@@ -69,7 +69,7 @@ fn drops() {
 
     struct Foo<'a>(&'a Cell<usize>);
 
-    impl<'a> Drop for Foo<'a> {
+    impl Drop for Foo<'_> {
         fn drop(&mut self) {
             self.0.set(self.0.get() + 1);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@
 #![doc(test(
     no_crate_inject,
     attr(
-        deny(warnings, rust_2018_idioms),
+        deny(warnings, rust_2018_idioms, single_use_lifetimes),
         allow(dead_code, unused_assignments, unused_variables)
     )
 ))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,12 +45,7 @@
         allow(dead_code, unused_assignments, unused_variables)
     )
 ))]
-#![warn(
-    missing_docs,
-    missing_debug_implementations,
-    rust_2018_idioms,
-    unreachable_pub
-)]
+#![warn(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub use crossbeam_utils::atomic;


### PR DESCRIPTION
I'm putting them into one PR because CI is slow. See individual commits for content.

- AtomicCell: Always implement {,Ref}UnwindSafe.
- Use 2021 edition & v2 resolver 
- Use [lints] in Cargo.toml & apply more lint
- Alternative to #724 & remove dependency on scopeguard

Closes #724