### PR TITLE
Prepare for the next release

### DIFF
--- a/crossbeam-skiplist/CHANGELOG.md
+++ b/crossbeam-skiplist/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Version 0.1.2
+
+- Bump the minimum supported Rust version to 1.61. (#1037)
+- Add `compare_insert`. (#976)
+- Improve support for targets without atomic CAS. (#1037)
+- Remove build script. (#1037)
+- Remove dependency on `scopeguard`. (#1045)
+
 # Version 0.1.1
 
 - Fix `get_unchecked` panic by raw pointer calculation. (#940)

--- a/crossbeam-skiplist/Cargo.toml
+++ b/crossbeam-skiplist/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-skiplist"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-skiplist-X.Y.Z" git tag
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 rust-version = "1.61"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
- crossbeam-skiplist 0.1.1 -> 0.1.2
  - Bump the minimum supported Rust version to 1.61. (#1037)
  - Add `compare_insert`. (#976)
  - Improve support for targets without atomic CAS. (#1037)
  - Remove build script. (#1037)
  - Remove dependency on `scopeguard`. (#1045)

Other crates are already released in #1061.