### PR TITLE
skiplist: a new iteator which is sendable among threads

### DIFF
--- a/crossbeam-skiplist/src/base.rs
+++ b/crossbeam-skiplist/src/base.rs
@@ -517,7 +517,7 @@ where
     }
 
     /// Returns an iterator over all entries in the skip list who owns a reference to the skiplist.
-    pub fn owned_iter(self: &Arc<Self>) -> OwnedIter<Arc<Self>, K, V> {
+    pub fn owned_iter(self: &Arc<Self>) -> OwnedIter<K, V> {
         OwnedIter {
             list: self.clone(),
             cursor: None,
@@ -2259,17 +2259,13 @@ impl<K, V> Drop for OwnedEntry<K, V> {
 }
 
 /// A iterator with a clone of the concurrent skip list
-pub struct OwnedIter<T, K, V>
-where
-    T: AsRef<SkipList<K, V>>,
-{
-    list: T,
+pub struct OwnedIter<K, V> {
+    list: Arc<SkipList<K, V>>,
     cursor: Option<OwnedEntry<K, V>>,
 }
 
-impl<T, K, V> fmt::Debug for OwnedIter<T, K, V>
+impl<K, V> fmt::Debug for OwnedIter<K, V>
 where
-    T: AsRef<SkipList<K, V>>,
     K: fmt::Debug,
     V: fmt::Debug,
 {
@@ -2283,7 +2279,7 @@ where
     }
 }
 
-impl<K, V, T: AsRef<SkipList<K, V>>> OwnedIter<T, K, V>
+impl<K, V> OwnedIter<K, V>
 where
     K: Ord,
 {
@@ -2341,7 +2337,11 @@ where
     }
 
     /// Make iterator point to the element whose key is larger or equal to the target
-    pub fn seek(&mut self, target: &K, guard: &Guard) {
+    pub fn seek<Q>(&mut self, target: &Q, guard: &Guard)
+    where
+        K: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
         self.list.as_ref().check_guard(guard);
         if let Some(n) = self.cursor.take() {
             n.release(guard);
@@ -2353,7 +2353,11 @@ where
     }
 
     /// Make iterator point to the element whose key is less than the target
-    pub fn seek_for_prev(&mut self, target: &K, guard: &Guard) {
+    pub fn seek_for_prev<Q>(&mut self, target: &Q, guard: &Guard)
+    where
+        K: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
         self.list.as_ref().check_guard(guard);
         if let Some(n) = self.cursor.take() {
             n.release(guard);

--- a/crossbeam-skiplist/src/base.rs
+++ b/crossbeam-skiplist/src/base.rs
@@ -2201,7 +2201,7 @@ fn below_upper_bound<T: Ord + ?Sized>(bound: &Bound<&T>, other: &T) -> bool {
 ///
 /// You *must* call `release` to free this type, otherwise the node will be
 /// leaked. This is because releasing the entry requires a `Guard`.
-pub struct OwnedEntry<K, V> {
+struct OwnedEntry<K, V> {
     node: *const Node<K, V>,
     released: bool,
 }
@@ -2221,17 +2221,17 @@ impl<K, V> OwnedEntry<K, V> {
     }
 
     /// Returns a reference to the key.
-    pub fn key(&self) -> &K {
+    fn key(&self) -> &K {
         unsafe { &(*self.node).key }
     }
 
     /// Returns a reference to the value.
-    pub fn value(&self) -> &V {
+    fn value(&self) -> &V {
         unsafe { &(*self.node).value }
     }
 
     /// Releases the reference on the entry.
-    pub fn release(mut self, guard: &Guard) {
+    fn release(mut self, guard: &Guard) {
         self.released = true;
         unsafe { (*self.node).decrement(guard) }
     }
@@ -2276,6 +2276,15 @@ where
             Some(e) => d.field("cursor", &(e.key(), e.value())),
         };
         d.finish()
+    }
+}
+
+impl<K, V> Drop for OwnedIter<K, V> {
+    fn drop(&mut self) {
+        if let Some(cursor) = self.cursor.take() {
+            let guard = &epoch::pin();
+            cursor.release(guard);
+        }
     }
 }
 

--- a/crossbeam-skiplist/src/base.rs
+++ b/crossbeam-skiplist/src/base.rs
@@ -2128,6 +2128,8 @@ pub struct RefCountedEntry<K, V> {
     node: *const Node<K, V>,
 }
 
+unsafe impl<K, V> Send for RefCountedEntry<K, V> {}
+
 impl<K, V> Drop for RefCountedEntry<K, V> {
     fn drop(&mut self) {
         let guard = &epoch::pin();

--- a/crossbeam-skiplist/tests/base.rs
+++ b/crossbeam-skiplist/tests/base.rs
@@ -128,10 +128,11 @@ fn remove2() {
     let mut iter = s.owned_iter();
     let h = std::thread::spawn(move || {
         let mut v = vec![];
-        iter.seek_to_first();
+        let guard = &epoch::pin();
+        iter.seek_to_first(guard);
         while iter.valid() {
             v.push(*iter.key());
-            iter.next();
+            iter.next(guard);
         }
         assert_eq!(v, remaining);
     });

--- a/crossbeam-skiplist/tests/base.rs
+++ b/crossbeam-skiplist/tests/base.rs
@@ -2,9 +2,9 @@
 
 use std::ops::Bound;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 
 use crossbeam_epoch as epoch;
-use crossbeam_skiplist::base::ConcurrentSkipList;
 use crossbeam_skiplist::{base, SkipList};
 
 fn ref_entry<'a, K, V>(e: impl Into<Option<base::RefEntry<'a, K, V>>>) -> Entry<'a, K, V> {
@@ -113,7 +113,7 @@ fn remove2() {
     let remove = [2, 12, 8];
     let remaining = [0, 4, 5, 7, 11];
 
-    let s = ConcurrentSkipList::new(epoch::default_collector().clone());
+    let s = Arc::new(SkipList::new(epoch::default_collector().clone()));
 
     for &x in &insert {
         s.insert(x, x * 10, guard).release(guard);
@@ -125,7 +125,7 @@ fn remove2() {
         s.remove(x, guard).unwrap().release(guard);
     }
 
-    let mut iter = s.iter();
+    let mut iter = s.owned_iter();
     let h = std::thread::spawn(move || {
         let mut v = vec![];
         iter.seek_to_first();

--- a/crossbeam-skiplist/tests/base.rs
+++ b/crossbeam-skiplist/tests/base.rs
@@ -125,14 +125,18 @@ fn remove2() {
         s.remove(x, guard).unwrap().release(guard);
     }
 
-    let mut v = vec![];
     let mut iter = s.iter();
-    iter.seek_to_first();
-    while iter.valid() {
-        v.push(*iter.key());
-        iter.next();
-    }
-    assert_eq!(v, remaining);
+    let h = std::thread::spawn(move || {
+        let mut v = vec![];
+        iter.seek_to_first();
+        while iter.valid() {
+            v.push(*iter.key());
+            iter.next();
+        }
+        assert_eq!(v, remaining);
+    });
+
+    h.join().unwrap();
 }
 
 #[test]


### PR DESCRIPTION
Ref https://github.com/crossbeam-rs/crossbeam/issues/1090

This PR implements a wrapper of the skiplist which supports creating iteator that is sendable among threads.
More tests or comment can be added if this is needed.