### PR TITLE
Add force_send method to channel Sender

### DIFF
--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -1,6 +1,5 @@
 //! The channel interface.
 
-use core::sync::atomic::AtomicUsize;
 use std::fmt;
 use std::iter::FusedIterator;
 use std::mem;

--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -1,5 +1,6 @@
 //! The channel interface.
 
+use core::sync::atomic::AtomicUsize;
 use std::fmt;
 use std::iter::FusedIterator;
 use std::mem;
@@ -10,7 +11,8 @@ use std::time::{Duration, Instant};
 use crate::context::Context;
 use crate::counter;
 use crate::err::{
-    RecvError, RecvTimeoutError, SendError, SendTimeoutError, TryRecvError, TrySendError,
+    ForceSendError, RecvError, RecvTimeoutError, SendError, SendTimeoutError, TryRecvError,
+    TrySendError,
 };
 use crate::flavors;
 use crate::select::{Operation, SelectHandle, Token};
@@ -407,6 +409,45 @@ impl<T> Sender<T> {
             SenderFlavor::Array(chan) => chan.try_send(msg),
             SenderFlavor::List(chan) => chan.try_send(msg),
             SenderFlavor::Zero(chan) => chan.try_send(msg),
+        }
+    }
+
+    /// Sends a message to a channel without blocking. It will only fail if the channel is disconnected.
+    ///
+    /// This method will either send a message into the channel immediately,
+    /// overwrite and return the last value in the channel or return an error if
+    /// the channel is full. The returned error contains the original message.
+    ///
+    /// If called on a zero-capacity channel, this method will send the message only if there
+    /// happens to be a receive operation on the other side of the channel at the same time.
+    ///
+    /// ```
+    /// use crossbeam_channel::{bounded, ForceSendError};
+    ///
+    /// let (s, r) = bounded(3);
+    /// assert_eq!(s.force_send(0), Ok(None));
+    /// assert_eq!(s.force_send(1), Ok(None));
+    /// assert_eq!(s.force_send(2), Ok(None));
+    /// assert_eq!(s.force_send(3), Ok(Some(2)));
+    /// assert_eq!(r.recv(), Ok(0));
+    /// assert_eq!(s.force_send(4), Ok(None));
+    /// assert_eq!(r.recv(), Ok(1));
+    /// assert_eq!(r.recv(), Ok(3));
+    /// assert_eq!(s.force_send(5), Ok(None));
+    /// assert_eq!(s.force_send(6), Ok(None));
+    /// assert_eq!(s.force_send(7), Ok(Some(6)));
+    /// assert_eq!(s.force_send(8), Ok(Some(7)));
+    /// assert_eq!(r.recv(), Ok(4));
+    /// assert_eq!(r.recv(), Ok(5));
+    /// assert_eq!(r.recv(), Ok(8));
+    /// drop(r);
+    /// assert_eq!(s.force_send(9), Err(ForceSendError::Disconnected(9)));
+    /// ``````
+    pub fn force_send(&self, msg: T) -> Result<Option<T>, ForceSendError<T>> {
+        match &self.flavor {
+            SenderFlavor::Array(chan) => chan.force_send(msg),
+            SenderFlavor::List(chan) => chan.force_send(msg),
+            SenderFlavor::Zero(chan) => chan.force_send(msg),
         }
     }
 

--- a/crossbeam-channel/src/err.rs
+++ b/crossbeam-channel/src/err.rs
@@ -220,6 +220,59 @@ impl<T> TrySendError<T> {
     }
 }
 
+impl<T> fmt::Debug for ForceSendError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Self::Disconnected(..) => "Disconnected(..)".fmt(f),
+        }
+    }
+}
+
+impl<T> fmt::Display for ForceSendError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Self::Disconnected(..) => "sending on a disconnected channel".fmt(f),
+        }
+    }
+}
+
+impl<T: Send> error::Error for ForceSendError<T> {}
+
+impl<T> From<SendError<T>> for ForceSendError<T> {
+    fn from(err: SendError<T>) -> Self {
+        match err {
+            SendError(t) => Self::Disconnected(t),
+        }
+    }
+}
+
+impl<T> ForceSendError<T> {
+    /// Unwraps the message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_channel::bounded;
+    ///
+    /// let (s, r) = bounded(0);
+    /// drop(r);
+    ///
+    /// if let Err(err) = s.force_send("foo") {
+    ///     assert_eq!(err.into_inner(), "foo");
+    /// }
+    /// ```
+    pub fn into_inner(self) -> T {
+        match self {
+            Self::Disconnected(v) => v,
+        }
+    }
+
+    /// Returns `true` if the send operation failed because the channel is disconnected.
+    pub fn is_disconnected(&self) -> bool {
+        matches!(self, Self::Disconnected(_))
+    }
+}
+
 impl<T> fmt::Debug for SendTimeoutError<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         "SendTimeoutError(..)".fmt(f)

--- a/crossbeam-channel/src/err.rs
+++ b/crossbeam-channel/src/err.rs
@@ -11,6 +11,17 @@ use std::fmt;
 #[derive(PartialEq, Eq, Clone, Copy)]
 pub struct SendError<T>(pub T);
 
+/// An error returned from the [`force_send`] method.
+///
+/// The error contains the message being sent so it can be recovered.
+///
+/// [`force_send`]: super::Sender::force_send
+#[derive(PartialEq, Eq, Clone, Copy)]
+pub enum ForceSendError<T> {
+    /// The message could not be sent because the channel is disconnected.
+    Disconnected(T),
+}
+
 /// An error returned from the [`try_send`] method.
 ///
 /// The error contains the message being sent so it can be recovered.

