### PR TITLE
v0.8: Prepare for the next release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
 
 env:
   RUSTFLAGS: -Dwarnings
+  RUSTDOCFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
 
 defaults:
@@ -69,7 +70,7 @@ jobs:
         uses: taiki-e/install-action@cross
         if: matrix.target != ''
       - name: Test
-        run: ./ci/test.sh
+        run: ci/test.sh
 
   # Check all feature combinations works properly.
   features:
@@ -90,7 +91,7 @@ jobs:
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
       - name: Check features
-        run: ./ci/check-features.sh
+        run: ci/check-features.sh
 
   # Check for duplicate dependencies.
   dependencies:
@@ -104,7 +105,7 @@ jobs:
       - name: Install cargo-minimal-versions
         uses: taiki-e/install-action@cargo-minimal-versions
       - name: dependency tree check
-        run: ./ci/dependencies.sh
+        run: ci/dependencies.sh
 
   # When this job failed, run ci/no_atomic.sh and commit result changes.
   codegen:
@@ -150,7 +151,7 @@ jobs:
       - name: Install Rust
         run: rustup update stable
       - name: rustfmt
-        run: ./ci/rustfmt.sh
+        run: cargo fmt --all --check
 
   # This branch no longer actively developed. Most commits to this
   # branch are backporting and should not be blocked by clippy.
@@ -162,7 +163,7 @@ jobs:
   #     - name: Install Rust
   #       run: rustup update stable
   #     - name: clippy
-  #       run: ./ci/clippy.sh
+  #       run: cargo clippy --all --tests --examples
 
   # Run miri.
   miri:
@@ -172,7 +173,7 @@ jobs:
       - name: Install Rust
         run: rustup toolchain install nightly --component miri && rustup default nightly
       - name: miri
-        run: ./ci/miri.sh
+        run: ci/miri.sh
 
   # Run sanitizers.
   san:
@@ -182,7 +183,7 @@ jobs:
       - name: Install Rust
         run: rustup update nightly && rustup default nightly
       - name: Run sanitizers
-        run: ./ci/san.sh
+        run: ci/san.sh
 
   # Run loom tests.
   loom:
@@ -192,7 +193,7 @@ jobs:
       - name: Install Rust
         run: rustup update stable
       - name: loom
-        run: ./ci/crossbeam-epoch-loom.sh
+        run: ci/crossbeam-epoch-loom.sh
 
   # Check if the document can be generated without warning.
   docs:
@@ -202,7 +203,7 @@ jobs:
       - name: Install Rust
         run: rustup update nightly && rustup default nightly
       - name: docs
-        run: ./ci/docs.sh
+        run: cargo doc --no-deps --all --all-features
 
   shellcheck:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.8.4
