### PR TITLE
Remove dependency on cfg-if

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,6 @@ crossbeam-epoch = { version = "0.9.17", path = "crossbeam-epoch", default-featur
 crossbeam-queue = { version = "0.3.10", path = "crossbeam-queue", default-features = false, optional = true }
 crossbeam-utils = { version = "0.8.18", path = "crossbeam-utils", default-features = false }
 
-cfg-if = "1"
-
 [dev-dependencies]
 rand = "0.8"
 

--- a/crossbeam-channel/Cargo.toml
+++ b/crossbeam-channel/Cargo.toml
@@ -26,8 +26,6 @@ std = ["crossbeam-utils/std"]
 [dependencies]
 crossbeam-utils = { version = "0.8.18", path = "../crossbeam-utils", default-features = false }
 
-cfg-if = "1"
-
 [dev-dependencies]
 num_cpus = "1.13.0"
 rand = "0.8"

--- a/crossbeam-channel/src/lib.rs
+++ b/crossbeam-channel/src/lib.rs
@@ -335,36 +335,40 @@
 #![warn(missing_docs, unsafe_op_in_unsafe_fn)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use cfg_if::cfg_if;
+#[cfg(feature = "std")]
+mod channel;
+#[cfg(feature = "std")]
+mod context;
+#[cfg(feature = "std")]
+mod counter;
+#[cfg(feature = "std")]
+mod err;
+#[cfg(feature = "std")]
+mod flavors;
+#[cfg(feature = "std")]
+mod select;
+#[cfg(feature = "std")]
+mod select_macro;
+#[cfg(feature = "std")]
+mod utils;
+#[cfg(feature = "std")]
+mod waker;
 
-cfg_if! {
-    if #[cfg(feature = "std")] {
-        mod channel;
-        mod context;
-        mod counter;
-        mod err;
-        mod flavors;
-        mod select;
-        mod select_macro;
-        mod utils;
-        mod waker;
-
-        /// Crate internals used by the `select!` macro.
-        #[doc(hidden)]
-        pub mod internal {
-            pub use crate::select::SelectHandle;
-            pub use crate::select::{select, select_timeout, try_select};
-        }
-
-        pub use crate::channel::{after, at, never, tick};
-        pub use crate::channel::{bounded, unbounded};
-        pub use crate::channel::{IntoIter, Iter, TryIter};
-        pub use crate::channel::{Receiver, Sender};
-
-        pub use crate::select::{Select, SelectedOperation};
-
-        pub use crate::err::{ReadyTimeoutError, SelectTimeoutError, TryReadyError, TrySelectError};
-        pub use crate::err::{RecvError, RecvTimeoutError, TryRecvError};
-        pub use crate::err::{SendError, SendTimeoutError, TrySendError};
-    }
+/// Crate internals used by the `select!` macro.
+#[doc(hidden)]
+#[cfg(feature = "std")]
+pub mod internal {
+    pub use crate::select::{select, select_timeout, try_select, SelectHandle};
 }
+
+#[cfg(feature = "std")]
+pub use crate::{
+    channel::{
+        after, at, bounded, never, tick, unbounded, IntoIter, Iter, Receiver, Sender, TryIter,
+    },
+    err::{
+        ReadyTimeoutError, RecvError, RecvTimeoutError, SelectTimeoutError, SendError,
+        SendTimeoutError, TryReadyError, TryRecvError, TrySelectError, TrySendError,
+    },
+    select::{Select, SelectedOperation},
+};

--- a/crossbeam-deque/Cargo.toml
+++ b/crossbeam-deque/Cargo.toml
@@ -27,8 +27,6 @@ std = ["crossbeam-epoch/std", "crossbeam-utils/std"]
 crossbeam-epoch = { version = "0.9.17", path = "../crossbeam-epoch", default-features = false }
 crossbeam-utils = { version = "0.8.18", path = "../crossbeam-utils", default-features = false }
 
-cfg-if = "1"
-
 [dev-dependencies]
 rand = "0.8"
 

--- a/crossbeam-deque/src/deque.rs
+++ b/crossbeam-deque/src/deque.rs
@@ -8,8 +8,8 @@ use std::slice;
 use std::sync::atomic::{self, AtomicIsize, AtomicPtr, AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use crate::epoch::{self, Atomic, Owned};
-use crate::utils::{Backoff, CachePadded};
+use crossbeam_epoch::{self as epoch, Atomic, Owned};
+use crossbeam_utils::{Backoff, CachePadded};
 
 // Minimum buffer capacity.
 const MIN_CAP: usize = 64;

--- a/crossbeam-deque/src/lib.rs
+++ b/crossbeam-deque/src/lib.rs
@@ -92,14 +92,7 @@
 #![warn(missing_docs, unsafe_op_in_unsafe_fn)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use cfg_if::cfg_if;
-
-cfg_if! {
-    if #[cfg(feature = "std")] {
-        use crossbeam_epoch as epoch;
-        use crossbeam_utils as utils;
-
-        mod deque;
-        pub use crate::deque::{Injector, Steal, Stealer, Worker};
-    }
-}
+#[cfg(feature = "std")]
+mod deque;
+#[cfg(feature = "std")]
+pub use crate::deque::{Injector, Steal, Stealer, Worker};

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -36,8 +36,6 @@ loom = ["loom-crate", "crossbeam-utils/loom"]
 [dependencies]
 crossbeam-utils = { version = "0.8.18", path = "../crossbeam-utils", default-features = false }
 
-cfg-if = "1"
-
 # Enable the use of loom for concurrency testing.
 #
 # NOTE: This feature is outside of the normal semver guarantees and minor or

--- a/crossbeam-epoch/src/lib.rs
+++ b/crossbeam-epoch/src/lib.rs
@@ -61,8 +61,6 @@
 #[cfg(crossbeam_loom)]
 extern crate loom_crate as loom;
 
-use cfg_if::cfg_if;
-
 #[cfg(crossbeam_loom)]
 #[allow(unused_imports, dead_code)]
 mod primitive {
@@ -129,35 +127,37 @@ mod primitive {
     pub(crate) use std::thread_local;
 }
 
-#[cfg(target_has_atomic = "ptr")]
-cfg_if! {
-    if #[cfg(feature = "alloc")] {
-        extern crate alloc;
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+extern crate alloc;
 
-        mod atomic;
-        mod collector;
-        mod deferred;
-        mod epoch;
-        mod guard;
-        mod internal;
-        mod sync;
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+mod atomic;
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+mod collector;
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+mod deferred;
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+mod epoch;
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+mod guard;
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+mod internal;
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+mod sync;
 
-        pub use self::atomic::{
-            Pointable, Atomic, CompareExchangeError,
-            Owned, Pointer, Shared,
-        };
-        pub use self::collector::{Collector, LocalHandle};
-        pub use self::guard::{unprotected, Guard};
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+pub use crate::{
+    atomic::{Atomic, CompareExchangeError, Owned, Pointable, Pointer, Shared},
+    collector::{Collector, LocalHandle},
+    guard::{unprotected, Guard},
+};
 
-        mod sealed {
-            pub trait Sealed {}
-        }
-    }
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+mod sealed {
+    pub trait Sealed {}
 }
 
-cfg_if! {
-    if #[cfg(feature = "std")] {
-        mod default;
-        pub use self::default::{default_collector, is_pinned, pin};
-    }
-}
+#[cfg(feature = "std")]
+mod default;
+#[cfg(feature = "std")]
+pub use crate::default::{default_collector, is_pinned, pin};

--- a/crossbeam-queue/Cargo.toml
+++ b/crossbeam-queue/Cargo.toml
@@ -30,8 +30,6 @@ alloc = []
 [dependencies]
 crossbeam-utils = { version = "0.8.18", path = "../crossbeam-utils", default-features = false }
 
-cfg-if = "1"
-
 [dev-dependencies]
 rand = "0.8"
 

--- a/crossbeam-queue/src/lib.rs
+++ b/crossbeam-queue/src/lib.rs
@@ -15,15 +15,13 @@
 #![warn(missing_docs, unsafe_op_in_unsafe_fn)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(target_has_atomic = "ptr")]
-cfg_if::cfg_if! {
-    if #[cfg(feature = "alloc")] {
-        extern crate alloc;
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+extern crate alloc;
 
-        mod array_queue;
-        mod seg_queue;
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+mod array_queue;
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+mod seg_queue;
 
-        pub use self::array_queue::ArrayQueue;
-        pub use self::seg_queue::SegQueue;
-    }
-}
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+pub use crate::{array_queue::ArrayQueue, seg_queue::SegQueue};

