### PR TITLE
Make benchmark graph extensible and add more bars

### DIFF
--- a/crossbeam-channel/benchmarks/README.md
+++ b/crossbeam-channel/benchmarks/README.md
@@ -16,6 +16,12 @@ Default configuration:
 
 ### Running
 
+Install python packages:
+
+```
+pip install -r requirements.txt
+```
+
 Runs benchmarks, stores results into `*.txt` files, and generates `plot.png`:
 
 ```
@@ -28,7 +34,8 @@ Dependencies:
 - Go
 - Bash
 - Python 
-- Plotly
+- plotly (python graphing library)
+- kaleido (image export engine for plotly)
 
 ### Results
 

--- a/crossbeam-channel/benchmarks/README.md
+++ b/crossbeam-channel/benchmarks/README.md
@@ -28,7 +28,7 @@ Dependencies:
 - Go
 - Bash
 - Python 
-- Matplotlib
+- Plotly
 
 ### Results
 

--- a/crossbeam-channel/benchmarks/plot.py
+++ b/crossbeam-channel/benchmarks/plot.py
@@ -10,8 +10,8 @@ def read_data(files):
         with open(f) as f:
             for line in f.readlines():
                 test, lang, impl, secs, _ = line.split()
-                splt = test.split('_')
-                results.append((splt[0], '_'.join(splt[1:]), lang, impl, float(secs)))
+                splt = test.split("_")
+                results.append((splt[0], "_".join(splt[1:]), lang, impl, float(secs)))
     return results
 
 
@@ -33,45 +33,45 @@ def find(s, x):
 
 
 color_set = {
-    'aqua': '#00ffff',
-    'azure': '#f0ffff',
-    'beige': '#f5f5dc',
-    'black': '#000000',
-    'blue': '#0000ff',
-    'brown': '#a52a2a',
-    'cyan': '#00ffff',
-    'darkblue': '#00008b',
-    'darkcyan': '#008b8b',
-    'darkgrey': '#a9a9a9',
-    'darkgreen': '#006400',
-    'darkkhaki': '#bdb76b',
-    'darkmagenta': '#8b008b',
-    'darkolivegreen': '#556b2f',
-    'darkorange': '#ff8c00',
-    'darkorchid': '#9932cc',
-    'darkred': '#8b0000',
-    'darksalmon': '#e9967a',
-    'darkviolet': '#9400d3',
-    'fuchsia': '#ff00ff',
-    'gold': '#ffd700',
-    'green': '#008000',
-    'indigo': '#4b0082',
-    'khaki': '#f0e68c',
-    'lightblue': '#add8e6',
-    'lightcyan': '#e0ffff',
-    'lightgreen': '#90ee90',
-    'lightgrey': '#d3d3d3',
-    'lightpink': '#ffb6c1',
-    'lightyellow': '#ffffe0',
-    'lime': '#00ff00',
-    'magenta': '#ff00ff',
-    'maroon': '#800000',
-    'navy': '#000080',
-    'olive': '#808000',
-    'orange': '#ffa500',
-    'pink': '#ffc0cb',
-    'purple': '#800080',
-    'red': '#ff0000',
+    "aqua": "#00ffff",
+    "azure": "#f0ffff",
+    "beige": "#f5f5dc",
+    "black": "#000000",
+    "blue": "#0000ff",
+    "brown": "#a52a2a",
+    "cyan": "#00ffff",
+    "darkblue": "#00008b",
+    "darkcyan": "#008b8b",
+    "darkgrey": "#a9a9a9",
+    "darkgreen": "#006400",
+    "darkkhaki": "#bdb76b",
+    "darkmagenta": "#8b008b",
+    "darkolivegreen": "#556b2f",
+    "darkorange": "#ff8c00",
+    "darkorchid": "#9932cc",
+    "darkred": "#8b0000",
+    "darksalmon": "#e9967a",
+    "darkviolet": "#9400d3",
+    "fuchsia": "#ff00ff",
+    "gold": "#ffd700",
+    "green": "#008000",
+    "indigo": "#4b0082",
+    "khaki": "#f0e68c",
+    "lightblue": "#add8e6",
+    "lightcyan": "#e0ffff",
+    "lightgreen": "#90ee90",
+    "lightgrey": "#d3d3d3",
+    "lightpink": "#ffb6c1",
+    "lightyellow": "#ffffe0",
+    "lime": "#00ff00",
+    "magenta": "#ff00ff",
+    "maroon": "#800000",
+    "navy": "#000080",
+    "olive": "#808000",
+    "orange": "#ffa500",
+    "pink": "#ffc0cb",
+    "purple": "#800080",
+    "red": "#ff0000",
 }
 saved_color = {}
 
@@ -92,26 +92,31 @@ def plot(results, fig, subplot, title, prefix):
     ax.set_title(title)
     ax.set_yticks(ys)
     ax.set_yticklabels(runs)
-    ax.tick_params(which='major', length=0)
-    ax.set_xlabel('seconds')
+    ax.tick_params(which="major", length=0)
+    ax.set_xlabel("seconds")
 
     scores = {}
 
     for pre, test, lang, impl, secs in results:
         if pre == prefix:
-            name = impl if lang == 'Rust' else impl + f' ({lang})'
+            name = impl if lang == "Rust" else impl + f" ({lang})"
             if name not in scores:
                 scores[name] = [0] * len(runs)
             scores[name][find(runs, test)] = secs
 
-    opts = dict(height=0.8, align='center')
+    opts = dict(height=0.8, align="center")
     x_max = max(max(scores.values(), key=lambda x: max(x)))
     for i, (name, score) in enumerate(scores.items()):
         yy = [y + i - len(runs) // 2 + 0.2 for y in ys]
         ax.barh(yy, score, color=get_color(name), **opts)
         for xxx, yyy in zip(score, yy):
             if xxx:
-                ax.text(min(x_max - len(name) * 0.018 * x_max, xxx), yyy - 0.25, name, fontsize=9)
+                ax.text(
+                    min(x_max - len(name) * 0.018 * x_max, xxx),
+                    yyy - 0.25,
+                    name,
+                    fontsize=9,
+                )
 
 
 def plot_all(results, descriptions, labels):
@@ -128,21 +133,21 @@ def plot_all(results, descriptions, labels):
         wspace=0.3,
         hspace=0.2,
     )
-    plt.savefig('plot.png')
+    plt.savefig("plot.png")
     # plt.show()
 
 
 def main():
     results = read_data(sys.argv[1:])
     descriptions = [
-        'Bounded channel of capacity 0',
-        'Bounded channel of capacity 1',
-        'Bounded channel of capacity N',
-        'Unbounded channel',
+        "Bounded channel of capacity 0",
+        "Bounded channel of capacity 1",
+        "Bounded channel of capacity N",
+        "Unbounded channel",
     ]
-    labels = ['bounded0', 'bounded1', 'bounded', 'unbounded']
+    labels = ["bounded0", "bounded1", "bounded", "unbounded"]
     plot_all(results, descriptions, labels)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/crossbeam-channel/benchmarks/run.sh
+++ b/crossbeam-channel/benchmarks/run.sh
@@ -7,18 +7,13 @@ cargo run --release --bin crossbeam-channel | tee crossbeam-channel.txt
 cargo run --release --bin futures-channel | tee futures-channel.txt
 cargo run --release --bin mpsc | tee mpsc.txt
 cargo run --release --bin flume | tee flume.txt
+cargo run --release --bin atomicringqueue | tee atomicringqueue.txt
+cargo run --release --bin atomicring | tee atomicring.txt
+cargo run --release --bin bus | tee bus.txt
+cargo run --release --bin crossbeam-deque | tee crossbeam-deque.txt
+cargo run --release --bin lockfree | tee lockfree.txt
+cargo run --release --bin segqueue | tee segqueue.txt
+cargo run --release --bin mpmc | tee mpmc.txt
 go run go.go | tee go.txt
-
-# These can also be run, but too many plot bars mess
-# up the plot (they start to overlap). So only 5 contenders
-# with the most tests are included by default.
-
-# cargo run --release --bin atomicringqueue | tee atomicringqueue.txt
-# cargo run --release --bin atomicring | tee atomicring.txt
-# cargo run --release --bin bus | tee bus.txt
-# cargo run --release --bin crossbeam-deque | tee crossbeam-deque.txt
-# cargo run --release --bin lockfree | tee lockfree.txt
-# cargo run --release --bin segqueue | tee segqueue.txt
-# cargo run --release --bin mpmc | tee mpmc.txt
 
 ./plot.py ./*.txt


### PR DESCRIPTION
I want to visualize the results of multiple benchmarks in a graph. However, the subplot layout, along with many magic constants, is almost hard-coded. And as mentioned in the comments of run.sh, it is not possible to add a sufficient number of bar graphs.
I replaced the graph library from matplotlib to plotly and made modifications, to reduce magic constants and to make it easier to expand. I also introduced type hints in the Python code.

The attached image is an example when including all bar graphs. But I don't have a native Linux box, so the benchmark result graph could not be included in the PR. It was executed on WSL.
![plot](https://github.com/crossbeam-rs/crossbeam/assets/16424085/102d55e5-00b0-497c-bbbe-64cb392e8a93)

The first commit only contains format change without altering any code, you can skip it and read the second one.(https://github.com/crossbeam-rs/crossbeam/commit/3b0732bd47fff9cd8dccf5c3da29fadee56707f2)
