### PR TITLE
Create separate sub-crate for CachePadded (second attempt)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ workspace = true
 resolver = "2"
 members = [
   ".",
+  "crossbeam-cachepadded",
   "crossbeam-channel",
   "crossbeam-channel/benchmarks",
   "crossbeam-deque",

--- a/crossbeam-cachepadded/Cargo.toml
+++ b/crossbeam-cachepadded/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "crossbeam-cachepadded"
+# When publishing a new version:
+# - Update CHANGELOG.md
+# - Update README.md
+# - Create "crossbeam-cachepadded-X.Y.Z" git tag
+version = "0.0.0"
+edition = "2018"
+rust-version = "1.38"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/crossbeam-rs/crossbeam"
+homepage = "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-cachepadded"
+documentation = "https://docs.rs/crossbeam-cachepadded"
+description = "Prevent false sharing by padding and aligning to the length of a cache line"
+keywords = ["cache", "padding", "lock-free", "atomic"]
+categories = ["concurrency", "no-std"]
+
+[lib]
+# The tests are executed in the crossbeam-util crate.
+doctest = false

--- a/crossbeam-cachepadded/src/cache_padded.rs
+++ b/crossbeam-cachepadded/src/cache_padded.rs
@@ -1,0 +1,1 @@
+../../crossbeam-utils/src/cache_padded.rs

--- a/crossbeam-cachepadded/src/lib.rs
+++ b/crossbeam-cachepadded/src/lib.rs
@@ -1,0 +1,14 @@
+//! TODO
+
+#![doc(test(
+    no_crate_inject,
+    attr(
+        deny(warnings, rust_2018_idioms, single_use_lifetimes),
+        allow(dead_code, unused_assignments, unused_variables)
+    )
+))]
+#![warn(missing_docs, unsafe_op_in_unsafe_fn)]
+#![no_std]
+
+mod cache_padded;
+pub use crate::cache_padded::CachePadded;

--- a/crossbeam-cachepadded/src/lib.rs
+++ b/crossbeam-cachepadded/src/lib.rs
@@ -1,13 +1,5 @@
-//! TODO
+//! Prevent false sharing by padding and aligning to the length of a cache line.
 
-#![doc(test(
-    no_crate_inject,
-    attr(
-        deny(warnings, rust_2018_idioms, single_use_lifetimes),
-        allow(dead_code, unused_assignments, unused_variables)
-    )
-))]
-#![warn(missing_docs, unsafe_op_in_unsafe_fn)]
 #![no_std]
 
 mod cache_padded;


### PR DESCRIPTION
This is an alternative to #1069.

This simply creates a symbolic link to `cache_padded.rs`.

This way, `crossbeam-utils` is unaffected.

Fixes #1066, which contains related discussion.

This is also a proof of concept, some details still need to be ironed out.