### PR TITLE
Fix lockfree benchmark output

### DIFF
--- a/crossbeam-channel/benchmarks/lockfree.rs
+++ b/crossbeam-channel/benchmarks/lockfree.rs
@@ -95,7 +95,7 @@ fn main() {
             println!(
                 "{:25} {:15} {:7.3} sec",
                 $name,
-                "Rust crossbeam-channel",
+                "Rust lockfree",
                 elapsed.as_secs() as f64 + elapsed.subsec_nanos() as f64 / 1e9
             );
         };


### PR DESCRIPTION
I am trying to run the lockfree benchmark and plot the results, but the output file has an incorrect name tag.
This causes the lockfree results to disappear. And if both lockfree and crossbeam-channel results coexist, the crossbeam-channel result may be overwritten and corrupted on the benchmark graph.
