### PR TITLE
v0.8: Prepare for the next release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ defaults:
   run:
     shell: bash
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   # Test crates on their minimum Rust versions and nightly Rust.
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,13 +75,14 @@ jobs:
       fail-fast: false
       matrix:
         rust:
-          - '1.61'
+          - msrv
           - nightly
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
         run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
+        if: matrix.rust != 'msrv'
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
       - name: Check features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.8.3
+
+- Bump the minimum supported Rust version to 1.61. (#1037)
+
 # Version 0.8.2
 
 - Bump the minimum supported Rust version to 1.38. (#877)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-X.Y.Z" git tag
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 rust-version = "1.61"
 license = "MIT OR Apache-2.0"
@@ -41,36 +41,13 @@ alloc = ["crossbeam-epoch/alloc", "crossbeam-queue/alloc"]
 nightly = ["crossbeam-epoch/nightly", "crossbeam-utils/nightly", "crossbeam-queue/nightly"]
 
 [dependencies]
+crossbeam-channel = { version = "0.5.10", path = "crossbeam-channel", default-features = false, optional = true }
+crossbeam-deque = { version = "0.8.4", path = "crossbeam-deque", default-features = false, optional = true }
+crossbeam-epoch = { version = "0.9.17", path = "crossbeam-epoch", default-features = false, optional = true }
+crossbeam-queue = { version = "0.3.10", path = "crossbeam-queue", default-features = false, optional = true }
+crossbeam-utils = { version = "0.8.18", path = "crossbeam-utils", default-features = false }
+
 cfg-if = "1"
-
-[dependencies.crossbeam-channel]
-version = "0.5.9"
-path = "./crossbeam-channel"
-default-features = false
-optional = true
-
-[dependencies.crossbeam-deque]
-version = "0.8.4"
-path = "./crossbeam-deque"
-default-features = false
-optional = true
-
-[dependencies.crossbeam-epoch]
-version = "0.9.16"
-path = "./crossbeam-epoch"
-default-features = false
-optional = true
-
-[dependencies.crossbeam-queue]
-version = "0.3.9"
-path = "./crossbeam-queue"
-default-features = false
-optional = true
-
-[dependencies.crossbeam-utils]
-version = "0.8.17"
-path = "./crossbeam-utils"
-default-features = false
 
 [dev-dependencies]
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "crossbeam"
 # - Update README.md
 # - Create "crossbeam-X.Y.Z" git tag
 version = "0.8.2"
-edition = "2018"
+edition = "2021"
 rust-version = "1.61"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ default-features = false
 rand = "0.8"
 
 [workspace]
+resolver = "2"
 members = [
   ".",
   "crossbeam-channel",

--- a/ci/check-features.sh
+++ b/ci/check-features.sh
@@ -3,17 +3,20 @@ set -euxo pipefail
 IFS=$'\n\t'
 cd "$(dirname "$0")"/..
 
-if [[ "$RUST_VERSION" != "nightly"* ]]; then
-    # On MSRV, features other than nightly should work.
-    # * `--feature-powerset` - run for the feature powerset which includes --no-default-features and default features of package
-    # * `--no-dev-deps` - build without dev-dependencies to avoid https://github.com/rust-lang/cargo/issues/4866
-    # * `--exclude benchmarks` - benchmarks doesn't published.
-    # * `--skip nightly` - skip `nightly` feature as requires nightly compilers.
+# * `--feature-powerset` - run for the feature powerset which includes --no-default-features and default features of package
+# * `--no-dev-deps` - build without dev-dependencies to avoid https://github.com/rust-lang/cargo/issues/4866
+# * `--exclude benchmarks` - benchmarks doesn't published.
+# * `--skip nightly` - skip `nightly` feature as requires nightly compilers.
+if [[ "${RUST_VERSION}" == "msrv" ]]; then
+    cargo hack build --all --feature-powerset --no-dev-deps --exclude benchmarks --skip nightly --rust-version
+elif [[ "$RUST_VERSION" != "nightly"* ]]; then
     cargo hack build --all --feature-powerset --no-dev-deps --exclude benchmarks --skip nightly
 else
     # On nightly, all feature　combinations should work.
     cargo hack build --all --feature-powerset --no-dev-deps --exclude benchmarks
+fi
 
+if [[ "${RUST_VERSION}" == "nightly"* ]]; then
     # Build for no_std environment.
     # thumbv7m-none-eabi supports atomic CAS.
     # thumbv6m-none-eabi supports atomic, but not atomic CAS.

--- a/crossbeam-channel/CHANGELOG.md
+++ b/crossbeam-channel/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 0.5.10
+
+- Relax the minimum supported Rust version to 1.60. (#1056)
+- Optimize `Drop` implementation of bounded channel. (#1057)
+
 # Version 0.5.9
 
 - Bump the minimum supported Rust version to 1.61. (#1037)

--- a/crossbeam-channel/Cargo.toml
+++ b/crossbeam-channel/Cargo.toml
@@ -6,7 +6,7 @@ name = "crossbeam-channel"
 # - Create "crossbeam-channel-X.Y.Z" git tag
 version = "0.5.9"
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.60"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"
 homepage = "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-channel"

--- a/crossbeam-channel/Cargo.toml
+++ b/crossbeam-channel/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-channel"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-channel-X.Y.Z" git tag
-version = "0.5.9"
+version = "0.5.10"
 edition = "2021"
 rust-version = "1.60"
 license = "MIT OR Apache-2.0"
@@ -24,13 +24,9 @@ default = ["std"]
 std = ["crossbeam-utils/std"]
 
 [dependencies]
-cfg-if = "1"
+crossbeam-utils = { version = "0.8.18", path = "../crossbeam-utils", default-features = false }
 
-[dependencies.crossbeam-utils]
-version = "0.8.17"
-path = "../crossbeam-utils"
-default-features = false
-optional = true
+cfg-if = "1"
 
 [dev-dependencies]
 num_cpus = "1.13.0"

--- a/crossbeam-channel/Cargo.toml
+++ b/crossbeam-channel/Cargo.toml
@@ -5,7 +5,7 @@ name = "crossbeam-channel"
 # - Update README.md
 # - Create "crossbeam-channel-X.Y.Z" git tag
 version = "0.5.9"
-edition = "2018"
+edition = "2021"
 rust-version = "1.61"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"

--- a/crossbeam-channel/README.md
+++ b/crossbeam-channel/README.md
@@ -8,7 +8,7 @@ https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-channel#license)
 https://crates.io/crates/crossbeam-channel)
 [![Documentation](https://docs.rs/crossbeam-channel/badge.svg)](
 https://docs.rs/crossbeam-channel)
-[![Rust 1.61+](https://img.shields.io/badge/rust-1.61+-lightgray.svg)](
+[![Rust 1.60+](https://img.shields.io/badge/rust-1.60+-lightgray.svg)](
 https://www.rust-lang.org)
 [![chat](https://img.shields.io/discord/569610676205781012.svg?logo=discord)](https://discord.com/invite/JXYwgWZ)
 
@@ -48,7 +48,7 @@ crossbeam-channel = "0.5"
 
 Crossbeam Channel supports stable Rust releases going back at least six months,
 and every time the minimum supported Rust version is increased, a new minor
-version is released. Currently, the minimum supported Rust version is 1.61.
+version is released. Currently, the minimum supported Rust version is 1.60.
 
 ## License
 

--- a/crossbeam-channel/benchmarks/Cargo.toml
+++ b/crossbeam-channel/benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "benchmarks"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
 publish = false
 

--- a/crossbeam-channel/benchmarks/Cargo.toml
+++ b/crossbeam-channel/benchmarks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "benchmarks"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/crossbeam-channel/src/flavors/array.rs
+++ b/crossbeam-channel/src/flavors/array.rs
@@ -549,8 +549,7 @@ impl<T> Drop for Channel<T> {
             unsafe {
                 debug_assert!(index < self.buffer.len());
                 let slot = self.buffer.get_unchecked_mut(index);
-                let msg = &mut *slot.msg.get();
-                msg.as_mut_ptr().drop_in_place();
+                (*slot.msg.get()).assume_init_drop();
             }
         }
     }

--- a/crossbeam-channel/src/flavors/array.rs
+++ b/crossbeam-channel/src/flavors/array.rs
@@ -9,7 +9,7 @@
 //!   - <https://docs.google.com/document/d/1yIAYmbvL3JxOKOjuCyon7JhW4cSv1wy5hC0ApeGMV9s/pub>
 
 use std::cell::UnsafeCell;
-use std::mem::MaybeUninit;
+use std::mem::{self, MaybeUninit};
 use std::ptr;
 use std::sync::atomic::{self, AtomicUsize, Ordering};
 use std::time::Instant;
@@ -520,36 +520,38 @@ impl<T> Channel<T> {
 
 impl<T> Drop for Channel<T> {
     fn drop(&mut self) {
-        // Get the index of the head.
-        let head = *self.head.get_mut();
-        let tail = *self.tail.get_mut();
+        if mem::needs_drop::<T>() {
+            // Get the index of the head.
+            let head = *self.head.get_mut();
+            let tail = *self.tail.get_mut();
 
-        let hix = head & (self.mark_bit - 1);
-        let tix = tail & (self.mark_bit - 1);
+            let hix = head & (self.mark_bit - 1);
+            let tix = tail & (self.mark_bit - 1);
 
-        let len = if hix < tix {
-            tix - hix
-        } else if hix > tix {
-            self.cap - hix + tix
-        } else if (tail & !self.mark_bit) == head {
-            0
-        } else {
-            self.cap
-        };
-
-        // Loop over all slots that hold a message and drop them.
-        for i in 0..len {
-            // Compute the index of the next slot holding a message.
-            let index = if hix + i < self.cap {
-                hix + i
+            let len = if hix < tix {
+                tix - hix
+            } else if hix > tix {
+                self.cap - hix + tix
+            } else if (tail & !self.mark_bit) == head {
+                0
             } else {
-                hix + i - self.cap
+                self.cap
             };
 
-            unsafe {
-                debug_assert!(index < self.buffer.len());
-                let slot = self.buffer.get_unchecked_mut(index);
-                (*slot.msg.get()).assume_init_drop();
+            // Loop over all slots that hold a message and drop them.
+            for i in 0..len {
+                // Compute the index of the next slot holding a message.
+                let index = if hix + i < self.cap {
+                    hix + i
+                } else {
+                    hix + i - self.cap
+                };
+
+                unsafe {
+                    debug_assert!(index < self.buffer.len());
+                    let slot = self.buffer.get_unchecked_mut(index);
+                    (*slot.msg.get()).assume_init_drop();
+                }
             }
         }
     }

--- a/crossbeam-channel/src/flavors/list.rs
+++ b/crossbeam-channel/src/flavors/list.rs
@@ -604,8 +604,7 @@ impl<T> Channel<T> {
                     // Drop the message in the slot.
                     let slot = (*block).slots.get_unchecked(offset);
                     slot.wait_write();
-                    let p = &mut *slot.msg.get();
-                    p.as_mut_ptr().drop_in_place();
+                    (*slot.msg.get()).assume_init_drop();
                 } else {
                     (*block).wait_next();
                     // Deallocate the block and move to the next one.
@@ -663,8 +662,7 @@ impl<T> Drop for Channel<T> {
                 if offset < BLOCK_CAP {
                     // Drop the message in the slot.
                     let slot = (*block).slots.get_unchecked(offset);
-                    let p = &mut *slot.msg.get();
-                    p.as_mut_ptr().drop_in_place();
+                    (*slot.msg.get()).assume_init_drop();
                 } else {
                     // Deallocate the block and move to the next one.
                     let next = *(*block).next.get_mut();

--- a/crossbeam-channel/src/select_macro.rs
+++ b/crossbeam-channel/src/select_macro.rs
@@ -685,7 +685,7 @@ macro_rules! crossbeam_channel_internal {
         $default:tt
     ) => {{
         const _LEN: usize = $crate::crossbeam_channel_internal!(@count ($($cases)*));
-        let _handle: &$crate::internal::SelectHandle = &$crate::never::<()>();
+        let _handle: &dyn $crate::internal::SelectHandle = &$crate::never::<()>();
 
         #[allow(unused_mut)]
         let mut _sel = [(_handle, 0, ::std::ptr::null()); _LEN];

--- a/crossbeam-deque/Cargo.toml
+++ b/crossbeam-deque/Cargo.toml
@@ -5,7 +5,7 @@ name = "crossbeam-deque"
 # - Update README.md
 # - Create "crossbeam-deque-X.Y.Z" git tag
 version = "0.8.4"
-edition = "2018"
+edition = "2021"
 rust-version = "1.61"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"

--- a/crossbeam-deque/Cargo.toml
+++ b/crossbeam-deque/Cargo.toml
@@ -24,19 +24,10 @@ default = ["std"]
 std = ["crossbeam-epoch/std", "crossbeam-utils/std"]
 
 [dependencies]
+crossbeam-epoch = { version = "0.9.17", path = "../crossbeam-epoch", default-features = false }
+crossbeam-utils = { version = "0.8.18", path = "../crossbeam-utils", default-features = false }
+
 cfg-if = "1"
-
-[dependencies.crossbeam-epoch]
-version = "0.9.16"
-path = "../crossbeam-epoch"
-default-features = false
-optional = true
-
-[dependencies.crossbeam-utils]
-version = "0.8.17"
-path = "../crossbeam-utils"
-default-features = false
-optional = true
 
 [dev-dependencies]
 rand = "0.8"

--- a/crossbeam-deque/src/deque.rs
+++ b/crossbeam-deque/src/deque.rs
@@ -1987,8 +1987,7 @@ impl<T> Drop for Injector<T> {
                 if offset < BLOCK_CAP {
                     // Drop the task in the slot.
                     let slot = (*block).slots.get_unchecked(offset);
-                    let p = &mut *slot.task.get();
-                    p.as_mut_ptr().drop_in_place();
+                    (*slot.task.get()).assume_init_drop();
                 } else {
                     // Deallocate the block and move to the next one.
                     let next = *(*block).next.get_mut();

--- a/crossbeam-deque/src/deque.rs
+++ b/crossbeam-deque/src/deque.rs
@@ -1,7 +1,6 @@
 use std::cell::{Cell, UnsafeCell};
 use std::cmp;
 use std::fmt;
-use std::iter::FromIterator;
 use std::marker::PhantomData;
 use std::mem::{self, ManuallyDrop, MaybeUninit};
 use std::ptr;

--- a/crossbeam-epoch/CHANGELOG.md
+++ b/crossbeam-epoch/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.9.17
+
+- Remove dependency on `memoffset`. (#1058)
+
 # Version 0.9.16
 
 - Bump the minimum supported Rust version to 1.61. (#1037)

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -5,7 +5,7 @@ name = "crossbeam-epoch"
 # - Update README.md
 # - Create "crossbeam-epoch-X.Y.Z" git tag
 version = "0.9.16"
-edition = "2018"
+edition = "2021"
 rust-version = "1.61"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-epoch"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-epoch-X.Y.Z" git tag
-version = "0.9.16"
+version = "0.9.17"
 edition = "2021"
 rust-version = "1.61"
 license = "MIT OR Apache-2.0"
@@ -46,6 +46,8 @@ loom = ["loom-crate", "crossbeam-utils/loom"]
 autocfg = "1"
 
 [dependencies]
+crossbeam-utils = { version = "0.8.18", path = "../crossbeam-utils", default-features = false }
+
 cfg-if = "1"
 
 # Enable the use of loom for concurrency testing.
@@ -54,11 +56,6 @@ cfg-if = "1"
 # patch versions of crossbeam may make breaking changes to them at any time.
 [target.'cfg(crossbeam_loom)'.dependencies]
 loom-crate = { package = "loom", version = "0.7.1", optional = true }
-
-[dependencies.crossbeam-utils]
-version = "0.8.17"
-path = "../crossbeam-utils"
-default-features = false
 
 [dev-dependencies]
 rand = "0.8"

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -47,7 +47,6 @@ autocfg = "1"
 
 [dependencies]
 cfg-if = "1"
-memoffset = "0.9"
 
 # Enable the use of loom for concurrency testing.
 #

--- a/crossbeam-epoch/src/sync/queue.rs
+++ b/crossbeam-epoch/src/sync/queue.rs
@@ -132,8 +132,7 @@ impl<T> Queue<T> {
                                 .compare_exchange(tail, next, Release, Relaxed, guard);
                         }
                         guard.defer_destroy(head);
-                        // TODO: Replace with MaybeUninit::read when api is stable
-                        Some(n.data.as_ptr().read())
+                        Some(n.data.assume_init_read())
                     })
                     .map_err(|_| ())
             },
@@ -165,7 +164,7 @@ impl<T> Queue<T> {
                                 .compare_exchange(tail, next, Release, Relaxed, guard);
                         }
                         guard.defer_destroy(head);
-                        Some(n.data.as_ptr().read())
+                        Some(n.data.assume_init_read())
                     })
                     .map_err(|_| ())
             },

--- a/crossbeam-queue/CHANGELOG.md
+++ b/crossbeam-queue/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 0.3.10
+
+- Relax the minimum supported Rust version to 1.60. (#1056)
+- Implement `UnwindSafe` and `RefUnwindSafe` for `ArrayQueue` and `SegQueue`. (#1053)
+- Optimize `Drop` implementation of `ArrayQueue`. (#1057)
+
 # Version 0.3.9
 
 - Bump the minimum supported Rust version to 1.61. (#1037)

--- a/crossbeam-queue/Cargo.toml
+++ b/crossbeam-queue/Cargo.toml
@@ -5,7 +5,7 @@ name = "crossbeam-queue"
 # - Update README.md
 # - Create "crossbeam-queue-X.Y.Z" git tag
 version = "0.3.9"
-edition = "2018"
+edition = "2021"
 rust-version = "1.61"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"

--- a/crossbeam-queue/Cargo.toml
+++ b/crossbeam-queue/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-queue"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-queue-X.Y.Z" git tag
-version = "0.3.9"
+version = "0.3.10"
 edition = "2021"
 rust-version = "1.60"
 license = "MIT OR Apache-2.0"
@@ -37,12 +37,9 @@ alloc = []
 nightly = ["crossbeam-utils/nightly"]
 
 [dependencies]
-cfg-if = "1"
+crossbeam-utils = { version = "0.8.18", path = "../crossbeam-utils", default-features = false }
 
-[dependencies.crossbeam-utils]
-version = "0.8.17"
-path = "../crossbeam-utils"
-default-features = false
+cfg-if = "1"
 
 [dev-dependencies]
 rand = "0.8"

--- a/crossbeam-queue/Cargo.toml
+++ b/crossbeam-queue/Cargo.toml
@@ -6,7 +6,7 @@ name = "crossbeam-queue"
 # - Create "crossbeam-queue-X.Y.Z" git tag
 version = "0.3.9"
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.60"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"
 homepage = "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-queue"

--- a/crossbeam-queue/README.md
+++ b/crossbeam-queue/README.md
@@ -8,7 +8,7 @@ https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-queue#license)
 https://crates.io/crates/crossbeam-queue)
 [![Documentation](https://docs.rs/crossbeam-queue/badge.svg)](
 https://docs.rs/crossbeam-queue)
-[![Rust 1.61+](https://img.shields.io/badge/rust-1.61+-lightgray.svg)](
+[![Rust 1.60+](https://img.shields.io/badge/rust-1.60+-lightgray.svg)](
 https://www.rust-lang.org)
 [![chat](https://img.shields.io/discord/569610676205781012.svg?logo=discord)](https://discord.com/invite/JXYwgWZ)
 
@@ -36,7 +36,7 @@ crossbeam-queue = "0.3"
 
 Crossbeam Queue supports stable Rust releases going back at least six months,
 and every time the minimum supported Rust version is increased, a new minor
-version is released. Currently, the minimum supported Rust version is 1.61.
+version is released. Currently, the minimum supported Rust version is 1.60.
 
 ## License
 

--- a/crossbeam-queue/src/array_queue.rs
+++ b/crossbeam-queue/src/array_queue.rs
@@ -476,8 +476,7 @@ impl<T> Drop for ArrayQueue<T> {
             unsafe {
                 debug_assert!(index < self.buffer.len());
                 let slot = self.buffer.get_unchecked_mut(index);
-                let value = &mut *slot.value.get();
-                value.as_mut_ptr().drop_in_place();
+                (*slot.value.get()).assume_init_drop();
             }
         }
     }

--- a/crossbeam-queue/src/array_queue.rs
+++ b/crossbeam-queue/src/array_queue.rs
@@ -7,6 +7,7 @@ use alloc::boxed::Box;
 use core::cell::UnsafeCell;
 use core::fmt;
 use core::mem::MaybeUninit;
+use core::panic::{RefUnwindSafe, UnwindSafe};
 use core::sync::atomic::{self, AtomicUsize, Ordering};
 
 use crossbeam_utils::{Backoff, CachePadded};
@@ -75,6 +76,9 @@ pub struct ArrayQueue<T> {
 
 unsafe impl<T: Send> Sync for ArrayQueue<T> {}
 unsafe impl<T: Send> Send for ArrayQueue<T> {}
+
+impl<T> UnwindSafe for ArrayQueue<T> {}
+impl<T> RefUnwindSafe for ArrayQueue<T> {}
 
 impl<T> ArrayQueue<T> {
     /// Creates a new bounded queue with the given capacity.

--- a/crossbeam-queue/src/seg_queue.rs
+++ b/crossbeam-queue/src/seg_queue.rs
@@ -3,6 +3,7 @@ use core::cell::UnsafeCell;
 use core::fmt;
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
+use core::panic::{RefUnwindSafe, UnwindSafe};
 use core::ptr;
 use core::sync::atomic::{self, AtomicPtr, AtomicUsize, Ordering};
 
@@ -147,6 +148,9 @@ pub struct SegQueue<T> {
 
 unsafe impl<T: Send> Send for SegQueue<T> {}
 unsafe impl<T: Send> Sync for SegQueue<T> {}
+
+impl<T> UnwindSafe for SegQueue<T> {}
+impl<T> RefUnwindSafe for SegQueue<T> {}
 
 impl<T> SegQueue<T> {
     /// Creates a new unbounded queue.

--- a/crossbeam-queue/src/seg_queue.rs
+++ b/crossbeam-queue/src/seg_queue.rs
@@ -459,8 +459,7 @@ impl<T> Drop for SegQueue<T> {
                 if offset < BLOCK_CAP {
                     // Drop the value in the slot.
                     let slot = (*block).slots.get_unchecked(offset);
-                    let p = &mut *slot.value.get();
-                    p.as_mut_ptr().drop_in_place();
+                    (*slot.value.get()).assume_init_drop();
                 } else {
                     // Deallocate the block and move to the next one.
                     let next = *(*block).next.get_mut();
@@ -525,8 +524,7 @@ impl<T> Iterator for IntoIter<T> {
             // and this is a non-empty queue.
             let item = unsafe {
                 let slot = (*block).slots.get_unchecked(offset);
-                let p = &mut *slot.value.get();
-                p.as_mut_ptr().read()
+                slot.value.get().read().assume_init()
             };
             if offset + 1 == BLOCK_CAP {
                 // Deallocate the block and move to the next one.

--- a/crossbeam-skiplist/Cargo.toml
+++ b/crossbeam-skiplist/Cargo.toml
@@ -5,7 +5,7 @@ name = "crossbeam-skiplist"
 # - Update README.md
 # - Create "crossbeam-skiplist-X.Y.Z" git tag
 version = "0.0.0"
-edition = "2018"
+edition = "2021"
 rust-version = "1.61"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"

--- a/crossbeam-skiplist/Cargo.toml
+++ b/crossbeam-skiplist/Cargo.toml
@@ -28,18 +28,10 @@ std = ["alloc", "crossbeam-epoch/std", "crossbeam-utils/std"]
 alloc = ["crossbeam-epoch/alloc"]
 
 [dependencies]
+crossbeam-epoch = { version = "0.9.17", path = "../crossbeam-epoch", default-features = false }
+crossbeam-utils = { version = "0.8.18", path = "../crossbeam-utils", default-features = false }
+
 cfg-if = "1"
-
-[dependencies.crossbeam-epoch]
-version = "0.9.16"
-path = "../crossbeam-epoch"
-default-features = false
-optional = true
-
-[dependencies.crossbeam-utils]
-version = "0.8.17"
-path = "../crossbeam-utils"
-default-features = false
 
 [dev-dependencies]
 rand = "0.8"

--- a/crossbeam-skiplist/src/map.rs
+++ b/crossbeam-skiplist/src/map.rs
@@ -2,7 +2,6 @@
 
 use std::borrow::Borrow;
 use std::fmt;
-use std::iter::FromIterator;
 use std::mem::ManuallyDrop;
 use std::ops::{Bound, RangeBounds};
 use std::ptr;

--- a/crossbeam-skiplist/src/set.rs
+++ b/crossbeam-skiplist/src/set.rs
@@ -2,7 +2,6 @@
 
 use std::borrow::Borrow;
 use std::fmt;
-use std::iter::FromIterator;
 use std::ops::Deref;
 use std::ops::{Bound, RangeBounds};
 

--- a/crossbeam-utils/CHANGELOG.md
+++ b/crossbeam-utils/CHANGELOG.md
@@ -1,8 +1,13 @@
+# Version 0.8.18
+
+- Relax the minimum supported Rust version to 1.60. (#1056)
+- Improve scalability of `AtomicCell` fallback. (#1055)
+
 # Version 0.8.17
 
 - Bump the minimum supported Rust version to 1.61. (#1037)
 - Improve support for targets without atomic CAS or 64-bit atomic. (#1037)
-- Always implement `{,Ref}UnwindSafe` for AtomicCell. (#1045)
+- Always implement `UnwindSafe` and `RefUnwindSafe` for `AtomicCell`. (#1045)
 - Improve compatibility with Miri, TSan, and loom. (#995, #1003)
 - Improve compatibility with unstable `oom=panic`. (#1045)
 - Improve implementation of `CachePadded`. (#1014, #1025)

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-utils"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-utils-X.Y.Z" git tag
-version = "0.8.17"
+version = "0.8.18"
 edition = "2021"
 rust-version = "1.60"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -5,7 +5,7 @@ name = "crossbeam-utils"
 # - Update README.md
 # - Create "crossbeam-utils-X.Y.Z" git tag
 version = "0.8.17"
-edition = "2018"
+edition = "2021"
 rust-version = "1.61"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -6,7 +6,7 @@ name = "crossbeam-utils"
 # - Create "crossbeam-utils-X.Y.Z" git tag
 version = "0.8.17"
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.60"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"
 homepage = "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-utils"

--- a/crossbeam-utils/README.md
+++ b/crossbeam-utils/README.md
@@ -8,7 +8,7 @@ https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-utils#license)
 https://crates.io/crates/crossbeam-utils)
 [![Documentation](https://docs.rs/crossbeam-utils/badge.svg)](
 https://docs.rs/crossbeam-utils)
-[![Rust 1.61+](https://img.shields.io/badge/rust-1.61+-lightgray.svg)](
+[![Rust 1.60+](https://img.shields.io/badge/rust-1.60+-lightgray.svg)](
 https://www.rust-lang.org)
 [![chat](https://img.shields.io/discord/569610676205781012.svg?logo=discord)](https://discord.com/invite/JXYwgWZ)
 
@@ -55,7 +55,7 @@ crossbeam-utils = "0.8"
 
 Crossbeam Utils supports stable Rust releases going back at least six months,
 and every time the minimum supported Rust version is increased, a new minor
-version is released. Currently, the minimum supported Rust version is 1.61.
+version is released. Currently, the minimum supported Rust version is 1.60.
 
 ## License
 

--- a/crossbeam-utils/src/atomic/atomic_cell.rs
+++ b/crossbeam-utils/src/atomic/atomic_cell.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::unit_arg)]
 
 use crate::primitive::sync::atomic::{self, Ordering};
+use crate::CachePadded;
 use core::cell::UnsafeCell;
 use core::cmp;
 use core::fmt;
@@ -998,10 +999,10 @@ fn lock(addr: usize) -> &'static SeqLock {
     // Now, if we have a slice of type `&[Foo]`, it is possible that field `a` in all items gets
     // stored at addresses that are multiples of 3. It'd be too bad if `LEN` was divisible by 3.
     // In order to protect from such cases, we simply choose a large prime number for `LEN`.
-    const LEN: usize = 97;
+    const LEN: usize = 67;
     #[allow(clippy::declare_interior_mutable_const)]
-    const L: SeqLock = SeqLock::new();
-    static LOCKS: [SeqLock; LEN] = [L; LEN];
+    const L: CachePadded<SeqLock> = CachePadded::new(SeqLock::new());
+    static LOCKS: [CachePadded<SeqLock>; LEN] = [L; LEN];
 
     // If the modulus is a constant number, the compiler will use crazy math to transform this into
     // a sequence of cheap arithmetic operations rather than using the slow modulo instruction.

--- a/crossbeam-utils/src/thread.rs
+++ b/crossbeam-utils/src/thread.rs
@@ -84,7 +84,7 @@
 //! tricky because argument `s` lives *inside* the invocation of `thread::scope()` and as such
 //! cannot be borrowed by scoped threads:
 //!
-//! ```compile_fail,E0373,E0521
+//! ```compile_fail,E0521
 //! use crossbeam_utils::thread;
 //!
 //! thread::scope(|s| {


### PR DESCRIPTION
- crossbeam-channel 0.5.9 -> 0.5.10
  - Relax the minimum supported Rust version to 1.60. (#1056)
  - Optimize `Drop` implementation of bounded channel. (#1057)
- crossbeam-epoch 0.9.16 -> 0.9.17
  - Remove dependency on `memoffset`. (#1058)
- crossbeam-queue 0.3.9 -> 0.3.10
  - Relax the minimum supported Rust version to 1.60. (#1056)
  - Implement `UnwindSafe` and `RefUnwindSafe` for `ArrayQueue` and `SegQueue`. (#1053)
  - Optimize `Drop` implementation of `ArrayQueue`. (#1057)
- crossbeam-utils 0.8.17 -> 0.8.18
  - Relax the minimum supported Rust version to 1.60. (#1056)
  - Improve scalability of `AtomicCell` fallback. (#1055)
- crossbeam 0.8.2 -> 0.8.3
  - Bump the minimum supported Rust version to 1.61. (#1037)