### PR TITLE
Implement Stealer::will_steal_from

### DIFF
--- a/crossbeam-deque/src/deque.rs
+++ b/crossbeam-deque/src/deque.rs
@@ -296,8 +296,8 @@ impl<T> Worker<T> {
     /// let w_1 = Worker::<i32>::new_lifo();
     /// let w_2 = Worker::<i32>::new_fifo();
     ///
-    /// let s_1 = w.stealer();
-    /// let s_2 = w.stealer();
+    /// let s_1 = w_1.stealer();
+    /// let s_2 = w_2.stealer();
     ///
     /// assert!(w_1.is_same_as(&s_1));
     /// assert!(w_2.is_same_as(&s_2));

--- a/crossbeam-deque/src/deque.rs
+++ b/crossbeam-deque/src/deque.rs
@@ -286,6 +286,28 @@ impl<T> Worker<T> {
         }
     }
 
+    /// Checks if the worker and the provided stealer are pointing to the same underlying queue.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_deque::Worker;
+    ///
+    /// let w_1 = Worker::<i32>::new_lifo();
+    /// let w_2 = Worker::<i32>::new_fifo();
+    ///
+    /// let s_1 = w.stealer();
+    /// let s_2 = w.stealer();
+    ///
+    /// assert!(w_1.is_same_as(&s_1));
+    /// assert!(w_2.is_same_as(&s_2));
+    /// assert!(!w_1.is_same_as(&s_2));
+    /// assert!(!w_2.is_same_as(&s_1));
+    /// ```
+    pub fn is_same_as(&self, stealer: &Stealer<T>) -> bool {
+        Arc::ptr_eq(&self.inner, &stealer.inner)
+    }
+
     /// Resizes the internal buffer to the new capacity of `new_cap`.
     #[cold]
     unsafe fn resize(&self, new_cap: usize) {

--- a/crossbeam-deque/src/deque.rs
+++ b/crossbeam-deque/src/deque.rs
@@ -286,28 +286,6 @@ impl<T> Worker<T> {
         }
     }
 
-    /// Checks if the worker and the provided stealer are pointing to the same underlying queue.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use crossbeam_deque::Worker;
-    ///
-    /// let w_1 = Worker::<i32>::new_lifo();
-    /// let w_2 = Worker::<i32>::new_fifo();
-    ///
-    /// let s_1 = w_1.stealer();
-    /// let s_2 = w_2.stealer();
-    ///
-    /// assert!(w_1.donates_to(&s_1));
-    /// assert!(w_2.donates_to(&s_2));
-    /// assert!(!w_1.donates_to(&s_2));
-    /// assert!(!w_2.donates_to(&s_1));
-    /// ```
-    pub fn donates_to(&self, stealer: &Stealer<T>) -> bool {
-        Arc::ptr_eq(&self.inner, &stealer.inner)
-    }
-
     /// Resizes the internal buffer to the new capacity of `new_cap`.
     #[cold]
     unsafe fn resize(&self, new_cap: usize) {
@@ -643,6 +621,30 @@ impl<T> Stealer<T> {
         atomic::fence(Ordering::SeqCst);
         let b = self.inner.back.load(Ordering::Acquire);
         b.wrapping_sub(f).max(0) as usize
+    }
+
+    /// Checks if the stealer will steal from the provided worker.
+    ///
+    /// If both are pointing to the same underlying queue, this will return false.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_deque::Worker;
+    ///
+    /// let w_1 = Worker::<i32>::new_lifo();
+    /// let w_2 = Worker::<i32>::new_fifo();
+    ///
+    /// let s_1 = w_1.stealer();
+    /// let s_2 = w_2.stealer();
+    ///
+    /// assert!(!w_1.will_steal_fromq(&s_1));
+    /// assert!(!w_2.will_steal_fromq(&s_2));
+    /// assert!(w_1.will_steal_fromq(&s_2));
+    /// assert!(w_2.will_steal_fromq(&s_1));
+    /// ```
+    pub fn will_steal_fromq(&self, stealer: &Stealer<T>) -> bool {
+        !Arc::ptr_eq(&self.inner, &stealer.inner)
     }
 
     /// Steals a task from the queue.

--- a/crossbeam-deque/src/deque.rs
+++ b/crossbeam-deque/src/deque.rs
@@ -299,12 +299,12 @@ impl<T> Worker<T> {
     /// let s_1 = w_1.stealer();
     /// let s_2 = w_2.stealer();
     ///
-    /// assert!(w_1.is_same_as(&s_1));
-    /// assert!(w_2.is_same_as(&s_2));
-    /// assert!(!w_1.is_same_as(&s_2));
-    /// assert!(!w_2.is_same_as(&s_1));
+    /// assert!(w_1.donates_to(&s_1));
+    /// assert!(w_2.donates_to(&s_2));
+    /// assert!(!w_1.donates_to(&s_2));
+    /// assert!(!w_2.donates_to(&s_1));
     /// ```
-    pub fn is_same_as(&self, stealer: &Stealer<T>) -> bool {
+    pub fn donates_to(&self, stealer: &Stealer<T>) -> bool {
         Arc::ptr_eq(&self.inner, &stealer.inner)
     }
 

--- a/crossbeam-deque/src/deque.rs
+++ b/crossbeam-deque/src/deque.rs
@@ -638,13 +638,13 @@ impl<T> Stealer<T> {
     /// let s_1 = w_1.stealer();
     /// let s_2 = w_2.stealer();
     ///
-    /// assert!(!w_1.will_steal_fromq(&s_1));
-    /// assert!(!w_2.will_steal_fromq(&s_2));
-    /// assert!(w_1.will_steal_fromq(&s_2));
-    /// assert!(w_2.will_steal_fromq(&s_1));
+    /// assert!(!s_1.will_steal_fromq(&w_1));
+    /// assert!(!s_2.will_steal_fromq(&w_2));
+    /// assert!(s_1.will_steal_fromq(&w_2));
+    /// assert!(s_2.will_steal_fromq(&w_1));
     /// ```
-    pub fn will_steal_fromq(&self, stealer: &Stealer<T>) -> bool {
-        !Arc::ptr_eq(&self.inner, &stealer.inner)
+    pub fn will_steal_fromq(&self, worker: &Worker<T>) -> bool {
+        !Arc::ptr_eq(&self.inner, &worker.inner)
     }
 
     /// Steals a task from the queue.


### PR DESCRIPTION
Currently it's not possible to tell if a Worker and a Stealer point to the same underlying queue. This make it difficult to tell which stealer to remove from a list and you have a local Worker on hand, or skip stealing from when given a global list of stealers. The implementation just forwards to Arc::ptr_eq on the inner buffer. Added a doctest as well.