### PR TITLE
epoch: Remove dependency on memoffset

### DIFF
--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -38,7 +38,6 @@ autocfg = "1"
 
 [dependencies]
 cfg-if = "1"
-memoffset = "0.9"
 
 # Enable the use of loom for concurrency testing.
 #

--- a/crossbeam-epoch/src/internal.rs
+++ b/crossbeam-epoch/src/internal.rs
@@ -43,7 +43,6 @@ use core::num::Wrapping;
 use core::{fmt, ptr};
 
 use crossbeam_utils::CachePadded;
-use memoffset::offset_of;
 
 use crate::atomic::{Owned, Shared};
 use crate::collector::{Collector, LocalHandle};
@@ -268,6 +267,7 @@ impl Global {
 }
 
 /// Participant for garbage collection.
+#[repr(C)] // Note: `entry` must be the first field
 pub(crate) struct Local {
     /// A node in the intrusive linked list of `Local`s.
     entry: Entry,
@@ -536,18 +536,16 @@ impl Local {
 
 impl IsElement<Self> for Local {
     fn entry_of(local: &Self) -> &Entry {
+        // SAFETY: `Local` is `repr(C)` and `entry` is the first field of it.
         unsafe {
-            let entry_ptr = (local as *const Self as *const u8)
-                .add(offset_of!(Local, entry))
-                .cast::<Entry>();
+            let entry_ptr = (local as *const Self).cast::<Entry>();
             &*entry_ptr
         }
     }
 
     unsafe fn element_of(entry: &Entry) -> &Self {
-        let local_ptr = (entry as *const Entry as *const u8)
-            .sub(offset_of!(Local, entry))
-            .cast::<Self>();
+        // SAFETY: `Local` is `repr(C)` and `entry` is the first field of it.
+        let local_ptr = (entry as *const Entry).cast::<Self>();
         &*local_ptr
     }
 


### PR DESCRIPTION
`entry` is the first field of `Local`, so we can remove the needs of `offset_of` by just making `Local` `repr(C)`.