### PR TITLE
Explicitly annotate lifetime of entry methods

### DIFF
--- a/crossbeam-skiplist/src/base.rs
+++ b/crossbeam-skiplist/src/base.rs
@@ -1456,12 +1456,12 @@ impl<'a, K: 'a, V: 'a> RefEntry<'a, K, V> {
     }
 
     /// Returns a reference to the key.
-    pub fn key(&self) -> &K {
+    pub fn key(&self) -> &'a K {
         &self.node.key
     }
 
     /// Returns a reference to the value.
-    pub fn value(&self) -> &V {
+    pub fn value(&self) -> &'a V {
         &self.node.value
     }
 

--- a/crossbeam-skiplist/src/map.rs
+++ b/crossbeam-skiplist/src/map.rs
@@ -572,12 +572,12 @@ impl<'a, K, V> Entry<'a, K, V> {
     }
 
     /// Returns a reference to the key.
-    pub fn key(&self) -> &K {
+    pub fn key(&self) -> &'a K {
         self.inner.key()
     }
 
     /// Returns a reference to the value.
-    pub fn value(&self) -> &V {
+    pub fn value(&self) -> &'a V {
         self.inner.value()
     }
 

--- a/crossbeam-skiplist/src/set.rs
+++ b/crossbeam-skiplist/src/set.rs
@@ -455,7 +455,7 @@ impl<'a, T> Entry<'a, T> {
     }
 
     /// Returns a reference to the value.
-    pub fn value(&self) -> &T {
+    pub fn value(&self) -> &'a T {
         self.inner.key()
     }
 


### PR DESCRIPTION
The `.key()` and `.value()` should return a borrow whose lifetime aligns with the container, instead of the entry itself.