--- a/crossbeam-channel/src/flavors/array.rs
+++ b/crossbeam-channel/src/flavors/array.rs
@@ -334,10 +334,11 @@ impl<T> Channel<T> {
         }
 
         let old_msg = if self.is_full() {
-            let Ok(old_msg) = self.try_recv() else {
+            let old_msg = self.try_recv().ok();
+            if old_msg.is_none() {
                 return Err(ForceSendError(msg));
-            };
-            Some(old_msg)
+            }
+            old_msg
         } else {
             None
         };

--- a/crossbeam-channel/src/flavors/list.rs
+++ b/crossbeam-channel/src/flavors/list.rs
@@ -421,7 +421,7 @@ impl<T> Channel<T> {
     pub(crate) fn force_send(&self, msg: T) -> Result<Option<T>, ForceSendError<T>> {
         match self.send(msg, None) {
             Ok(()) => Ok(None),
-            Err(SendTimeoutError::Disconnected(err)) => Err(ForceSendError::Disconnected(err)),
+            Err(SendTimeoutError::Disconnected(err)) => Err(ForceSendError(err)),
             Err(SendTimeoutError::Timeout(_)) => unreachable!(),
         }
     }

--- a/crossbeam-channel/src/flavors/list.rs
+++ b/crossbeam-channel/src/flavors/list.rs
@@ -11,7 +11,7 @@ use std::time::Instant;
 use crossbeam_utils::{Backoff, CachePadded};
 
 use crate::context::Context;
-use crate::err::{RecvTimeoutError, SendTimeoutError, TryRecvError, TrySendError};
+use crate::err::{ForceSendError, RecvTimeoutError, SendTimeoutError, TryRecvError, TrySendError};
 use crate::select::{Operation, SelectHandle, Selected, Token};
 use crate::waker::SyncWaker;
 
@@ -415,6 +415,15 @@ impl<T> Channel<T> {
             SendTimeoutError::Disconnected(msg) => TrySendError::Disconnected(msg),
             SendTimeoutError::Timeout(_) => unreachable!(),
         })
+    }
+
+    /// Forces a send, failing only if the channel is disconnected
+    pub(crate) fn force_send(&self, msg: T) -> Result<Option<T>, ForceSendError<T>> {
+        match self.send(msg, None) {
+            Ok(()) => Ok(None),
+            Err(SendTimeoutError::Disconnected(err)) => Err(ForceSendError::Disconnected(err)),
+            Err(SendTimeoutError::Timeout(_)) => unreachable!(),
+        }
     }
 
     /// Sends a message into the channel.

--- a/crossbeam-channel/src/flavors/zero.rs
+++ b/crossbeam-channel/src/flavors/zero.rs
@@ -230,7 +230,7 @@ impl<T> Channel<T> {
             }
             Ok(None)
         } else if inner.is_disconnected {
-            Err(ForceSendError::Disconnected(msg))
+            Err(ForceSendError(msg))
         } else {
             Ok(Some(msg))
         }

--- a/crossbeam-channel/src/lib.rs
+++ b/crossbeam-channel/src/lib.rs
@@ -370,8 +370,8 @@ pub use crate::{
         after, at, bounded, never, tick, unbounded, IntoIter, Iter, Receiver, Sender, TryIter,
     },
     err::{
-        ReadyTimeoutError, RecvError, RecvTimeoutError, SelectTimeoutError, SendError,
-        SendTimeoutError, TryReadyError, TryRecvError, TrySelectError, TrySendError,
+        ForceSendError, ReadyTimeoutError, RecvError, RecvTimeoutError, SelectTimeoutError,
+        SendError, SendTimeoutError, TryReadyError, TryRecvError, TrySelectError, TrySendError,
     },
     select::{Select, SelectedOperation},
 };


### PR DESCRIPTION
### Add a force_push method to the Sender part of a channel. 

In particular, this is useful for bounded channels of non-zero size.

Motivation:
- https://github.com/crossbeam-rs/crossbeam/issues/400

Design goals:
- It is fine to lose messages, but messages should never appear in a different order from which they were sent
- For bounded (non-zero-sized) channels, force_send should never fail (except when the receiver has been dropped)
- Should not be blocking

```rs
use crossbeam_channel::{bounded, ForceSendError};

let (s, r) = bounded(3);

assert_eq!(s.force_send(0), Ok(None));
assert_eq!(s.force_send(1), Ok(None));
assert_eq!(s.force_send(2), Ok(None));
assert_eq!(s.force_send(3), Ok(Some(0)));

assert_eq!(r.recv(), Ok(1));

assert_eq!(s.force_send(4), Ok(None));

assert_eq!(r.recv(), Ok(2));
assert_eq!(r.recv(), Ok(3));

assert_eq!(s.force_send(5), Ok(None));
assert_eq!(s.force_send(6), Ok(None));
assert_eq!(s.force_send(7), Ok(Some(4)));
assert_eq!(s.force_send(8), Ok(Some(5)));

assert_eq!(r.recv(), Ok(6));
assert_eq!(r.recv(), Ok(7));
assert_eq!(r.recv(), Ok(8));

drop(r);

assert_eq!(s.force_send(9), Err(ForceSendError(9)));
```

Closes https://github.com/crossbeam-rs/crossbeam/issues/400