### PR TITLE
Prepare for the next release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.8.4
+
+- Remove dependency on `cfg-if`. (#1072)
+
 # Version 0.8.3
 
 - Bump the minimum supported Rust version to 1.61. (#1037)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-X.Y.Z" git tag
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 rust-version = "1.61"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-channel/CHANGELOG.md
+++ b/crossbeam-channel/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.5.11
+
+- Remove dependency on `cfg-if`. (#1072)
+
 # Version 0.5.10
 
 - Relax the minimum supported Rust version to 1.60. (#1056)

--- a/crossbeam-channel/Cargo.toml
+++ b/crossbeam-channel/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-channel"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-channel-X.Y.Z" git tag
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 rust-version = "1.60"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-deque/CHANGELOG.md
+++ b/crossbeam-deque/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.8.5
+
+- Remove dependency on `cfg-if`. (#1072)
+
 # Version 0.8.4
 
 - Bump the minimum supported Rust version to 1.61. (#1037)

--- a/crossbeam-deque/Cargo.toml
+++ b/crossbeam-deque/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-deque"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-deque-X.Y.Z" git tag
-version = "0.8.4"
+version = "0.8.5"
 edition = "2021"
 rust-version = "1.61"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-deque/src/deque.rs
+++ b/crossbeam-deque/src/deque.rs
@@ -41,7 +41,7 @@ impl<T> Buffer<T> {
         let ptr = Box::into_raw(
             (0..cap)
                 .map(|_| MaybeUninit::<T>::uninit())
-                .collect::<Box<_>>(),
+                .collect::<Box<[_]>>(),
         )
         .cast::<T>();
 

--- a/crossbeam-epoch/CHANGELOG.md
+++ b/crossbeam-epoch/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 0.9.18
+
+- Remove dependency on `cfg-if`. (#1072)
+- Remove dependency on `autocfg`. (#1071)
+
 # Version 0.9.17
 
 - Remove dependency on `memoffset`. (#1058)

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-epoch"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-epoch-X.Y.Z" git tag
-version = "0.9.17"
+version = "0.9.18"
 edition = "2021"
 rust-version = "1.61"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-queue/CHANGELOG.md
+++ b/crossbeam-queue/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.3.11
+
+- Remove dependency on `cfg-if`. (#1072)
+
 # Version 0.3.10
 
 - Relax the minimum supported Rust version to 1.60. (#1056)

--- a/crossbeam-queue/Cargo.toml
+++ b/crossbeam-queue/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-queue"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-queue-X.Y.Z" git tag
-version = "0.3.10"
+version = "0.3.11"
 edition = "2021"
 rust-version = "1.60"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-skiplist/CHANGELOG.md
+++ b/crossbeam-skiplist/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.1.3
+
+- Remove dependency on `cfg-if`. (#1072)
+
 # Version 0.1.2
 
 - Bump the minimum supported Rust version to 1.61. (#1037)

--- a/crossbeam-skiplist/Cargo.toml
+++ b/crossbeam-skiplist/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-skiplist"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-skiplist-X.Y.Z" git tag
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 rust-version = "1.61"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-utils/CHANGELOG.md
+++ b/crossbeam-utils/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.8.19
+
+- Remove dependency on `cfg-if`. (#1072)
+
 # Version 0.8.18
 
 - Relax the minimum supported Rust version to 1.60. (#1056)

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-utils"
 # - Update CHANGELOG.md
 # - Update README.md
 # - Create "crossbeam-utils-X.Y.Z" git tag
-version = "0.8.18"
+version = "0.8.19"
 edition = "2021"
 rust-version = "1.60"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
- crossbeam-skiplist 0.1.2 -> 0.1.3
  - Remove dependency on `cfg-if`. (#1072)

Other crates are already released in #1073.