### PR TITLE
Pin nightly to 2024-05-04 due to recently-enabled check-cfg

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,6 +16,7 @@ aarch64_linux_task:
   arm_container:
     image: rust
   setup_script:
+    # TODO: Pin nightly due to: https://github.com/rust-lang/rust/issues/124800
     - rustup toolchain add nightly-2024-05-04 && rustup default nightly-2024-05-04
   test_script:
     - cargo test --all --all-features --exclude benchmarks -- --test-threads=1
@@ -28,6 +29,7 @@ aarch64_macos_task:
   macos_instance:
     image: ghcr.io/cirruslabs/macos-ventura-xcode
   setup_script:
+    # TODO: Pin nightly due to: https://github.com/rust-lang/rust/issues/124800
     - curl --proto '=https' --tlsv1.2 -fsSL --retry 10 --retry-connrefused https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain nightly-2024-05-04 --no-modify-path
   test_script:
     - . "$HOME/.cargo/env"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,7 +16,7 @@ aarch64_linux_task:
   arm_container:
     image: rust
   setup_script:
-    - rustup toolchain add nightly && rustup default nightly
+    - rustup toolchain add nightly-2024-05-04 && rustup default nightly-2024-05-04
   test_script:
     - cargo test --all --all-features --exclude benchmarks -- --test-threads=1
     - cargo test --all --all-features --exclude benchmarks --release -- --test-threads=1
@@ -28,7 +28,7 @@ aarch64_macos_task:
   macos_instance:
     image: ghcr.io/cirruslabs/macos-ventura-xcode
   setup_script:
-    - curl --proto '=https' --tlsv1.2 -fsSL --retry 10 --retry-connrefused https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain nightly --no-modify-path
+    - curl --proto '=https' --tlsv1.2 -fsSL --retry 10 --retry-connrefused https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain nightly-2024-05-04 --no-modify-path
   test_script:
     - . "$HOME/.cargo/env"
     - cargo test --all --all-features --exclude benchmarks -- --test-threads=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ concurrency:
 
 jobs:
   # Test crates on their minimum Rust versions and nightly Rust.
+  # TODO: Pin nightly due to: https://github.com/rust-lang/rust/issues/124800
   test:
     env:
       RUST_VERSION: ${{ matrix.rust }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,18 +48,18 @@ jobs:
             os: ubuntu-latest
           - rust: stable
             os: windows-latest
-          - rust: nightly
+          - rust: nightly-2024-05-04
             os: ubuntu-latest
-          - rust: nightly
+          - rust: nightly-2024-05-04
             os: windows-latest
-          - rust: nightly
+          - rust: nightly-2024-05-04
             os: ubuntu-latest
             target: i686-unknown-linux-gnu
-          - rust: nightly
+          - rust: nightly-2024-05-04
             os: ubuntu-latest
             target: armv7-unknown-linux-gnueabihf
           # Test 32-bit target that does not have AtomicU64/AtomicI64.
-          - rust: nightly
+          - rust: nightly-2024-05-04
             os: ubuntu-latest
             target: armv5te-unknown-linux-gnueabi
     runs-on: ${{ matrix.os }}
@@ -85,7 +85,7 @@ jobs:
       matrix:
         rust:
           - msrv
-          - nightly
+          - nightly-2024-05-04
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -105,7 +105,7 @@ jobs:
     steps:
       - uses: taiki-e/checkout-action@v1
       - name: Install Rust
-        run: rustup update nightly && rustup default nightly
+        run: rustup update nightly-2024-05-04 && rustup default nightly-2024-05-04
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
       - name: Install cargo-minimal-versions
@@ -179,7 +179,7 @@ jobs:
     steps:
       - uses: taiki-e/checkout-action@v1
       - name: Install Rust
-        run: rustup toolchain install nightly --component miri && rustup default nightly
+        run: rustup toolchain install nightly-2024-05-04 --component miri && rustup default nightly-2024-05-04
       - name: miri
         run: ci/miri.sh
 
@@ -190,7 +190,7 @@ jobs:
     steps:
       - uses: taiki-e/checkout-action@v1
       - name: Install Rust
-        run: rustup toolchain install nightly --component rust-src && rustup default nightly
+        run: rustup toolchain install nightly-2024-05-04 --component rust-src && rustup default nightly-2024-05-04
       - uses: taiki-e/install-action@cargo-careful
       - name: Run cargo-careful
         run: ci/careful.sh
@@ -202,7 +202,7 @@ jobs:
     steps:
       - uses: taiki-e/checkout-action@v1
       - name: Install Rust
-        run: rustup update nightly && rustup default nightly
+        run: rustup update nightly-2024-05-04 && rustup default nightly-2024-05-04
       # https://github.com/google/sanitizers/issues/1716 / https://github.com/actions/runner-images/issues/9491
       - run: sudo sysctl vm.mmap_rnd_bits=28
       - name: Run sanitizers
@@ -226,7 +226,7 @@ jobs:
     steps:
       - uses: taiki-e/checkout-action@v1
       - name: Install Rust
-        run: rustup update nightly && rustup default nightly
+        run: rustup update nightly-2024-05-04 && rustup default nightly-2024-05-04
       - name: docs
         run: cargo doc --no-deps --all --all-features
 


### PR DESCRIPTION
I'm jumping on this workaround in https://github.com/crossbeam-rs/crossbeam/pull/1040#issuecomment-2109391432 in desperation of shipping `select_biased!`, assuming `build.rs` isn't a viable option (as concerns is raised upstream: https://github.com/rust-lang/rust/issues/124800)....:

> Maybe pinning to older nightly (nightly-2024-05-04 or earlier according to https://blog.rust-lang.org/2024/05/06/check-cfg.html) in crossbeam CI isn't a viable option?