### PR TITLE
Remove optimistic spinning from Context::wait_until

### DIFF
--- a/crossbeam-channel/src/context.rs
+++ b/crossbeam-channel/src/context.rs
@@ -138,21 +138,6 @@ impl Context {
     /// If the deadline is reached, `Selected::Aborted` will be selected.
     #[inline]
     pub fn wait_until(&self, deadline: Option<Instant>) -> Selected {
-        // Spin for a short time, waiting until an operation is selected.
-        let backoff = Backoff::new();
-        loop {
-            let sel = Selected::from(self.inner.select.load(Ordering::Acquire));
-            if sel != Selected::Waiting {
-                return sel;
-            }
-
-            if backoff.is_completed() {
-                break;
-            } else {
-                backoff.snooze();
-            }
-        }
-
         loop {
             // Check whether an operation has been selected.
             let sel = Selected::from(self.inner.select.load(Ordering::Acquire));


### PR DESCRIPTION
Per https://github.com/crossbeam-rs/crossbeam/pull/1038#issuecomment-2091047279, removes optimistic spinning from Context::wait_until, which is a non-controversial change.

cc @ibraheemdev