--- a/crossbeam-skiplist/Cargo.toml
+++ b/crossbeam-skiplist/Cargo.toml
@@ -31,8 +31,6 @@ alloc = ["crossbeam-epoch/alloc"]
 crossbeam-epoch = { version = "0.9.17", path = "../crossbeam-epoch", default-features = false }
 crossbeam-utils = { version = "0.8.18", path = "../crossbeam-utils", default-features = false }
 
-cfg-if = "1"
-
 [dev-dependencies]
 rand = "0.8"
 

--- a/crossbeam-skiplist/src/base.rs
+++ b/crossbeam-skiplist/src/base.rs
@@ -10,8 +10,8 @@ use core::ops::{Bound, Deref, Index, RangeBounds};
 use core::ptr;
 use core::sync::atomic::{fence, AtomicUsize, Ordering};
 
-use crate::epoch::{self, Atomic, Collector, Guard, Shared};
-use crate::utils::CachePadded;
+use crossbeam_epoch::{self as epoch, Atomic, Collector, Guard, Shared};
+use crossbeam_utils::CachePadded;
 
 /// Number of bits needed to store height.
 const HEIGHT_BITS: usize = 5;

--- a/crossbeam-skiplist/src/lib.rs
+++ b/crossbeam-skiplist/src/lib.rs
@@ -238,30 +238,20 @@
 #![warn(missing_docs, unsafe_op_in_unsafe_fn)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use cfg_if::cfg_if;
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+extern crate alloc;
 
