### PR TITLE
Relax MSRV of channel, queue, and utils to 1.60

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,13 +83,14 @@ jobs:
       fail-fast: false
       matrix:
         rust:
-          - '1.61'
+          - msrv
           - nightly
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
         run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
+        if: matrix.rust != 'msrv'
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
       - name: Check features

--- a/ci/check-features.sh
+++ b/ci/check-features.sh
@@ -6,9 +6,13 @@ cd "$(dirname "$0")"/..
 # * `--feature-powerset` - run for the feature powerset which includes --no-default-features and default features of package
 # * `--no-dev-deps` - build without dev-dependencies to avoid https://github.com/rust-lang/cargo/issues/4866
 # * `--exclude benchmarks` - benchmarks doesn't published.
-cargo hack build --all --feature-powerset --no-dev-deps --exclude benchmarks
+if [[ "${RUST_VERSION}" == "msrv" ]]; then
+    cargo hack build --all --feature-powerset --no-dev-deps --exclude benchmarks --rust-version
+else
+    cargo hack build --all --feature-powerset --no-dev-deps --exclude benchmarks
+fi
 
-if [[ "$RUST_VERSION" == "nightly"* ]]; then
+if [[ "${RUST_VERSION}" == "nightly"* ]]; then
     # Build for no_std environment.
     # thumbv7m-none-eabi supports atomic CAS.
     # thumbv6m-none-eabi supports atomic, but not atomic CAS.

--- a/crossbeam-channel/Cargo.toml
+++ b/crossbeam-channel/Cargo.toml
@@ -6,7 +6,7 @@ name = "crossbeam-channel"
 # - Create "crossbeam-channel-X.Y.Z" git tag
 version = "0.5.9"
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.60"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"
 homepage = "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-channel"

--- a/crossbeam-channel/README.md
+++ b/crossbeam-channel/README.md
@@ -8,7 +8,7 @@ https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-channel#license)
 https://crates.io/crates/crossbeam-channel)
 [![Documentation](https://docs.rs/crossbeam-channel/badge.svg)](
 https://docs.rs/crossbeam-channel)
-[![Rust 1.61+](https://img.shields.io/badge/rust-1.61+-lightgray.svg)](
+[![Rust 1.60+](https://img.shields.io/badge/rust-1.60+-lightgray.svg)](
 https://www.rust-lang.org)
 [![chat](https://img.shields.io/discord/569610676205781012.svg?logo=discord)](https://discord.com/invite/JXYwgWZ)
 
@@ -48,7 +48,7 @@ crossbeam-channel = "0.5"
 
 Crossbeam Channel supports stable Rust releases going back at least six months,
 and every time the minimum supported Rust version is increased, a new minor
-version is released. Currently, the minimum supported Rust version is 1.61.
+version is released. Currently, the minimum supported Rust version is 1.60.
 
 ## License
 

--- a/crossbeam-queue/Cargo.toml
+++ b/crossbeam-queue/Cargo.toml
@@ -6,7 +6,7 @@ name = "crossbeam-queue"
 # - Create "crossbeam-queue-X.Y.Z" git tag
 version = "0.3.9"
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.60"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"
 homepage = "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-queue"

--- a/crossbeam-queue/README.md
+++ b/crossbeam-queue/README.md
@@ -8,7 +8,7 @@ https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-queue#license)
 https://crates.io/crates/crossbeam-queue)
 [![Documentation](https://docs.rs/crossbeam-queue/badge.svg)](
 https://docs.rs/crossbeam-queue)
-[![Rust 1.61+](https://img.shields.io/badge/rust-1.61+-lightgray.svg)](
+[![Rust 1.60+](https://img.shields.io/badge/rust-1.60+-lightgray.svg)](
 https://www.rust-lang.org)
 [![chat](https://img.shields.io/discord/569610676205781012.svg?logo=discord)](https://discord.com/invite/JXYwgWZ)
 
@@ -36,7 +36,7 @@ crossbeam-queue = "0.3"
 
 Crossbeam Queue supports stable Rust releases going back at least six months,
 and every time the minimum supported Rust version is increased, a new minor
-version is released. Currently, the minimum supported Rust version is 1.61.
+version is released. Currently, the minimum supported Rust version is 1.60.
 
 ## License
 

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -6,7 +6,7 @@ name = "crossbeam-utils"
 # - Create "crossbeam-utils-X.Y.Z" git tag
 version = "0.8.17"
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.60"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"
 homepage = "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-utils"

--- a/crossbeam-utils/README.md
+++ b/crossbeam-utils/README.md
@@ -8,7 +8,7 @@ https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-utils#license)
 https://crates.io/crates/crossbeam-utils)
 [![Documentation](https://docs.rs/crossbeam-utils/badge.svg)](
 https://docs.rs/crossbeam-utils)
-[![Rust 1.61+](https://img.shields.io/badge/rust-1.61+-lightgray.svg)](
+[![Rust 1.60+](https://img.shields.io/badge/rust-1.60+-lightgray.svg)](
 https://www.rust-lang.org)
 [![chat](https://img.shields.io/discord/569610676205781012.svg?logo=discord)](https://discord.com/invite/JXYwgWZ)
 
@@ -55,7 +55,7 @@ crossbeam-utils = "0.8"
 
 Crossbeam Utils supports stable Rust releases going back at least six months,
 and every time the minimum supported Rust version is increased, a new minor
-version is released. Currently, the minimum supported Rust version is 1.61.
+version is released. Currently, the minimum supported Rust version is 1.60.
 
 ## License
 


### PR DESCRIPTION
Only epoch and its dependents require Rust 1.61.