### PR TITLE
Do not iterate elements in bounded queue/channel's destructor when needs_drop returns false

### DIFF
--- a/crossbeam-channel/src/flavors/array.rs
+++ b/crossbeam-channel/src/flavors/array.rs
@@ -9,7 +9,7 @@
 //!   - <https://docs.google.com/document/d/1yIAYmbvL3JxOKOjuCyon7JhW4cSv1wy5hC0ApeGMV9s/pub>
 
 use std::cell::UnsafeCell;
-use std::mem::MaybeUninit;
+use std::mem::{self, MaybeUninit};
 use std::ptr;
 use std::sync::atomic::{self, AtomicUsize, Ordering};
 use std::time::Instant;
@@ -520,36 +520,38 @@ impl<T> Channel<T> {
 
 impl<T> Drop for Channel<T> {
     fn drop(&mut self) {
-        // Get the index of the head.
-        let head = *self.head.get_mut();
-        let tail = *self.tail.get_mut();
+        if mem::needs_drop::<T>() {
+            // Get the index of the head.
+            let head = *self.head.get_mut();
+            let tail = *self.tail.get_mut();
 
-        let hix = head & (self.mark_bit - 1);
-        let tix = tail & (self.mark_bit - 1);
+            let hix = head & (self.mark_bit - 1);
+            let tix = tail & (self.mark_bit - 1);
 
-        let len = if hix < tix {
-            tix - hix
-        } else if hix > tix {
-            self.cap - hix + tix
-        } else if (tail & !self.mark_bit) == head {
-            0
-        } else {
-            self.cap
-        };
-
-        // Loop over all slots that hold a message and drop them.
-        for i in 0..len {
-            // Compute the index of the next slot holding a message.
-            let index = if hix + i < self.cap {
-                hix + i
+            let len = if hix < tix {
+                tix - hix
+            } else if hix > tix {
+                self.cap - hix + tix
+            } else if (tail & !self.mark_bit) == head {
+                0
             } else {
-                hix + i - self.cap
+                self.cap
             };
 
-            unsafe {
-                debug_assert!(index < self.buffer.len());
-                let slot = self.buffer.get_unchecked_mut(index);
-                (*slot.msg.get()).assume_init_drop();
+            // Loop over all slots that hold a message and drop them.
+            for i in 0..len {
+                // Compute the index of the next slot holding a message.
+                let index = if hix + i < self.cap {
+                    hix + i
+                } else {
+                    hix + i - self.cap
+                };
+
+                unsafe {
+                    debug_assert!(index < self.buffer.len());
+                    let slot = self.buffer.get_unchecked_mut(index);
+                    (*slot.msg.get()).assume_init_drop();
+                }
             }
         }
     }


### PR DESCRIPTION
https://doc.rust-lang.org/std/mem/fn.needs_drop.html
> Note that [drop_in_place](https://doc.rust-lang.org/std/ptr/fn.drop_in_place.html) already performs this check, so if your workload can be reduced to some small number of [drop_in_place](https://doc.rust-lang.org/std/ptr/fn.drop_in_place.html) calls, using this is unnecessary. In particular note that you can [drop_in_place](https://doc.rust-lang.org/std/ptr/fn.drop_in_place.html) a slice, and that will do a single needs_drop check for all the values.
>
> Types like `Vec` therefore just `drop_in_place(&mut self[..])` without using needs_drop explicitly. Types like [HashMap](https://doc.rust-lang.org/std/collections/struct.HashMap.html), on the other hand, have to drop values one at a time and should use this API.