-#[cfg(target_has_atomic = "ptr")]
-cfg_if! {
-    if #[cfg(feature = "alloc")] {
-        extern crate alloc;
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+pub mod base;
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+#[doc(inline)]
+pub use crate::base::SkipList;
 
-        use crossbeam_epoch as epoch;
-        use crossbeam_utils as utils;
+#[cfg(feature = "std")]
+pub mod map;
+#[cfg(feature = "std")]
+pub mod set;
 
-        pub mod base;
-        #[doc(inline)]
-        pub use crate::base::SkipList;
-    }
-}
-
-cfg_if! {
-    if #[cfg(feature = "std")] {
-        pub mod map;
-        #[doc(inline)]
-        pub use crate::map::SkipMap;
-
-        pub mod set;
-        #[doc(inline)]
-        pub use crate::set::SkipSet;
-    }
-}
+#[cfg(feature = "std")]
+#[doc(inline)]
+pub use crate::{map::SkipMap, set::SkipSet};

--- a/crossbeam-skiplist/src/map.rs
+++ b/crossbeam-skiplist/src/map.rs
@@ -7,7 +7,7 @@ use std::ops::{Bound, RangeBounds};
 use std::ptr;
 
 use crate::base::{self, try_pin_loop};
-use crate::epoch;
+use crossbeam_epoch as epoch;
 
 /// An ordered map based on a lock-free skip list.
 ///

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -22,7 +22,6 @@ default = ["std"]
 std = []
 
 [dependencies]
-cfg-if = "1"
 
 # Enable the use of loom for concurrency testing.
 #

--- a/crossbeam-utils/src/atomic/mod.rs
+++ b/crossbeam-utils/src/atomic/mod.rs
@@ -5,23 +5,18 @@
 
 #[cfg(target_has_atomic = "ptr")]
 #[cfg(not(crossbeam_loom))]
