### PR TITLE
Fix check-cfg-related and rust-lld-related CI failures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,5 +63,11 @@ members = [
 missing_debug_implementations = "warn"
 rust_2018_idioms = "warn"
 single_use_lifetimes = "warn"
+unexpected_cfgs = { level = "warn", check-cfg = [
+  'cfg(crossbeam_loom)',
+  'cfg(crossbeam_no_atomic)',
+  'cfg(crossbeam_sanitize)',
+  'cfg(crossbeam_sanitize_thread)',
+] }
 unreachable_pub = "warn"
 # unsafe_op_in_unsafe_fn = "warn" # Set at crate-level instead since https://github.com/rust-lang/rust/pull/100081 is not available on MSRV

--- a/ci/careful.sh
+++ b/ci/careful.sh
@@ -3,9 +3,9 @@ set -euxo pipefail
 IFS=$'\n\t'
 cd "$(dirname "$0")"/..
 
-# TODO: Use the system's default linker instead of rust-lld, which recently
-# became the default until this cargo-careful bug is fixed:
-#   https://github.com/RalfJung/cargo-careful/issues/31
+# TODO: Once cargo-careful's bug (https://github.com/RalfJung/cargo-careful/issues/31) is fixed,
+# stop reverting back to the system's default linker, instead of rust-lld, which became the new 
+# default on linux recently (nightly-2024-05-18 and onwards).
 export RUSTFLAGS="${RUSTFLAGS:-} -Z randomize-layout -Z linker-features=-lld"
 
 cargo careful test --all --all-features --exclude benchmarks -- --test-threads=1

--- a/ci/careful.sh
+++ b/ci/careful.sh
@@ -3,6 +3,9 @@ set -euxo pipefail
 IFS=$'\n\t'
 cd "$(dirname "$0")"/..
 
-export RUSTFLAGS="${RUSTFLAGS:-} -Z randomize-layout"
+# TODO: Use the system's default linker instead of rust-lld, which recently
+# became the default until this cargo-careful bug is fixed:
+#   https://github.com/RalfJung/cargo-careful/issues/31
+export RUSTFLAGS="${RUSTFLAGS:-} -Z randomize-layout -Z linker-features=-lld"
 
 cargo careful test --all --all-features --exclude benchmarks -- --test-threads=1


### PR DESCRIPTION
Fix master ci, which is broken due 2 problems:

- the new check-cfg: https://blog.rust-lang.org/2024/05/06/check-cfg.html
- the default linker change: https://blog.rust-lang.org/2024/05/17/enabling-rust-lld-on-linux.html
