### PR TITLE
utils: Move atomic module behind atomic feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
       - name: Install Rust
         run: rustup update stable
       - name: clippy
-        run: cargo clippy --all --tests --examples
+        run: cargo clippy --all --all-features --tests --examples
 
   # Run miri.
   miri:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ crossbeam-channel = { version = "0.5.10", path = "crossbeam-channel", default-fe
 crossbeam-deque = { version = "0.8.4", path = "crossbeam-deque", default-features = false, optional = true }
 crossbeam-epoch = { version = "0.9.17", path = "crossbeam-epoch", default-features = false, optional = true }
 crossbeam-queue = { version = "0.3.10", path = "crossbeam-queue", default-features = false, optional = true }
-crossbeam-utils = { version = "0.8.18", path = "crossbeam-utils", default-features = false }
+crossbeam-utils = { version = "0.8.18", path = "crossbeam-utils", default-features = false, features = ["atomic"] }
 
 [dev-dependencies]
 rand = "0.8"

--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -16,20 +16,20 @@ export MIRIFLAGS="${MIRIFLAGS:-} -Zmiri-strict-provenance -Zmiri-symbolic-alignm
 case "${group}" in
     channel)
         MIRI_LEAK_CHECK='1' \
-            cargo miri test \
+            cargo miri test --all-features \
             -p crossbeam-channel 2>&1 | ts -i '%.s  '
         # -Zmiri-ignore-leaks is needed because we use detached threads in tests in tests/golang.rs: https://github.com/rust-lang/miri/issues/1371
         MIRIFLAGS="${MIRIFLAGS} -Zmiri-ignore-leaks" \
-            cargo miri test \
+            cargo miri test --all-features \
             -p crossbeam-channel --test golang 2>&1 | ts -i '%.s  '
         ;;
     others)
-        cargo miri test \
+        cargo miri test --all-features \
             -p crossbeam-queue \
             -p crossbeam-utils 2>&1 | ts -i '%.s  '
         # Use Tree Borrows instead of Stacked Borrows because epoch is not compatible with Stacked Borrows: https://github.com/crossbeam-rs/crossbeam/issues/545#issuecomment-1192785003
         MIRIFLAGS="${MIRIFLAGS} -Zmiri-tree-borrows" \
-            cargo miri test \
+            cargo miri test --all-features \
             -p crossbeam-epoch \
             -p crossbeam-skiplist \
             -p crossbeam 2>&1 | ts -i '%.s  '
@@ -38,7 +38,7 @@ case "${group}" in
         # doctest of Stealer::steal) incorrectly assume that sequential weak CAS will never fail.
         # -Zmiri-preemption-rate=0 is needed because this code technically has UB and Miri catches that.
         MIRIFLAGS="${MIRIFLAGS} -Zmiri-tree-borrows -Zmiri-compare-exchange-weak-failure-rate=0.0 -Zmiri-preemption-rate=0" \
-            cargo miri test \
+            cargo miri test --all-features \
             -p crossbeam-deque 2>&1 | ts -i '%.s  '
         ;;
     *)

--- a/ci/san.sh
+++ b/ci/san.sh
@@ -15,10 +15,11 @@ rustup component add rust-src
 # `--cfg crossbeam_sanitize`.
 cargo clean
 RUSTFLAGS="${RUSTFLAGS:-} -Z sanitizer=address --cfg crossbeam_sanitize" \
-    cargo test -Z build-std --all --release --target x86_64-unknown-linux-gnu --tests --exclude benchmarks -- --test-threads=1
+    cargo test -Z build-std --all --all-features --release --target x86_64-unknown-linux-gnu --tests --exclude benchmarks -- --test-threads=1
 
 RUSTFLAGS="${RUSTFLAGS:-} -Z sanitizer=address --cfg crossbeam_sanitize" \
     cargo run -Z build-std \
+    --all-features \
     --release \
     --target x86_64-unknown-linux-gnu \
     --example sanitize \
@@ -27,10 +28,10 @@ RUSTFLAGS="${RUSTFLAGS:-} -Z sanitizer=address --cfg crossbeam_sanitize" \
 # Run memory sanitizer
 cargo clean
 RUSTFLAGS="${RUSTFLAGS:-} -Z sanitizer=memory --cfg crossbeam_sanitize" \
-    cargo test -Z build-std --all --release --target x86_64-unknown-linux-gnu --tests --exclude benchmarks -- --test-threads=1
+    cargo test -Z build-std --all --all-features --release --target x86_64-unknown-linux-gnu --tests --exclude benchmarks -- --test-threads=1
 
 # Run thread sanitizer
 cargo clean
 TSAN_OPTIONS="suppressions=$(pwd)/ci/tsan" \
 RUSTFLAGS="${RUSTFLAGS:-} -Z sanitizer=thread --cfg crossbeam_sanitize" \
-    cargo test -Z build-std --all --release --target x86_64-unknown-linux-gnu --tests --exclude benchmarks -- --test-threads=1
+    cargo test -Z build-std --all --all-features --release --target x86_64-unknown-linux-gnu --tests --exclude benchmarks -- --test-threads=1

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -5,8 +5,8 @@ cd "$(dirname "$0")"/..
 
 # shellcheck disable=SC2086
 if [[ -n "${RUST_TARGET:-}" ]]; then