-cfg_if::cfg_if! {
-    // Use "wide" sequence lock if the pointer width <= 32 for preventing its counter against wrap
-    // around.
-    //
-    // We are ignoring too wide architectures (pointer width >= 256), since such a system will not
-    // appear in a conceivable future.
-    //
-    // In narrow architectures (pointer width <= 16), the counter is still <= 32-bit and may be
-    // vulnerable to wrap around. But it's mostly okay, since in such a primitive hardware, the
-    // counter will not be increased that fast.
-    if #[cfg(any(target_pointer_width = "64", target_pointer_width = "128"))] {
-        mod seq_lock;
-    } else {
-        #[path = "seq_lock_wide.rs"]
-        mod seq_lock;
-    }
-}
+// Use "wide" sequence lock if the pointer width <= 32 for preventing its counter against wrap
+// around.
+//
+// In narrow architectures (pointer width <= 16), the counter is still <= 32-bit and may be
+// vulnerable to wrap around. But it's mostly okay, since in such a primitive hardware, the
+// counter will not be increased that fast.
+// Note that Rust (and C99) pointers must be at least 16-bits: https://github.com/rust-lang/rust/pull/49305
+#[cfg_attr(
+    any(target_pointer_width = "16", target_pointer_width = "32"),
+    path = "seq_lock_wide.rs"
+)]
+mod seq_lock;
 
 #[cfg(target_has_atomic = "ptr")]
 // We cannot provide AtomicCell under cfg(crossbeam_loom) because loom's atomic
@@ -29,9 +24,9 @@ cfg_if::cfg_if! {
 // TODO: The latest loom supports fences, so fallback using seqlock may be available.
 #[cfg(not(crossbeam_loom))]
 mod atomic_cell;
-mod consume;
-
 #[cfg(target_has_atomic = "ptr")]
 #[cfg(not(crossbeam_loom))]
-pub use self::atomic_cell::AtomicCell;
-pub use self::consume::AtomicConsume;
+pub use atomic_cell::AtomicCell;
+
+mod consume;
+pub use consume::AtomicConsume;

--- a/crossbeam-utils/src/lib.rs
+++ b/crossbeam-utils/src/lib.rs
@@ -94,13 +94,9 @@ pub use crate::cache_padded::CachePadded;
 mod backoff;
 pub use crate::backoff::Backoff;
 
-use cfg_if::cfg_if;
+#[cfg(feature = "std")]
+pub mod sync;
 
-cfg_if! {
-    if #[cfg(feature = "std")] {
-        pub mod sync;
-
-        #[cfg(not(crossbeam_loom))]
-        pub mod thread;
-    }
-}
+#[cfg(feature = "std")]
+#[cfg(not(crossbeam_loom))]
+pub mod thread;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,32 +60,17 @@ pub mod utils {
     pub use crossbeam_utils::CachePadded;
 }
 
-use cfg_if::cfg_if;
+#[cfg(feature = "alloc")]
+#[doc(inline)]
+pub use {crossbeam_epoch as epoch, crossbeam_queue as queue};
 
-cfg_if! {
-    if #[cfg(feature = "alloc")] {
-        #[doc(inline)]
-        pub use crossbeam_epoch as epoch;
+#[cfg(feature = "std")]
+#[doc(inline)]
+pub use {
+    crossbeam_channel as channel, crossbeam_channel::select, crossbeam_deque as deque,
+    crossbeam_utils::sync,
+};
 
-        #[doc(inline)]
-        pub use crossbeam_queue as queue;
-    }
-}
-
-cfg_if! {
-    if #[cfg(feature = "std")] {
-        #[doc(inline)]
-        pub use crossbeam_deque as deque;
-
-        #[doc(inline)]
-        pub use crossbeam_channel as channel;
-        pub use crossbeam_channel::select;
-
-        pub use crossbeam_utils::sync;
-
-        #[cfg(not(crossbeam_loom))]
-        pub use crossbeam_utils::thread;
-        #[cfg(not(crossbeam_loom))]
-        pub use crossbeam_utils::thread::scope;
-    }
-}
+#[cfg(feature = "std")]
+#[cfg(not(crossbeam_loom))]
+pub use crossbeam_utils::thread::{self, scope};


### PR DESCRIPTION
IMO, while cfg-if is powerful where there are complex mutual exclusion conditions such as "a or b or c or ...", its benefits are not great for simple use cases like ours.

There are also compatibility issues with tools such as rustfmt (and r-a IIRC?), and interoperability with doc_cfg, which is what I plan to use. The rustfmt issue affects not only the code within the macro, but also the module defined within the macro. It is why [tokio's contributing guideline recommends the direct use of rustfmt with git ls-files instead of cargo fmt](https://github.com/tokio-rs/tokio/blob/84c5674c601dfc36ab417ff0ec01763c2dd30a5c/CONTRIBUTING.md#cargo-commands).

