### PR TITLE
Move CachePadded to separate sub-crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ std = [
 alloc = ["crossbeam-epoch/alloc", "crossbeam-queue/alloc"]
 
 [dependencies]
+crossbeam-cachepadded = { version = "0.0", path = "crossbeam-cachepadded", default-features = false, optional = true }
 crossbeam-channel = { version = "0.5.10", path = "crossbeam-channel", default-features = false, optional = true }
 crossbeam-deque = { version = "0.8.4", path = "crossbeam-deque", default-features = false, optional = true }
 crossbeam-epoch = { version = "0.9.17", path = "crossbeam-epoch", default-features = false, optional = true }
@@ -52,6 +53,7 @@ workspace = true
 resolver = "2"
 members = [
   ".",
+  "crossbeam-cachepadded",
   "crossbeam-channel",
   "crossbeam-channel/benchmarks",
   "crossbeam-deque",

--- a/crossbeam-cachepadded/Cargo.toml
+++ b/crossbeam-cachepadded/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "crossbeam-cachepadded"
+# When publishing a new version:
+# - Update CHANGELOG.md
+# - Update README.md
+# - Create "crossbeam-cachepadded-X.Y.Z" git tag
+version = "0.0.0"
+authors = ["The Crossbeam Project Developers"]
+edition = "2018"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/crossbeam-rs/crossbeam"
+homepage = "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-cachepadded"
+documentation = "https://docs.rs/crossbeam-cachepadded"
+description = "Prevent false sharing by padding and aligning to the length of a cache line"
+keywords = ["cache", "padding", "lock-free", "atomic"]
+categories = ["concurrency", "no-std"]

--- a/crossbeam-cachepadded/Cargo.toml
+++ b/crossbeam-cachepadded/Cargo.toml
@@ -6,6 +6,7 @@ name = "crossbeam-cachepadded"
 # - Create "crossbeam-cachepadded-X.Y.Z" git tag
 version = "0.0.0"
 edition = "2018"
+rust-version = "1.38"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"
 homepage = "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-cachepadded"

--- a/crossbeam-cachepadded/Cargo.toml
+++ b/crossbeam-cachepadded/Cargo.toml
@@ -5,7 +5,6 @@ name = "crossbeam-cachepadded"
 # - Update README.md
 # - Create "crossbeam-cachepadded-X.Y.Z" git tag
 version = "0.0.0"
-authors = ["The Crossbeam Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"

--- a/crossbeam-cachepadded/src/lib.rs
+++ b/crossbeam-cachepadded/src/lib.rs
@@ -1,3 +1,20 @@
+//! TODO
+
+#![doc(test(
+    no_crate_inject,
+    attr(
+        deny(warnings, rust_2018_idioms),
+        allow(dead_code, unused_assignments, unused_variables)
+    )
+))]
+#![warn(
+    missing_docs,
+    missing_debug_implementations,
+    rust_2018_idioms,
+    unreachable_pub
+)]
+#![no_std]
+
 use core::fmt;
 use core::ops::{Deref, DerefMut};
 
@@ -34,7 +51,7 @@ use core::ops::{Deref, DerefMut};
 /// Alignment and padding:
 ///
 /// ```
-/// use crossbeam_utils::CachePadded;
+/// use crossbeam_cachepadded::CachePadded;
 ///
 /// let array = [CachePadded::new(1i8), CachePadded::new(2i8)];
 /// let addr1 = &*array[0] as *const i8 as usize;
@@ -50,7 +67,7 @@ use core::ops::{Deref, DerefMut};
 /// each other's cache lines:
 ///
 /// ```
-/// use crossbeam_utils::CachePadded;
+/// use crossbeam_cachepadded::CachePadded;
 /// use std::sync::atomic::AtomicUsize;
 ///
 /// struct Queue<T> {
@@ -156,7 +173,7 @@ impl<T> CachePadded<T> {
     /// # Examples
     ///
     /// ```
-    /// use crossbeam_utils::CachePadded;
+    /// use crossbeam_cachepadded::CachePadded;
     ///
     /// let padded_value = CachePadded::new(1);
     /// ```
@@ -169,7 +186,7 @@ impl<T> CachePadded<T> {
     /// # Examples
     ///
     /// ```
-    /// use crossbeam_utils::CachePadded;
+    /// use crossbeam_cachepadded::CachePadded;
     ///
     /// let padded_value = CachePadded::new(7);
     /// let value = padded_value.into_inner();

--- a/crossbeam-cachepadded/tests/cache_padded.rs
+++ b/crossbeam-cachepadded/tests/cache_padded.rs
@@ -1,7 +1,7 @@
 use std::cell::Cell;
 use std::mem;
 
-use crossbeam_utils::CachePadded;
+use crossbeam_cachepadded::CachePadded;
 
 #[test]
 fn default() {

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -24,6 +24,8 @@ std = []
 [dependencies]
 cfg-if = "1"
 
+crossbeam-cachepadded = { version = "0.0", path = "../crossbeam-cachepadded", default-features = false }
+
 # Enable the use of loom for concurrency testing.
 #
 # NOTE: This feature is outside of the normal semver guarantees and minor or

--- a/crossbeam-utils/src/lib.rs
+++ b/crossbeam-utils/src/lib.rs
@@ -88,8 +88,7 @@ mod primitive {
 
 pub mod atomic;
 
-mod cache_padded;
-pub use crate::cache_padded::CachePadded;
+pub use crossbeam_cachepadded::CachePadded;
 
 mod backoff;
 pub use crate::backoff::Backoff;

--- a/tests/subcrates.rs
+++ b/tests/subcrates.rs
@@ -45,3 +45,8 @@ fn utils() {
     })
     .unwrap();
 }
+
+#[test]
+fn cachepadded() {
+    crossbeam::utils::CachePadded::new(7);
+}


### PR DESCRIPTION
This is (for now) just a proof of concept to see whether moving `CachePadded` to a separate sub-crate is feasible.

Fixes #1066, which contains related discussion.