### PR TITLE
[wip] Cumulative micro opts (1-2% perf. gain)

### DIFF
--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -1514,7 +1514,7 @@ pub(crate) unsafe fn write<T>(s: &Sender<T>, token: &mut Token, msg: T) -> Resul
     unsafe {
         match &s.flavor {
             SenderFlavor::Array(chan) => chan.write(token, msg),
-            SenderFlavor::List(chan) => chan.write(token, msg),
+            SenderFlavor::List(chan) => chan.write(&mut token.list, msg),
             SenderFlavor::Zero(chan) => chan.write(token, msg),
         }
     }
@@ -1525,7 +1525,7 @@ pub(crate) unsafe fn read<T>(r: &Receiver<T>, token: &mut Token) -> Result<T, ()
     unsafe {
         match &r.flavor {
             ReceiverFlavor::Array(chan) => chan.read(token),
-            ReceiverFlavor::List(chan) => chan.read(token),
+            ReceiverFlavor::List(chan) => chan.read(&mut token.list),
             ReceiverFlavor::Zero(chan) => chan.read(token),
             ReceiverFlavor::At(chan) => {
                 mem::transmute_copy::<Result<Instant, ()>, Result<T, ()>>(&chan.read(token))

--- a/crossbeam-channel/src/flavors/list.rs
+++ b/crossbeam-channel/src/flavors/list.rs
@@ -203,7 +203,7 @@ impl<T> Channel<T> {
     }
 
     /// Attempts to reserve a slot for sending a message.
-    fn start_send(&self, token: &mut Token) {
+    fn start_send(&self, token: &mut ListToken) {
         let backoff = Backoff::new();
         let mut next_block = ptr::null_mut::<Block<T>>();
 
@@ -215,7 +215,7 @@ impl<T> Channel<T> {
 
             // Check if the channel is disconnected.
             if tail & MARK_BIT != 0 {
-                token.list.block = ptr::null();
+                token.block = ptr::null();
                 break;
             }
 
@@ -266,8 +266,8 @@ impl<T> Channel<T> {
                         (*block).next.store(n, Ordering::Release);
                     }
 
-                    token.list.block = block as *const u8;
-                    token.list.offset = offset;
+                    token.block = block as *const u8;
+                    token.offset = offset;
                     break;
                 },
                 Err(_) => {
@@ -282,15 +282,15 @@ impl<T> Channel<T> {
     }
 
     /// Writes a message into the channel.
-    pub(crate) unsafe fn write(&self, token: &mut Token, msg: T) -> Result<(), T> {
+    pub(crate) unsafe fn write(&self, token: &mut ListToken, msg: T) -> Result<(), T> {
         // If there is no slot, the channel is disconnected.
-        if token.list.block.is_null() {
+        if token.block.is_null() {
             return Err(msg);
         }
 
         // Write the message into the slot.
-        let block = token.list.block.cast::<Block<T>>();
-        let offset = token.list.offset;
+        let block = token.block.cast::<Block<T>>();
+        let offset = token.offset;
         let slot = unsafe { (*block).get_slot_unchecked(offset) };
         unsafe { slot.msg.get().write(msg) }
         slot.state.fetch_or(WRITE, Ordering::Release);
@@ -301,7 +301,7 @@ impl<T> Channel<T> {
     }
 
     /// Attempts to reserve a slot for receiving a message.
-    fn start_recv(&self, token: &mut Token) -> bool {
+    fn start_recv(&self, token: &mut ListToken) -> bool {
         let backoff = Backoff::new();
         let mut head;
         let mut block;
@@ -330,7 +330,7 @@ impl<T> Channel<T> {
                     // If the channel is disconnected...
                     if tail & MARK_BIT != 0 {
                         // ...then receive an error.
-                        token.list.block = ptr::null();
+                        token.block = ptr::null();
                         return true;
                     } else {
                         // Otherwise, the receive operation is not ready.
@@ -371,8 +371,8 @@ impl<T> Channel<T> {
                         self.head.index.store(next_index, Ordering::Release);
                     }
 
-                    token.list.block = block as *const u8;
-                    token.list.offset = offset;
+                    token.block = block as *const u8;
+                    token.offset = offset;
                     return true;
                 },
                 Err(_) => {
@@ -383,15 +383,15 @@ impl<T> Channel<T> {
     }
 
     /// Reads a message from the channel.
-    pub(crate) unsafe fn read(&self, token: &mut Token) -> Result<T, ()> {
-        if token.list.block.is_null() {
+    pub(crate) unsafe fn read(&self, token: &mut ListToken) -> Result<T, ()> {
+        if token.block.is_null() {
             // The channel is disconnected.
             return Err(());
         }
 
         // Read the message.
-        let block = token.list.block as *mut Block<T>;
-        let offset = token.list.offset;
+        let block = token.block as *mut Block<T>;
+        let offset = token.offset;
         let slot = unsafe { (*block).get_slot_unchecked(offset) };
         slot.wait_write();
         let msg = unsafe { slot.msg.get().read() };
@@ -423,8 +423,7 @@ impl<T> Channel<T> {
         msg: T,
         _deadline: Option<Instant>,
     ) -> Result<(), SendTimeoutError<T>> {
-        let token = MaybeUninit::uninit();
-        let token = &mut unsafe { token.assume_init() };
+        let token = &mut ListToken::default();
 
         self.start_send(token);
         unsafe {
@@ -435,8 +434,7 @@ impl<T> Channel<T> {
 
     /// Attempts to receive a message without blocking.
     pub(crate) fn try_recv(&self) -> Result<T, TryRecvError> {
-        let token = MaybeUninit::uninit();
-        let token = &mut unsafe { token.assume_init() };
+        let token = &mut ListToken::default();
 
         if self.start_recv(token) {
             unsafe { self.read(token).map_err(|_| TryRecvError::Disconnected) }
@@ -447,8 +445,7 @@ impl<T> Channel<T> {
 
     /// Receives a message from the channel.
     pub(crate) fn recv(&self, deadline: Option<Instant>) -> Result<T, RecvTimeoutError> {
-        let token = MaybeUninit::uninit();
-        let token = &mut unsafe { token.assume_init() };
+        let token = &mut ListToken::default();
 
         loop {
             // Try receiving a message several times.
@@ -701,7 +698,7 @@ pub(crate) struct Sender<'a, T>(&'a Channel<T>);
 
 impl<T> SelectHandle for Receiver<'_, T> {
     fn try_select(&self, token: &mut Token) -> bool {
-        self.0.start_recv(token)
+        self.0.start_recv(&mut token.list)
     }
 
     fn deadline(&self) -> Option<Instant> {
@@ -737,7 +734,7 @@ impl<T> SelectHandle for Receiver<'_, T> {
 
 impl<T> SelectHandle for Sender<'_, T> {
     fn try_select(&self, token: &mut Token) -> bool {
-        self.0.start_send(token);
+        self.0.start_send(&mut token.list);
         true
     }
 


### PR DESCRIPTION
Well, I REALLY want my other prs to be merged (or decided to be rejected, so that i can decide to fork crossbeam for my work....). All of them got stale for long time for some reason.

So, I'm wondering whether it could help by actively contributing to crossbeam or not, in order to indicate my willingness to spend my time in exchange of my prs got being reviewed. :)

here it is. Assorted of micro ops, i came up with. note that I haven't evaluated each in depth. This pr is to start triage them from more knowledgeable people. so that I can create more serious prs for each.

General theme of them is to reduce instructions.

(note to self):
- inject to-be-dropped buffer from receiver to sender
- new with at-the-end of index so that initial alloc can happen even with non-option buffer