### PR TITLE
channel tests: don't reset allocated bytes counter

### DIFF
--- a/crossbeam-channel/tests/golang.rs
+++ b/crossbeam-channel/tests/golang.rs
@@ -754,8 +754,6 @@ mod select2 {
         let c = make_unbounded::<i32>();
         let dummy = make_unbounded::<i32>();
 
-        ALLOCATED.store(0, SeqCst);
-
         go!(c, sender(&c, N));
         receiver(&c, &dummy, N);
 
@@ -764,10 +762,9 @@ mod select2 {
         go!(c, sender(&c, N));
         receiver(&c, &dummy, N);
 
-        assert!(
-            !(ALLOCATED.load(SeqCst) > alloc
-                && (ALLOCATED.load(SeqCst) - alloc) > (N as usize + 10000))
-        );
+        let final_alloc = ALLOCATED.load(SeqCst);
+
+        assert!(!(final_alloc > alloc && final_alloc - alloc > N as usize + 10000));
     }
 }
 


### PR DESCRIPTION
Ran into this test failure running tests in debug mode on macOS:
```
crossbeam-channel$ cargo test
...
    Running tests/golang.rs (/Users/csander/crossbeam/target/debug/deps/golang-5dfea7778bc0a8e8)

running 26 tests
test chan_test::test_chan_send_interface ... ok
test chan_test::test_select_duplicate_channel ... ok
test chan1::main ... ok
test fifo::asynch_fifo ... ok
test fifo::synch_fifo ... ok
test goroutines::main ... ok
test nonblock::main ... ok
test chan_test::test_nonblock_recv_race ... ok
test select4::main ... ok
test select6::main ... ok
test select7::main ... ok
test select::main ... ok
test sieve1::main ... ok
test zerosize::zero_size_array ... ok
test zerosize::zero_size_struct ... ok
test chan_test::test_self_select ... ok
test chan_test::test_nonblock_select_race2 ... ok
test chan_test::test_select_fairness ... ok
test chan_test::test_nonblock_select_race ... ok
test select2::main ... FAILED
test doubleselect::main ... ok
test chan_test::test_multi_consumer ... ok
test chan_test::test_select_stress ... ok
test chan_test::test_pseudo_random_send ... ok
test chan::main ... ok
test chan_test::test_chan ... ok

failures:

---- select2::main stdout ----
thread 'select2::main' panicked at 'assertion failed: !(ALLOCATED.load(SeqCst) > alloc &&\n            (ALLOCATED.load(SeqCst) - alloc) > (N as usize + 10000))', crossbeam-channel/tests/golang.rs:767:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    select2::main

test result: FAILED. 25 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.94s
```
Printing out the values being asserted shows that `ALLOCATED` decreased during the execution of the test and underflowed:
```
---- select2::main stdout ----
[crossbeam-channel/tests/golang.rs:763] alloc = 79997
[crossbeam-channel/tests/golang.rs:768] ALLOCATED.load(SeqCst) = 18446744073709412546
thread 'select2::main' panicked at 'assertion failed: !(ALLOCATED.load(SeqCst) > alloc &&\n            (ALLOCATED.load(SeqCst) - alloc) > (N as usize + 10000))', crossbeam-channel/tests/golang.rs:770:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

The `ALLOCATED` atomic is used by the `golang::select2` test to track the total size of the current heap allocations. It is reset to 0 during the test, which can cause underflow if existing allocations are deallocated afterwards. The golang test this is copied from doesn't reset the alloc stats, and it doesn't affect the test result, since only the difference in bytes allocated is asserted.
So don't reset the ALLOCATED counter during the test.

Also only sample ALLOCATED once at the end of the test, to avoid its value being inconsistent between the 2 loads.