### PR TITLE
Add disconnected flavor which immediately fails

### DIFF
--- a/crossbeam-channel/src/flavors/disconnected.rs
+++ b/crossbeam-channel/src/flavors/disconnected.rs
@@ -1,0 +1,108 @@
+//! Channel that is always disconnected.
+//!
+//! Messages cannot be sent into this kind of channel.
+
+use std::marker::PhantomData;
+use std::time::Instant;
+
+use crate::context::Context;
+use crate::err::{RecvTimeoutError, TryRecvError};
+use crate::select::{Operation, SelectHandle, Token};
+
+/// This flavor doesn't need a token.
+pub(crate) type DisconnectedToken = ();
+
+/// Channel that always delivers messages.
+pub(crate) struct Channel<T> {
+    _marker: PhantomData<T>,
+}
+
+impl<T> Channel<T> {
+    /// Creates a channel that always delivers messages.
+    #[inline]
+    pub(crate) fn new() -> Self {
+        Channel {
+            _marker: PhantomData,
+        }
+    }
+
+    /// Attempts to receive a message without blocking.
+    #[inline]
+    pub(crate) fn try_recv(&self) -> Result<T, TryRecvError> {
+        Err(TryRecvError::Disconnected)
+    }
+
+    /// Receives a message from the channel.
+    #[inline]
+    pub(crate) fn recv(&self, _deadline: Option<Instant>) -> Result<T, RecvTimeoutError> {
+        Err(RecvTimeoutError::Disconnected)
+    }
+
+    /// Reads a message from the channel.
+    #[inline]
+    pub(crate) unsafe fn read(&self, _token: &mut Token) -> Result<T, ()> {
+        Err(())
+    }
+
+    /// Returns `true` if the channel is empty.
+    #[inline]
+    pub(crate) fn is_empty(&self) -> bool {
+        true
+    }
+
+    /// Returns `true` if the channel is full.
+    #[inline]
+    pub(crate) fn is_full(&self) -> bool {
+        true
+    }
+
+    /// Returns the number of messages in the channel.
+    #[inline]
+    pub(crate) fn len(&self) -> usize {
+        0
+    }
+
+    /// Returns the capacity of the channel.
+    #[inline]
+    pub(crate) fn capacity(&self) -> Option<usize> {
+        Some(0)
+    }
+}
+
+impl<T> SelectHandle for Channel<T> {
+    #[inline]
+    fn try_select(&self, _token: &mut Token) -> bool {
+        true
+    }
+
+    #[inline]
+    fn deadline(&self) -> Option<Instant> {
+        None
+    }
+
+    #[inline]
+    fn register(&self, _oper: Operation, _cx: &Context) -> bool {
+        self.is_ready()
+    }
+
+    #[inline]
+    fn unregister(&self, _oper: Operation) {}
+
+    #[inline]
+    fn accept(&self, token: &mut Token, _cx: &Context) -> bool {
+        self.try_select(token)
+    }
+
+    #[inline]
+    fn is_ready(&self) -> bool {
+        true
+    }
+
+    #[inline]
+    fn watch(&self, _oper: Operation, _cx: &Context) -> bool {
+        self.is_ready()
+    }
+
+    #[inline]
+    fn unwatch(&self, _oper: Operation) {}
+}

--- a/crossbeam-channel/src/flavors/mod.rs
+++ b/crossbeam-channel/src/flavors/mod.rs
@@ -6,11 +6,13 @@
 //! 2. `array` - Bounded channel based on a preallocated array.
 //! 3. `list` - Unbounded channel implemented as a linked list.
 //! 4. `never` - Channel that never delivers messages.
+//! 5. `disconnected` - Channel that is always disconnected.
 //! 5. `tick` - Channel that delivers messages periodically.
 //! 6. `zero` - Zero-capacity channel.
 
 pub(crate) mod array;
 pub(crate) mod at;
+pub(crate) mod disconnected;
 pub(crate) mod list;
 pub(crate) mod never;
 pub(crate) mod tick;

--- a/crossbeam-channel/src/lib.rs
+++ b/crossbeam-channel/src/lib.rs
@@ -356,7 +356,7 @@ cfg_if! {
             pub use crate::select::{select, select_timeout, try_select};
         }
 
-        pub use crate::channel::{after, at, never, tick};
+        pub use crate::channel::{after, at, never, disconnected, tick};
         pub use crate::channel::{bounded, unbounded};
         pub use crate::channel::{IntoIter, Iter, TryIter};
         pub use crate::channel::{Receiver, Sender};

--- a/crossbeam-channel/src/select.rs
+++ b/crossbeam-channel/src/select.rs
@@ -27,6 +27,8 @@ pub struct Token {
     pub(crate) list: flavors::list::ListToken,
     #[allow(dead_code)]
     pub(crate) never: flavors::never::NeverToken,
+    #[allow(dead_code)]
+    pub(crate) disconnected: flavors::disconnected::DisconnectedToken,
     pub(crate) tick: flavors::tick::TickToken,
     pub(crate) zero: flavors::zero::ZeroToken,
 }


### PR DESCRIPTION
Yet another small niceties, i'd like to add to `crossbeam_channel`.

This doesn't look meaningful by itself at first glance. However, this is useful for conditionally inserting an artificial select arm at predetermined priority in the `select_biased!()` #1040, combined with `never()` like this:


```rust
select_biased! {
    recv(important_channel) -> urgent_message => {
        ...
    },
    recv(if is_local_task_available { disconnected() } else { never() }) -> _dummy_signal => {
        ...
    },
    recv(normal_channel) -> normal_message => {
        ...
    },
}
```

Note that using `tick()` like below introduces needless calls to `Instant::now()` (which is a vdso basically) _per select invocation_ on top of the needless stack memory consumption. (On the other hand, the zst & `const`-code-heavy `disconnected()` will be optimized out to great degree after the macro expansion)..:

```rust
fn always() -> Receiver<Instant> {
    tick(Duration::default())
}

```

Also, unrolling the select is possible, but creates code duplication. Lastly, checking `is_local_task_available` after `select_biased!()` alone would introduce a priority inversion.

Thus, i think there's no acceptable alternative solution currently.