-    cargo test --all --target "$RUST_TARGET" --exclude benchmarks ${DOCTEST_XCOMPILE:-} -- --test-threads=1
-    cargo test --all --target "$RUST_TARGET" --exclude benchmarks --release ${DOCTEST_XCOMPILE:-} -- --test-threads=1
+    cargo test --all --all-features --target "$RUST_TARGET" --exclude benchmarks ${DOCTEST_XCOMPILE:-} -- --test-threads=1
+    cargo test --all --all-features --target "$RUST_TARGET" --exclude benchmarks --release ${DOCTEST_XCOMPILE:-} -- --test-threads=1
 
     # For now, the non-host target only runs tests.
     exit 0
@@ -18,5 +18,5 @@ cargo test --all --all-features --exclude benchmarks --release -- --test-threads
 
 if [[ "$RUST_VERSION" == "nightly"* ]]; then
     # Benchmarks are only checked on nightly because depending on unstable features.
-    cargo check --all --all-targets
+    cargo check --all --all-features --all-targets
 fi

--- a/crossbeam-channel/Cargo.toml
+++ b/crossbeam-channel/Cargo.toml
@@ -24,7 +24,7 @@ default = ["std"]
 std = ["crossbeam-utils/std"]
 
 [dependencies]
-crossbeam-utils = { version = "0.8.18", path = "../crossbeam-utils", default-features = false }
+crossbeam-utils = { version = "0.8.18", path = "../crossbeam-utils", default-features = false, features = ["atomic"] }
 
 [dev-dependencies]
 num_cpus = "1.13.0"

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -34,7 +34,7 @@ alloc = []
 loom = ["loom-crate", "crossbeam-utils/loom"]
 
 [dependencies]
-crossbeam-utils = { version = "0.8.18", path = "../crossbeam-utils", default-features = false }
+crossbeam-utils = { version = "0.8.18", path = "../crossbeam-utils", default-features = false, features = ["atomic"] }
 
 # Enable the use of loom for concurrency testing.
 #

--- a/crossbeam-epoch/src/lib.rs
+++ b/crossbeam-epoch/src/lib.rs
@@ -116,13 +116,9 @@ mod primitive {
         }
     }
     pub(crate) mod sync {
-        pub(crate) mod atomic {
-            pub(crate) use core::sync::atomic::{
-                compiler_fence, fence, AtomicPtr, AtomicUsize, Ordering,
-            };
-        }
         #[cfg(feature = "alloc")]
         pub(crate) use alloc::sync::Arc;
+        pub(crate) use core::sync::atomic;
     }
 
     #[cfg(feature = "std")]

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -14,12 +14,18 @@ description = "Utilities for concurrent programming"
 keywords = ["scoped", "thread", "atomic", "cache"]
 categories = ["algorithms", "concurrency", "data-structures", "no-std"]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [features]
 default = ["std"]
 
 # Enable to use APIs that require `std`.
 # This is enabled by default.
 std = []
+
+# Enable `atomic` module.
+atomic = []
 
 [dependencies]
 

--- a/crossbeam-utils/src/lib.rs
+++ b/crossbeam-utils/src/lib.rs
@@ -33,6 +33,7 @@
     )
 ))]
 #![warn(missing_docs, unsafe_op_in_unsafe_fn)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "std")]
 extern crate std;
@@ -67,28 +68,14 @@ mod primitive {
         pub(crate) use core::hint::spin_loop;
     }
     pub(crate) mod sync {
-        pub(crate) mod atomic {
-            pub(crate) use core::sync::atomic::{compiler_fence, Ordering};
-            #[cfg(not(crossbeam_no_atomic))]
-            pub(crate) use core::sync::atomic::{
-                AtomicBool, AtomicI16, AtomicI8, AtomicIsize, AtomicU16, AtomicU8, AtomicUsize,
-            };
-            #[cfg(not(crossbeam_no_atomic))]
-            #[cfg(any(target_has_atomic = "32", not(target_pointer_width = "16")))]
-            pub(crate) use core::sync::atomic::{AtomicI32, AtomicU32};
-            #[cfg(not(crossbeam_no_atomic))]
-            #[cfg(any(
-                target_has_atomic = "64",
-                not(any(target_pointer_width = "16", target_pointer_width = "32")),
-            ))]
-            pub(crate) use core::sync::atomic::{AtomicI64, AtomicU64};
-        }
-
+        pub(crate) use core::sync::atomic;
         #[cfg(feature = "std")]
         pub(crate) use std::sync::{Arc, Condvar, Mutex};
     }
 }
 
+#[cfg(feature = "atomic")]
+#[cfg_attr(docsrs, doc(cfg(feature = "atomic")))]
 pub mod atomic;
 
 mod cache_padded;


### PR DESCRIPTION
This module will require additional dep for soundness (https://github.com/crossbeam-rs/crossbeam/pull/1015), so split from APIs with default features.
This also help https://github.com/crossbeam-rs/crossbeam/pull/1075#issuecomment-2039050221 if we do it.