### PR TITLE
epoch: Remove unused autocfg dependency

### DIFF
--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -33,9 +33,6 @@ alloc = []
 # patch versions of crossbeam may make breaking changes to them at any time.
 loom = ["loom-crate", "crossbeam-utils/loom"]
 
-[build-dependencies]
-autocfg = "1"
-
 [dependencies]
 crossbeam-utils = { version = "0.8.18", path = "../crossbeam-utils", default-features = false }
 


### PR DESCRIPTION
This is unused since https://github.com/crossbeam-rs/crossbeam/pull/1037.