### PR TITLE
channel: Create `list::Block` directly on the heap

### DIFF
--- a/crossbeam-channel/tests/list.rs
+++ b/crossbeam-channel/tests/list.rs
@@ -580,3 +580,18 @@ fn channel_through_channel() {
     })
     .unwrap();
 }
+
+// If `Block` is created on the stack, the array of slots will multiply this `BigStruct` and
+// probably overflow the thread stack. It's now directly created on the heap to avoid this.
+#[test]
+fn stack_overflow() {
+    const N: usize = 32_768;
+    struct BigStruct {
+        _data: [u8; N],
+    }
+
+    let (sender, receiver) = unbounded::<BigStruct>();
+    sender.send(BigStruct { _data: [0u8; N] }).unwrap();
+
+    for _data in receiver.try_iter() {}
+}


### PR DESCRIPTION
The list channel's `Block::new` was causing a stack overflow because it
held 32 item slots, instantiated on the stack before moving to
`Box::new`. The 32x multiplier made modestly-large item sizes untenable.

That block is now initialized directly on the heap.

References from the `std` channel implementation:
* https://github.com/rust-lang/rust/issues/102246
* https://github.com/rust-lang/rust/pull/132738