+
+- Remove dependency on `cfg-if`. (#1072)
+
 # Version 0.8.3
 
 - Bump the minimum supported Rust version to 1.61. (#1037)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,6 @@ crossbeam-epoch = { version = "0.9.17", path = "crossbeam-epoch", default-featur
 crossbeam-queue = { version = "0.3.10", path = "crossbeam-queue", default-features = false, optional = true }
 crossbeam-utils = { version = "0.8.18", path = "crossbeam-utils", default-features = false }
 
-cfg-if = "1"
-
 [dev-dependencies]
 rand = "0.8"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-X.Y.Z" git tag
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 rust-version = "1.61"
 license = "MIT OR Apache-2.0"

--- a/ci/clippy.sh
+++ b/ci/clippy.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -euxo pipefail
-IFS=$'\n\t'
-cd "$(dirname "$0")"/..
-
-rustup component add clippy
-
-cargo clippy --all --tests --examples

--- a/ci/docs.sh
+++ b/ci/docs.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -euxo pipefail
-IFS=$'\n\t'
-cd "$(dirname "$0")"/..
-
-export RUSTDOCFLAGS="-D warnings"
-
-cargo doc --no-deps --all --all-features

--- a/ci/rustfmt.sh
+++ b/ci/rustfmt.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -euxo pipefail
-IFS=$'\n\t'
-cd "$(dirname "$0")"/..
-
-rustup component add rustfmt
-
-cargo fmt --all --check

--- a/crossbeam-channel/CHANGELOG.md
+++ b/crossbeam-channel/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.5.11
+
+- Remove dependency on `cfg-if`. (#1072)
+
 # Version 0.5.10
 
 - Relax the minimum supported Rust version to 1.60. (#1056)

--- a/crossbeam-channel/Cargo.toml
+++ b/crossbeam-channel/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-channel"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-channel-X.Y.Z" git tag
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 rust-version = "1.60"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-channel/Cargo.toml
+++ b/crossbeam-channel/Cargo.toml
@@ -26,8 +26,6 @@ std = ["crossbeam-utils/std"]
 [dependencies]
 crossbeam-utils = { version = "0.8.18", path = "../crossbeam-utils", default-features = false }
 
-cfg-if = "1"
-
 [dev-dependencies]
 num_cpus = "1.13.0"
 rand = "0.8"

--- a/crossbeam-channel/benchmarks/flume.rs
+++ b/crossbeam-channel/benchmarks/flume.rs
@@ -13,7 +13,7 @@ pub fn shuffle<T>(v: &mut [T]) {
     }
 
     thread_local! {
-        static RNG: Cell<Wrapping<u32>> = Cell::new(Wrapping(1));
+        static RNG: Cell<Wrapping<u32>> = const { Cell::new(Wrapping(1)) };
     }
 
     RNG.with(|rng| {

--- a/crossbeam-channel/benchmarks/message.rs
+++ b/crossbeam-channel/benchmarks/message.rs
@@ -3,7 +3,7 @@ use std::fmt;
 const LEN: usize = 1;
 
 #[derive(Clone, Copy)]
-pub struct Message(pub [usize; LEN]);
+pub struct Message(#[allow(dead_code)] [usize; LEN]);
 
 impl fmt::Debug for Message {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crossbeam-channel/benchmarks/mpsc.rs
+++ b/crossbeam-channel/benchmarks/mpsc.rs
@@ -15,7 +15,7 @@ pub fn shuffle<T>(v: &mut [T]) {
     }
 
     thread_local! {
-        static RNG: Cell<Wrapping<u32>> = Cell::new(Wrapping(1));
+        static RNG: Cell<Wrapping<u32>> = const { Cell::new(Wrapping(1)) };
     }
 
     RNG.with(|rng| {

--- a/crossbeam-channel/src/lib.rs
+++ b/crossbeam-channel/src/lib.rs
@@ -336,36 +336,40 @@
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use cfg_if::cfg_if;
+#[cfg(feature = "std")]
+mod channel;
+#[cfg(feature = "std")]
+mod context;
+#[cfg(feature = "std")]
+mod counter;
+#[cfg(feature = "std")]
+mod err;
+#[cfg(feature = "std")]
+mod flavors;
+#[cfg(feature = "std")]
+mod select;
+#[cfg(feature = "std")]
+mod select_macro;
+#[cfg(feature = "std")]
+mod utils;
+#[cfg(feature = "std")]
+mod waker;
 
-cfg_if! {
-    if #[cfg(feature = "std")] {
-        mod channel;
-        mod context;
-        mod counter;
-        mod err;
-        mod flavors;
-        mod select;
-        mod select_macro;
-        mod utils;
-        mod waker;
-
-        /// Crate internals used by the `select!` macro.
-        #[doc(hidden)]
-        pub mod internal {
-            pub use crate::select::SelectHandle;
-            pub use crate::select::{select, select_timeout, try_select};
-        }
-
-        pub use crate::channel::{after, at, never, tick};
-        pub use crate::channel::{bounded, unbounded};
-        pub use crate::channel::{IntoIter, Iter, TryIter};
-        pub use crate::channel::{Receiver, Sender};
-
-        pub use crate::select::{Select, SelectedOperation};
-
-        pub use crate::err::{ReadyTimeoutError, SelectTimeoutError, TryReadyError, TrySelectError};
-        pub use crate::err::{RecvError, RecvTimeoutError, TryRecvError};
-        pub use crate::err::{SendError, SendTimeoutError, TrySendError};
-    }
+/// Crate internals used by the `select!` macro.
+#[doc(hidden)]
+#[cfg(feature = "std")]
+pub mod internal {
+    pub use crate::select::{select, select_timeout, try_select, SelectHandle};
 }
+
+#[cfg(feature = "std")]
+pub use crate::{
+    channel::{
+        after, at, bounded, never, tick, unbounded, IntoIter, Iter, Receiver, Sender, TryIter,
+    },
+    err::{
+        ReadyTimeoutError, RecvError, RecvTimeoutError, SelectTimeoutError, SendError,
+        SendTimeoutError, TryReadyError, TryRecvError, TrySelectError, TrySendError,
+    },
+    select::{Select, SelectedOperation},
+};

--- a/crossbeam-channel/src/utils.rs
+++ b/crossbeam-channel/src/utils.rs
@@ -13,7 +13,7 @@ pub(crate) fn shuffle<T>(v: &mut [T]) {
     }
 
     thread_local! {
-        static RNG: Cell<Wrapping<u32>> = Cell::new(Wrapping(1_406_868_647));
+        static RNG: Cell<Wrapping<u32>> = const { Cell::new(Wrapping(1_406_868_647)) };
     }
 
     let _ = RNG.try_with(|rng| {

--- a/crossbeam-channel/tests/thread_locals.rs
+++ b/crossbeam-channel/tests/thread_locals.rs
@@ -30,7 +30,7 @@ fn use_while_exiting() {
     }
 
     thread_local! {
-        static FOO: Foo = Foo;
+        static FOO: Foo = const { Foo };
     }
 
     let (s, r) = unbounded::<()>();

--- a/crossbeam-deque/CHANGELOG.md
+++ b/crossbeam-deque/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.8.5
+
+- Remove dependency on `cfg-if`. (#1072)
+
 # Version 0.8.4
 
 - Bump the minimum supported Rust version to 1.61. (#1037)

--- a/crossbeam-deque/Cargo.toml
+++ b/crossbeam-deque/Cargo.toml
@@ -27,7 +27,5 @@ std = ["crossbeam-epoch/std", "crossbeam-utils/std"]
 crossbeam-epoch = { version = "0.9.17", path = "../crossbeam-epoch", default-features = false }
 crossbeam-utils = { version = "0.8.18", path = "../crossbeam-utils", default-features = false }
 
-cfg-if = "1"
-
 [dev-dependencies]
 rand = "0.8"

--- a/crossbeam-deque/Cargo.toml
+++ b/crossbeam-deque/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-deque"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-deque-X.Y.Z" git tag
-version = "0.8.4"
+version = "0.8.5"
 edition = "2021"
 rust-version = "1.61"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-deque/src/deque.rs
+++ b/crossbeam-deque/src/deque.rs
@@ -8,8 +8,8 @@ use std::slice;
 use std::sync::atomic::{self, AtomicIsize, AtomicPtr, AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use crate::epoch::{self, Atomic, Owned};
-use crate::utils::{Backoff, CachePadded};
+use crossbeam_epoch::{self as epoch, Atomic, Owned};
+use crossbeam_utils::{Backoff, CachePadded};
 
 // Minimum buffer capacity.
 const MIN_CAP: usize = 64;

--- a/crossbeam-deque/src/lib.rs
+++ b/crossbeam-deque/src/lib.rs
@@ -97,14 +97,7 @@
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use cfg_if::cfg_if;
-
-cfg_if! {
-    if #[cfg(feature = "std")] {
-        use crossbeam_epoch as epoch;
-        use crossbeam_utils as utils;
-
-        mod deque;
-        pub use crate::deque::{Injector, Steal, Stealer, Worker};
-    }
-}
+#[cfg(feature = "std")]
+mod deque;
+#[cfg(feature = "std")]
+pub use crate::deque::{Injector, Steal, Stealer, Worker};

--- a/crossbeam-epoch/CHANGELOG.md
+++ b/crossbeam-epoch/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 0.9.18
+
+- Remove dependency on `cfg-if`. (#1072)
+- Remove dependency on `autocfg`. (#1071)
+
 # Version 0.9.17
 
 - Remove dependency on `memoffset`. (#1058)

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -42,9 +42,6 @@ nightly = ["crossbeam-utils/nightly"]
 # patch versions of crossbeam may make breaking changes to them at any time.
 loom = ["loom-crate", "crossbeam-utils/loom"]
 
-[build-dependencies]
-autocfg = "1"
-
 [dependencies]
 crossbeam-utils = { version = "0.8.18", path = "../crossbeam-utils", default-features = false }
 

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-epoch"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-epoch-X.Y.Z" git tag
-version = "0.9.17"
+version = "0.9.18"
 edition = "2021"
 rust-version = "1.61"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -45,8 +45,6 @@ loom = ["loom-crate", "crossbeam-utils/loom"]
 [dependencies]
 crossbeam-utils = { version = "0.8.18", path = "../crossbeam-utils", default-features = false }
 
-cfg-if = "1"
-
 # Enable the use of loom for concurrency testing.
 #
 # NOTE: This feature is outside of the normal semver guarantees and minor or

--- a/crossbeam-epoch/src/collector.rs
+++ b/crossbeam-epoch/src/collector.rs
@@ -286,7 +286,7 @@ mod tests {
         const COUNT: usize = 100_000;
         static DROPS: AtomicUsize = AtomicUsize::new(0);
 
-        struct Elem(i32);
+        struct Elem(#[allow(dead_code)] i32);
 
         impl Drop for Elem {
             fn drop(&mut self) {
@@ -350,7 +350,7 @@ mod tests {
         const COUNT: usize = 700;
         static DROPS: AtomicUsize = AtomicUsize::new(0);
 
-        struct Elem(i32);
+        struct Elem(#[allow(dead_code)] i32);
 
         impl Drop for Elem {
             fn drop(&mut self) {
@@ -427,7 +427,7 @@ mod tests {
         const COUNT: usize = 100_000;
         static DROPS: AtomicUsize = AtomicUsize::new(0);
 
-        struct Elem(i32);
+        struct Elem(#[allow(dead_code)] i32);
 
         impl Drop for Elem {
             fn drop(&mut self) {

--- a/crossbeam-epoch/src/collector.rs
+++ b/crossbeam-epoch/src/collector.rs
@@ -403,9 +403,10 @@ mod tests {
             }
 
             let len = v.len();
-            let ptr = ManuallyDrop::new(v).as_mut_ptr() as usize;
+            let cap = v.capacity();
+            let ptr = ManuallyDrop::new(v).as_mut_ptr();
             guard.defer_unchecked(move || {
-                drop(Vec::from_raw_parts(ptr as *const i32 as *mut i32, len, len));
+                drop(Vec::from_raw_parts(ptr, len, cap));
                 DESTROYS.fetch_add(len, Ordering::Relaxed);
             });
             guard.flush();

--- a/crossbeam-epoch/src/default.rs
+++ b/crossbeam-epoch/src/default.rs
@@ -77,7 +77,7 @@ mod tests {
         }
 
         thread_local! {
-            static FOO: Foo = Foo;
+            static FOO: Foo = const { Foo };
         }
 
         thread::scope(|scope| {

--- a/crossbeam-epoch/src/lib.rs
+++ b/crossbeam-epoch/src/lib.rs
@@ -66,8 +66,6 @@
 #[cfg(crossbeam_loom)]
 extern crate loom_crate as loom;
 
-use cfg_if::cfg_if;
-
 #[cfg(crossbeam_loom)]
 #[allow(unused_imports, dead_code)]
 mod primitive {
@@ -134,34 +132,35 @@ mod primitive {
     pub(crate) use std::thread_local;
 }
 
-#[cfg(target_has_atomic = "ptr")]
-cfg_if! {
-    if #[cfg(feature = "alloc")] {
-        extern crate alloc;
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+extern crate alloc;
 
-        mod atomic;
-        mod collector;
-        mod deferred;
-        mod epoch;
-        mod guard;
-        mod internal;
-        mod sync;
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+mod atomic;
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+mod collector;
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+mod deferred;
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+mod epoch;
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+mod guard;
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+mod internal;
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+mod sync;
 
-        pub use self::atomic::{
-            Pointable, Atomic, CompareExchangeError,
-            Owned, Pointer, Shared,
-        };
-        pub use self::collector::{Collector, LocalHandle};
-        pub use self::guard::{unprotected, Guard};
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+#[allow(deprecated)]
+pub use crate::atomic::{CompareAndSetError, CompareAndSetOrdering};
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+pub use crate::{
+    atomic::{Atomic, CompareExchangeError, Owned, Pointable, Pointer, Shared},
+    collector::{Collector, LocalHandle},
+    guard::{unprotected, Guard},
+};
 
-        #[allow(deprecated)]
-        pub use self::atomic::{CompareAndSetError, CompareAndSetOrdering};
-    }
-}
-
-cfg_if! {
-    if #[cfg(feature = "std")] {
-        mod default;
-        pub use self::default::{default_collector, is_pinned, pin};
-    }
-}
+#[cfg(feature = "std")]
+mod default;
+#[cfg(feature = "std")]
+pub use crate::default::{default_collector, is_pinned, pin};

--- a/crossbeam-queue/CHANGELOG.md
+++ b/crossbeam-queue/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.3.11
+
+- Remove dependency on `cfg-if`. (#1072)
+
 # Version 0.3.10
 
 - Relax the minimum supported Rust version to 1.60. (#1056)

--- a/crossbeam-queue/Cargo.toml
+++ b/crossbeam-queue/Cargo.toml
@@ -39,7 +39,5 @@ nightly = ["crossbeam-utils/nightly"]
 [dependencies]
 crossbeam-utils = { version = "0.8.18", path = "../crossbeam-utils", default-features = false }
 
-cfg-if = "1"
-
 [dev-dependencies]
 rand = "0.8"

--- a/crossbeam-queue/Cargo.toml
+++ b/crossbeam-queue/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-queue"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-queue-X.Y.Z" git tag
-version = "0.3.10"
+version = "0.3.11"
 edition = "2021"
 rust-version = "1.60"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-queue/src/lib.rs
+++ b/crossbeam-queue/src/lib.rs
@@ -20,15 +20,13 @@
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(target_has_atomic = "ptr")]
-cfg_if::cfg_if! {
-    if #[cfg(feature = "alloc")] {
-        extern crate alloc;
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+extern crate alloc;
 
-        mod array_queue;
-        mod seg_queue;
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+mod array_queue;
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+mod seg_queue;
 
-        pub use self::array_queue::ArrayQueue;
-        pub use self::seg_queue::SegQueue;
-    }
-}
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+pub use crate::{array_queue::ArrayQueue, seg_queue::SegQueue};

--- a/crossbeam-skiplist/Cargo.toml
+++ b/crossbeam-skiplist/Cargo.toml
@@ -31,7 +31,5 @@ alloc = ["crossbeam-epoch/alloc"]
 crossbeam-epoch = { version = "0.9.17", path = "../crossbeam-epoch", default-features = false }
 crossbeam-utils = { version = "0.8.18", path = "../crossbeam-utils", default-features = false }
 
-cfg-if = "1"
-
 [dev-dependencies]
 rand = "0.8"

--- a/crossbeam-skiplist/src/base.rs
+++ b/crossbeam-skiplist/src/base.rs
@@ -10,8 +10,8 @@ use core::ops::{Bound, Deref, Index, RangeBounds};
 use core::ptr;
 use core::sync::atomic::{fence, AtomicUsize, Ordering};
 
-use crate::epoch::{self, Atomic, Collector, Guard, Shared};
-use crate::utils::CachePadded;
+use crossbeam_epoch::{self as epoch, Atomic, Collector, Guard, Shared};
+use crossbeam_utils::CachePadded;
 
 /// Number of bits needed to store height.
 const HEIGHT_BITS: usize = 5;

--- a/crossbeam-skiplist/src/lib.rs
+++ b/crossbeam-skiplist/src/lib.rs
@@ -243,30 +243,20 @@
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use cfg_if::cfg_if;
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+extern crate alloc;
 
-#[cfg(target_has_atomic = "ptr")]
-cfg_if! {
-    if #[cfg(feature = "alloc")] {
-        extern crate alloc;
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+pub mod base;
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+#[doc(inline)]
+pub use crate::base::SkipList;
 
-        use crossbeam_epoch as epoch;
-        use crossbeam_utils as utils;
+#[cfg(feature = "std")]
+pub mod map;
+#[cfg(feature = "std")]
+pub mod set;
 
-        pub mod base;
-        #[doc(inline)]
-        pub use crate::base::SkipList;
-    }
-}
-
-cfg_if! {
-    if #[cfg(feature = "std")] {
-        pub mod map;
-        #[doc(inline)]
-        pub use crate::map::SkipMap;
-
-        pub mod set;
-        #[doc(inline)]
-        pub use crate::set::SkipSet;
-    }
-}
+#[cfg(feature = "std")]
+#[doc(inline)]
+pub use crate::{map::SkipMap, set::SkipSet};

--- a/crossbeam-skiplist/src/map.rs
+++ b/crossbeam-skiplist/src/map.rs
@@ -7,7 +7,7 @@ use std::ops::{Bound, RangeBounds};
 use std::ptr;
 
 use crate::base::{self, try_pin_loop};
-use crate::epoch;
+use crossbeam_epoch as epoch;
 
 /// An ordered map based on a lock-free skip list.
 ///

--- a/crossbeam-utils/CHANGELOG.md
+++ b/crossbeam-utils/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.8.19
+
+- Remove dependency on `cfg-if`. (#1072)
+
 # Version 0.8.18
 
 - Relax the minimum supported Rust version to 1.60. (#1056)

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-utils"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-utils-X.Y.Z" git tag
-version = "0.8.18"
+version = "0.8.19"
 edition = "2021"
 rust-version = "1.60"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -31,7 +31,6 @@ std = []
 nightly = []
 
 [dependencies]
-cfg-if = "1"
 
 # Enable the use of loom for concurrency testing.
 #

--- a/crossbeam-utils/src/atomic/mod.rs
+++ b/crossbeam-utils/src/atomic/mod.rs
@@ -5,23 +5,18 @@
 
 #[cfg(target_has_atomic = "ptr")]
 #[cfg(not(crossbeam_loom))]
-cfg_if::cfg_if! {
-    // Use "wide" sequence lock if the pointer width <= 32 for preventing its counter against wrap
-    // around.
-    //
-    // We are ignoring too wide architectures (pointer width >= 256), since such a system will not
-    // appear in a conceivable future.
-    //
-    // In narrow architectures (pointer width <= 16), the counter is still <= 32-bit and may be
-    // vulnerable to wrap around. But it's mostly okay, since in such a primitive hardware, the
-    // counter will not be increased that fast.
-    if #[cfg(any(target_pointer_width = "64", target_pointer_width = "128"))] {
-        mod seq_lock;
-    } else {
-        #[path = "seq_lock_wide.rs"]
-        mod seq_lock;
-    }
-}
+// Use "wide" sequence lock if the pointer width <= 32 for preventing its counter against wrap
+// around.
+//
+// In narrow architectures (pointer width <= 16), the counter is still <= 32-bit and may be
+// vulnerable to wrap around. But it's mostly okay, since in such a primitive hardware, the
+// counter will not be increased that fast.
+// Note that Rust (and C99) pointers must be at least 16-bits: https://github.com/rust-lang/rust/pull/49305
+#[cfg_attr(
+    any(target_pointer_width = "16", target_pointer_width = "32"),
+    path = "seq_lock_wide.rs"
+)]
+mod seq_lock;
 
 #[cfg(target_has_atomic = "ptr")]
 // We cannot provide AtomicCell under cfg(crossbeam_loom) because loom's atomic
@@ -29,9 +24,9 @@ cfg_if::cfg_if! {
 // TODO: The latest loom supports fences, so fallback using seqlock may be available.
 #[cfg(not(crossbeam_loom))]
 mod atomic_cell;
-mod consume;
-
 #[cfg(target_has_atomic = "ptr")]
 #[cfg(not(crossbeam_loom))]
-pub use self::atomic_cell::AtomicCell;
-pub use self::consume::AtomicConsume;
+pub use atomic_cell::AtomicCell;
+
+mod consume;
+pub use consume::AtomicConsume;

--- a/crossbeam-utils/src/lib.rs
+++ b/crossbeam-utils/src/lib.rs
@@ -99,13 +99,9 @@ pub use crate::cache_padded::CachePadded;
 mod backoff;
 pub use crate::backoff::Backoff;
 
-use cfg_if::cfg_if;
+#[cfg(feature = "std")]
+pub mod sync;
 
-cfg_if! {
-    if #[cfg(feature = "std")] {
-        pub mod sync;
-
-        #[cfg(not(crossbeam_loom))]
-        pub mod thread;
-    }
-}
+#[cfg(feature = "std")]
+#[cfg(not(crossbeam_loom))]
+pub mod thread;

--- a/crossbeam-utils/tests/atomic_cell.rs
+++ b/crossbeam-utils/tests/atomic_cell.rs
@@ -6,11 +6,11 @@ use crossbeam_utils::atomic::AtomicCell;
 
 #[test]
 fn is_lock_free() {
-    struct UsizeWrap(usize);
-    struct U8Wrap(bool);
-    struct I16Wrap(i16);
+    struct UsizeWrap(#[allow(dead_code)] usize);
+    struct U8Wrap(#[allow(dead_code)] bool);
+    struct I16Wrap(#[allow(dead_code)] i16);
     #[repr(align(8))]
-    struct U64Align8(u64);
+    struct U64Align8(#[allow(dead_code)] u64);
 
     assert!(AtomicCell::<usize>::is_lock_free());
     assert!(AtomicCell::<isize>::is_lock_free());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,32 +65,17 @@ pub mod utils {
     pub use crossbeam_utils::CachePadded;
 }
 
-use cfg_if::cfg_if;
+#[cfg(feature = "alloc")]
+#[doc(inline)]
+pub use {crossbeam_epoch as epoch, crossbeam_queue as queue};
 
-cfg_if! {
-    if #[cfg(feature = "alloc")] {
-        #[doc(inline)]
-        pub use crossbeam_epoch as epoch;
+#[cfg(feature = "std")]
+#[doc(inline)]
+pub use {
+    crossbeam_channel as channel, crossbeam_channel::select, crossbeam_deque as deque,
+    crossbeam_utils::sync,
+};
 
-        #[doc(inline)]
-        pub use crossbeam_queue as queue;
-    }
-}
-
-cfg_if! {
-    if #[cfg(feature = "std")] {
-        #[doc(inline)]
-        pub use crossbeam_deque as deque;
-
-        #[doc(inline)]
-        pub use crossbeam_channel as channel;
-        pub use crossbeam_channel::select;
-
-        pub use crossbeam_utils::sync;
-
-        #[cfg(not(crossbeam_loom))]
-        pub use crossbeam_utils::thread;
-        #[cfg(not(crossbeam_loom))]
-        pub use crossbeam_utils::thread::scope;
-    }
-}
+#[cfg(feature = "std")]
+#[cfg(not(crossbeam_loom))]
+pub use crossbeam_utils::thread::{self, scope};


### PR DESCRIPTION
- crossbeam-channel 0.5.10 -> 0.5.11
  - Remove dependency on `cfg-if`. (#1072)
- crossbeam-deque 0.8.4 -> 0.8.5
  - Remove dependency on `cfg-if`. (#1072)
- crossbeam-epoch 0.9.17 -> 0.9.18
  - Remove dependency on `cfg-if`. (#1072)
  - Remove dependency on `autocfg`. (#1071)
- crossbeam-queue 0.3.10 -> 0.3.11
  - Remove dependency on `cfg-if`. (#1072)
- crossbeam-utils 0.8.18 -> 0.8.19
  - Remove dependency on `cfg-if`. (#1072)
- crossbeam 0.8.3 -> 0.8.4
  - Remove dependency on `cfg-if`. (#1072)