### PR TITLE
Fallback to Parking in Bounded and Unbounded Channels

### DIFF
--- a/crossbeam-channel/src/flavors/array.rs
+++ b/crossbeam-channel/src/flavors/array.rs
@@ -210,7 +210,7 @@ impl<T> Channel<T> {
 
                 // The head was advanced but the stamp hasn't been updated yet,
                 // meaning a receive is in-progress. Spin for a bit waiting for
-                // the receive to complete before falling back to parking.
+                // the receive to complete before falling back to blocking.
                 if backoff.is_completed() {
                     return Status::InProgress;
                 }
@@ -308,7 +308,7 @@ impl<T> Channel<T> {
 
                 // The tail was advanced but the stamp hasn't been updated yet,
                 // meaning a send is in-progress. Spin for a bit waiting for
-                // the send to complete before falling back to parking.
+                // the send to complete before falling back to blocking.
                 if backoff.is_completed() {
                     return Status::InProgress;
                 }

--- a/crossbeam-channel/src/flavors/at.rs
+++ b/crossbeam-channel/src/flavors/at.rs
@@ -10,6 +10,7 @@ use crate::context::Context;
 use crate::err::{RecvTimeoutError, TryRecvError};
 use crate::select::{Operation, SelectHandle, Token};
 use crate::utils;
+use crate::waker::BlockingState;
 
 /// Result of a receive operation.
 pub(crate) type AtToken = Option<Instant>;
@@ -140,6 +141,10 @@ impl Channel {
 }
 
 impl SelectHandle for Channel {
+    fn start(&self) -> Option<BlockingState<'_>> {
+        None
+    }
+
     #[inline]
     fn try_select(&self, token: &mut Token) -> bool {
         match self.try_recv() {
@@ -166,7 +171,12 @@ impl SelectHandle for Channel {
     }
 
     #[inline]
-    fn register(&self, _oper: Operation, _cx: &Context) -> bool {
+    fn register(
+        &self,
+        _oper: Operation,
+        _cx: &Context,
+        _state: Option<&BlockingState<'_>>,
+    ) -> bool {
         self.is_ready()
     }
 
@@ -184,7 +194,7 @@ impl SelectHandle for Channel {
     }
 
     #[inline]
-    fn watch(&self, _oper: Operation, _cx: &Context) -> bool {
+    fn watch(&self, _oper: Operation, _cx: &Context, _state: Option<&BlockingState<'_>>) -> bool {
         self.is_ready()
     }
 

--- a/crossbeam-channel/src/flavors/never.rs
+++ b/crossbeam-channel/src/flavors/never.rs
@@ -9,6 +9,7 @@ use crate::context::Context;
 use crate::err::{RecvTimeoutError, TryRecvError};
 use crate::select::{Operation, SelectHandle, Token};
 use crate::utils;
+use crate::waker::BlockingState;
 
 /// This flavor doesn't need a token.
 pub(crate) type NeverToken = ();
@@ -72,6 +73,10 @@ impl<T> Channel<T> {
 }
 
 impl<T> SelectHandle for Channel<T> {
+    fn start(&self) -> Option<BlockingState<'_>> {
+        None
+    }
+
     #[inline]
     fn try_select(&self, _token: &mut Token) -> bool {
         false
@@ -83,7 +88,12 @@ impl<T> SelectHandle for Channel<T> {
     }
 
     #[inline]
-    fn register(&self, _oper: Operation, _cx: &Context) -> bool {
+    fn register(
+        &self,
+        _oper: Operation,
+        _cx: &Context,
+        _state: Option<&BlockingState<'_>>,
+    ) -> bool {
         self.is_ready()
     }
 
@@ -101,7 +111,7 @@ impl<T> SelectHandle for Channel<T> {
     }
 
     #[inline]
-    fn watch(&self, _oper: Operation, _cx: &Context) -> bool {
+    fn watch(&self, _oper: Operation, _cx: &Context, _state: Option<&BlockingState<'_>>) -> bool {
         self.is_ready()
     }
 

--- a/crossbeam-channel/src/flavors/tick.rs
+++ b/crossbeam-channel/src/flavors/tick.rs
@@ -10,6 +10,7 @@ use crossbeam_utils::atomic::AtomicCell;
 use crate::context::Context;
 use crate::err::{RecvTimeoutError, TryRecvError};
 use crate::select::{Operation, SelectHandle, Token};
+use crate::waker::BlockingState;
 
 /// Result of a receive operation.
 pub(crate) type TickToken = Option<Instant>;
@@ -115,6 +116,10 @@ impl Channel {
 }
 
 impl SelectHandle for Channel {
+    fn start(&self) -> Option<BlockingState<'_>> {
+        None
+    }
+
     #[inline]
     fn try_select(&self, token: &mut Token) -> bool {
         match self.try_recv() {
@@ -136,7 +141,12 @@ impl SelectHandle for Channel {
     }
 
     #[inline]
-    fn register(&self, _oper: Operation, _cx: &Context) -> bool {
+    fn register(
+        &self,
+        _oper: Operation,
+        _cx: &Context,
+        _state: Option<&BlockingState<'_>>,
+    ) -> bool {
         self.is_ready()
     }
 
@@ -154,7 +164,7 @@ impl SelectHandle for Channel {
     }
 
     #[inline]
-    fn watch(&self, _oper: Operation, _cx: &Context) -> bool {
+    fn watch(&self, _oper: Operation, _cx: &Context, _state: Option<&BlockingState<'_>>) -> bool {
         self.is_ready()
     }
 

--- a/crossbeam-channel/src/lib.rs
+++ b/crossbeam-channel/src/lib.rs
@@ -362,6 +362,7 @@ mod waker;
 #[cfg(feature = "std")]
 pub mod internal {
     pub use crate::select::{select, select_timeout, try_select, SelectHandle};
+    pub use crate::waker::BlockingState;
 }
 
 #[cfg(feature = "std")]

--- a/crossbeam-channel/src/waker.rs
+++ b/crossbeam-channel/src/waker.rs
@@ -1,7 +1,8 @@
 //! Waking mechanism for threads blocked on channel operations.
 
+use core::sync::atomic::AtomicU32;
 use std::ptr;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Mutex;
 use std::thread::{self, ThreadId};
 use std::vec::Vec;
@@ -179,8 +180,8 @@ pub(crate) struct SyncWaker {
     /// The inner `Waker`.
     inner: Mutex<Waker>,
 
-    /// `true` if the waker is empty.
-    is_empty: AtomicBool,
+    /// Atomic state for this waker.
+    state: WakerState,
 }
 
 impl SyncWaker {
@@ -189,58 +190,52 @@ impl SyncWaker {
     pub(crate) fn new() -> Self {
         Self {
             inner: Mutex::new(Waker::new()),
-            is_empty: AtomicBool::new(true),
+            state: WakerState::new(),
+        }
+    }
+
+    /// Returns a token that can be used to manage the state of a blocking operation.
+    pub(crate) fn start(&self) -> BlockingState<'_> {
+        BlockingState {
+            is_waker: false,
+            waker: self,
         }
     }
 
     /// Registers the current thread with an operation.
     #[inline]
-    pub(crate) fn register(&self, oper: Operation, cx: &Context) {
-        let mut inner = self.inner.lock().unwrap();
-        inner.register(oper, cx);
-        self.is_empty.store(
-            inner.selectors.is_empty() && inner.observers.is_empty(),
-            Ordering::SeqCst,
-        );
+    pub(crate) fn register(&self, oper: Operation, cx: &Context, state: &BlockingState<'_>) {
+        self.inner.lock().unwrap().register(oper, cx);
+        self.state.park(state.is_waker);
     }
 
     /// Unregisters an operation previously registered by the current thread.
     #[inline]
     pub(crate) fn unregister(&self, oper: Operation) -> Option<Entry> {
-        let mut inner = self.inner.lock().unwrap();
-        let entry = inner.unregister(oper);
-        self.is_empty.store(
-            inner.selectors.is_empty() && inner.observers.is_empty(),
-            Ordering::SeqCst,
-        );
-        entry
+        self.inner.lock().unwrap().unregister(oper)
     }
 
     /// Attempts to find one thread (not the current one), select its operation, and wake it up.
     #[inline]
     pub(crate) fn notify(&self) {
-        if !self.is_empty.load(Ordering::SeqCst) {
-            let mut inner = self.inner.lock().unwrap();
-            if !self.is_empty.load(Ordering::SeqCst) {
-                inner.try_select();
-                inner.notify();
-                self.is_empty.store(
-                    inner.selectors.is_empty() && inner.observers.is_empty(),
-                    Ordering::SeqCst,
-                );
-            }
+        if self.state.try_notify() {
+            self.notify_one()
         }
+    }
+
+    // Finds a thread (not the current one), select its operation, and wake it up.
+    #[inline]
+    pub(crate) fn notify_one(&self) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.try_select();
+        inner.notify();
     }
 
     /// Registers an operation waiting to be ready.
     #[inline]
     pub(crate) fn watch(&self, oper: Operation, cx: &Context) {
-        let mut inner = self.inner.lock().unwrap();
-        inner.watch(oper, cx);
-        self.is_empty.store(
-            inner.selectors.is_empty() && inner.observers.is_empty(),
-            Ordering::SeqCst,
-        );
+        self.inner.lock().unwrap().watch(oper, cx);
+        self.state.park(false);
     }
 
     /// Unregisters an operation waiting to be ready.
@@ -248,10 +243,6 @@ impl SyncWaker {
     pub(crate) fn unwatch(&self, oper: Operation) {
         let mut inner = self.inner.lock().unwrap();
         inner.unwatch(oper);
-        self.is_empty.store(
-            inner.selectors.is_empty() && inner.observers.is_empty(),
-            Ordering::SeqCst,
-        );
     }
 
     /// Notifies all threads that the channel is disconnected.
@@ -259,17 +250,144 @@ impl SyncWaker {
     pub(crate) fn disconnect(&self) {
         let mut inner = self.inner.lock().unwrap();
         inner.disconnect();
-        self.is_empty.store(
-            inner.selectors.is_empty() && inner.observers.is_empty(),
-            Ordering::SeqCst,
-        );
     }
 }
 
 impl Drop for SyncWaker {
     #[inline]
     fn drop(&mut self) {
-        debug_assert!(self.is_empty.load(Ordering::SeqCst));
+        debug_assert!(!self.state.has_waiters());
+    }
+}
+
+/// A guard that manages the state of a blocking operation.
+#[derive(Clone)]
+struct BlockingState<'a> {
+    /// True if this thread is the waker thread, meaning it must
+    /// try to notify waiters after it completes.
+    is_waker: bool,
+
+    waker: &'a SyncWaker,
+}
+
+impl BlockingState<'_> {
+    /// Reset the state after waking up from parking.
+    #[inline]
+    pub(crate) fn unpark(&mut self) {
+        self.is_waker = self.waker.state.unpark();
+    }
+
+    /// Reset the state of an observer after waking up from parking.
+    #[inline]
+    pub(crate) fn unpark_observer(&mut self) {
+        self.waker.state.unpark_observer();
+    }
+}
+
+impl Drop for BlockingState<'_> {
+    fn drop(&mut self) {
+        if self.is_waker && self.waker.state.drop_waker() {
+            self.waker.notify_one();
+        }
+    }
+}
+
+const NOTIFIED: u32 = 0b001;
+const WAKER: u32 = 0b010;
+
+/// The state of a `SyncWaker`.
+struct WakerState {
+    state: AtomicU32,
+}
+
+impl WakerState {
+    /// Initialize the waker state.
+    fn new() -> WakerState {
+        WakerState {
+            state: AtomicU32::new(0),
+        }
+    }
+
+    /// Returns whether or not a waiter needs to be notified.
+    fn try_notify(&self) -> bool {
+        // because storing a value in the channel is also sequentially consistent,
+        // this creates a total order between storing a value and registering a waiter.
+        let state = self.state.load(Ordering::SeqCst);
+
+        // if a notification is already set, the waker thread will take care
+        // of further notifications. otherwise we have to notify if there are waiters
+        if ((state >> NOTIFIED) & (state & NOTIFIED)) > 0 {
+            return self
+                .state
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |state| {
+                    // set the notification if there are waiters and it is not already set
+                    if (state >> WAKER) > 0 && (state & NOTIFIED == 0) {
+                        Some(state | (WAKER | NOTIFIED))
+                    } else {
+                        None
+                    }
+                })
+                .is_ok();
+        }
+
+        false
+    }
+
+    /// Get ready for this waker to park. The channel should be checked after calling this
+    /// method, and before parking.
+    fn park(&self, waker: bool) {
+        // increment the waiter count. if we are the waker thread, we also have to remove the
+        // notification to allow other waiters to be notified after we park
+        let update = (1_u32 << WAKER).wrapping_sub(u32::from(waker));
+        self.state.fetch_add(update, Ordering::SeqCst);
+    }
+
+    /// Remove an observer from the waker state after it was unparked.
+    ///
+    /// Observers never become the waking thread because if there were waiters, they
+    /// are also woken up along with any observers.
+    fn unpark_observer(&self) {
+        self.state.fetch_sub(1_u32 << WAKER, Ordering::SeqCst);
+    }
+
+    /// Remove this waiter from the waker state after it was unparked.
+    ///
+    /// Returns `true` if this thread became the waking thread and must call `drop_waker`
+    /// after it completes it's operation.
+    fn unpark(&self) -> bool {
+        self.state
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |state| {
+                // decrement the waiter count and consume the waker token
+                Some((state - (1 << WAKER)) & !WAKER)
+            })
+            // did we consume the token and become the waker thread?
+            .map(|state| state & WAKER != 0)
+            .unwrap()
+    }
+
+    /// Called by the waking thread after completing it's operation.
+    ///
+    /// Returns `true` if a waiter should be notified.
+    fn drop_waker(&self) -> bool {
+        self.state
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |state| {
+                // if there are waiters, set the waker token and wake someone, transferring the
+                // waker thread. otherwise unset the notification so new waiters can synchronize
+                // with new notifications
+                Some(if (state >> WAKER) > 0 {
+                    state | WAKER
+                } else {
+                    state.wrapping_sub(NOTIFIED)
+                })
+            })
+            // were there waiters?
+            .map(|state| (state >> WAKER) > 0)
+            .unwrap()
+    }
+
+    /// Returns `true` if there are active waiters.
+    fn has_waiters(&self) -> bool {
+        (self.state.load(Ordering::Relaxed) >> WAKER) > 0
     }
 }
 

--- a/crossbeam-channel/tests/array.rs
+++ b/crossbeam-channel/tests/array.rs
@@ -427,6 +427,7 @@ fn stress_oneshot() {
     }
 }
 
+// TODO: failing sometimes
 #[test]
 fn stress_iter() {
     #[cfg(miri)]

--- a/crossbeam-channel/tests/array.rs
+++ b/crossbeam-channel/tests/array.rs
@@ -427,7 +427,6 @@ fn stress_oneshot() {
     }
 }
 
-// TODO: failing sometimes
 #[test]
 fn stress_iter() {
     #[cfg(miri)]

--- a/crossbeam-utils/src/backoff.rs
+++ b/crossbeam-utils/src/backoff.rs
@@ -269,7 +269,16 @@ impl Backoff {
     /// [`AtomicBool`]: std::sync::atomic::AtomicBool
     #[inline]
     pub fn is_completed(&self) -> bool {
-        self.step.get() > YIELD_LIMIT
+        #[cfg(not(test))]
+        {
+            self.step.get() > YIELD_LIMIT
+        }
+
+        // avoid spinning during tests, which can hide bugs in the waker
+        #[cfg(test)]
+        {
+            true
+        }
     }
 }
 


### PR DESCRIPTION
Currently, the queues used by the bounded and unbounded channels (also `ArrayQueue` and `SegQueue`) are not lock-free. The linearization point of a send or receive is moving the tail or head index respectively, meaning that if a sender or receiver sees the head/tail has moved but the value has not been written yet, they must spin until the corresponding receive or send completes that frees up space in the channel. Blocking in such a case is not possible, as sends might notify a receiver even though they are not visible due to a lagging sender holding up the channel, or vice versa, leading to missed wakeups.

The current solution of unbounded spinning can lead to issues, especially on platforms with a single core or custom thread priorities. One way to allow falling back to blocking is if waiters that see more values in the channel after being woken up notify any other waiters, making up for any missed notifications. However, this ends up being quite expensive and can lead to many unnecessary wakeups. A solution to this is wakeup throttling as implemented [by tokio](https://tokio.rs/blog/2019-10-scheduler#reducing-cross-thread-synchronization) and other userspace schedulers, which avoids notifications if there is already an active thread, the "waker thread". That thread will then notify another waiter if it finds a message, creating a new waker thread. This PR changes the bounded and unbounded channels to fallback to blocking after observing a linearizability condition, using wakeup throttling to makeup for missed notifications without creating too many unnecessary wakeups.

Thanks to @kprotty for pointing me in the right direction for the wakeup throttling algorithm. Hopefully paired with https://github.com/crossbeam-rs/crossbeam/pull/1038 this should resolve all of the spinning issues in crossbeam/std.

Should resolve https://github.com/crossbeam-rs/crossbeam/issues/366 and https://github.com/crossbeam-rs/crossbeam/issues/997 (as well as https://github.com/rust-lang/rust/issues/114851 and https://github.com/rust-lang/rust/issues/112723 when upstreamed to std).