### PR TITLE
Touch up PR 1110

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,9 +65,7 @@ rust_2018_idioms = "warn"
 single_use_lifetimes = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(crossbeam_loom)',
-  'cfg(crossbeam_no_atomic)',
   'cfg(crossbeam_sanitize)',
-  'cfg(crossbeam_sanitize_thread)',
 ] }
 unreachable_pub = "warn"
 # unsafe_op_in_unsafe_fn = "warn" # Set at crate-level instead since https://github.com/rust-lang/rust/pull/100081 is not available on MSRV

--- a/ci/careful.sh
+++ b/ci/careful.sh
@@ -3,9 +3,6 @@ set -euxo pipefail
 IFS=$'\n\t'
 cd "$(dirname "$0")"/..
 
-# TODO: Once cargo-careful's bug (https://github.com/RalfJung/cargo-careful/issues/31) is fixed,
-# stop reverting back to the system's default linker, instead of rust-lld, which became the new 
-# default on linux recently (nightly-2024-05-18 and onwards).
-export RUSTFLAGS="${RUSTFLAGS:-} -Z randomize-layout -Z linker-features=-lld"
+export RUSTFLAGS="${RUSTFLAGS:-} -Z randomize-layout"
 
 cargo careful test --all --all-features --exclude benchmarks -- --test-threads=1

--- a/crossbeam-utils/build.rs
+++ b/crossbeam-utils/build.rs
@@ -17,6 +17,7 @@ include!("build-common.rs");
 
 fn main() {
     println!("cargo:rerun-if-changed=no_atomic.rs");
+    println!("cargo:rustc-check-cfg=cfg(crossbeam_no_atomic,crossbeam_sanitize_thread)");
 
     let target = match env::var("TARGET") {
         Ok(target) => convert_custom_linux_target(target),


### PR DESCRIPTION
- cargo-careful bug has been fixed in 0.4.2
- move cfgs set by build scripts to cargo:rustc-check-cfg to be able to catch misuse