### PR TITLE
Relax MSRV of utils to 1.38

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "crossbeam"
 # - Update README.md (when increasing major or minor version)
 # - Run './tools/publish.sh crossbeam <version>'
 version = "0.8.4"
-edition = "2021"
+edition = "2018"
 rust-version = "1.61"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"
@@ -47,7 +47,6 @@ rand = "0.8"
 workspace = true
 
 [workspace]
-resolver = "2"
 members = [
   ".",
   "crossbeam-channel",

--- a/crossbeam-channel/Cargo.toml
+++ b/crossbeam-channel/Cargo.toml
@@ -5,7 +5,7 @@ name = "crossbeam-channel"
 # - Update README.md (when increasing major or minor version)
 # - Run './tools/publish.sh crossbeam-channel <version>'
 version = "0.5.13"
-edition = "2021"
+edition = "2018"
 rust-version = "1.60"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"

--- a/crossbeam-channel/benchmarks/Cargo.toml
+++ b/crossbeam-channel/benchmarks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "benchmarks"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 publish = false
 
 [dependencies]

--- a/crossbeam-deque/Cargo.toml
+++ b/crossbeam-deque/Cargo.toml
@@ -5,7 +5,7 @@ name = "crossbeam-deque"
 # - Update README.md (when increasing major or minor version)
 # - Run './tools/publish.sh crossbeam-deque <version>'
 version = "0.8.5"
-edition = "2021"
+edition = "2018"
 rust-version = "1.61"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"

--- a/crossbeam-deque/src/deque.rs
+++ b/crossbeam-deque/src/deque.rs
@@ -2,6 +2,7 @@ use std::boxed::Box;
 use std::cell::{Cell, UnsafeCell};
 use std::cmp;
 use std::fmt;
+use std::iter::FromIterator;
 use std::marker::PhantomData;
 use std::mem::{self, MaybeUninit};
 use std::ptr;

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -5,7 +5,7 @@ name = "crossbeam-epoch"
 # - Update README.md (when increasing major or minor version)
 # - Run './tools/publish.sh crossbeam-epoch <version>'
 version = "0.9.18"
-edition = "2021"
+edition = "2018"
 rust-version = "1.61"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"

--- a/crossbeam-queue/Cargo.toml
+++ b/crossbeam-queue/Cargo.toml
@@ -5,7 +5,7 @@ name = "crossbeam-queue"
 # - Update README.md (when increasing major or minor version)
 # - Run './tools/publish.sh crossbeam-queue <version>'
 version = "0.3.11"
-edition = "2021"
+edition = "2018"
 rust-version = "1.60"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"

--- a/crossbeam-skiplist/Cargo.toml
+++ b/crossbeam-skiplist/Cargo.toml
@@ -5,7 +5,7 @@ name = "crossbeam-skiplist"
 # - Update README.md (when increasing major or minor version)
 # - Run './tools/publish.sh crossbeam-skiplist <version>'
 version = "0.1.3"
-edition = "2021"
+edition = "2018"
 rust-version = "1.61"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"

--- a/crossbeam-skiplist/src/map.rs
+++ b/crossbeam-skiplist/src/map.rs
@@ -2,6 +2,7 @@
 
 use std::borrow::Borrow;
 use std::fmt;
+use std::iter::FromIterator;
 use std::mem::ManuallyDrop;
 use std::ops::{Bound, RangeBounds};
 use std::ptr;

--- a/crossbeam-skiplist/src/set.rs
+++ b/crossbeam-skiplist/src/set.rs
@@ -2,6 +2,7 @@
 
 use std::borrow::Borrow;
 use std::fmt;
+use std::iter::FromIterator;
 use std::ops::Deref;
 use std::ops::{Bound, RangeBounds};
 

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -5,8 +5,8 @@ name = "crossbeam-utils"
 # - Update README.md (when increasing major or minor version)
 # - Run './tools/publish.sh crossbeam-utils <version>'
 version = "0.8.20"
-edition = "2021"
-rust-version = "1.56"
+edition = "2018"
+rust-version = "1.38"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"
 homepage = "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-utils"

--- a/crossbeam-utils/README.md
+++ b/crossbeam-utils/README.md
@@ -55,7 +55,7 @@ crossbeam-utils = "0.8"
 
 Crossbeam Utils supports stable Rust releases going back at least six months,
 and every time the minimum supported Rust version is increased, a new minor
-version is released. Currently, the minimum supported Rust version is 1.56.
+version is released. Currently, the minimum supported Rust version is 1.38.
 
 ## License
 

--- a/crossbeam-utils/src/atomic/mod.rs
+++ b/crossbeam-utils/src/atomic/mod.rs
@@ -3,6 +3,10 @@
 //! * [`AtomicCell`], a thread-safe mutable memory location.
 //! * [`AtomicConsume`], for reading from primitive atomic types with "consume" ordering.
 
+// unsafe_op_in_unsafe_fn requires Rust 1.52, so cannot be used at crate-level,
+// but this module requires 1.60.
+#![warn(unsafe_op_in_unsafe_fn)]
+
 #[cfg(target_has_atomic = "ptr")]
 #[cfg(not(crossbeam_loom))]
 // Use "wide" sequence lock if the pointer width <= 32 for preventing its counter against wrap

--- a/crossbeam-utils/src/lib.rs
+++ b/crossbeam-utils/src/lib.rs
@@ -32,7 +32,7 @@
         allow(dead_code, unused_assignments, unused_variables)
     )
 ))]
-#![warn(missing_docs, unsafe_op_in_unsafe_fn)]
+#![warn(missing_docs, /* unsafe_op_in_unsafe_fn */)] // unsafe_op_in_unsafe_fn requires Rust 1.52
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "std")]
@@ -65,7 +65,13 @@ mod primitive {
 #[allow(unused_imports)]
 mod primitive {
     pub(crate) mod hint {
-        pub(crate) use core::hint::spin_loop;
+        // core::hint::spin_loop requires Rust 1.49
+        // pub(crate) use core::hint::spin_loop;
+        #[inline]
+        pub(crate) fn spin_loop() {
+            #[allow(deprecated)]
+            core::sync::atomic::spin_loop_hint();
+        }
     }
     pub(crate) mod sync {
         pub(crate) use core::sync::atomic;

--- a/crossbeam-utils/src/sync/mod.rs
+++ b/crossbeam-utils/src/sync/mod.rs
@@ -5,6 +5,7 @@
 //! * [`WaitGroup`], for synchronizing the beginning or end of some computation.
 
 #[cfg(not(crossbeam_loom))]
+#[allow(unused_unsafe)] // once_lock.rs is also used from epoch which sets unsafe_op_in_unsafe_fn.
 mod once_lock;
 mod parker;
 #[cfg(not(crossbeam_loom))]

--- a/crossbeam-utils/src/sync/parker.rs
+++ b/crossbeam-utils/src/sync/parker.rs
@@ -205,7 +205,7 @@ impl Parker {
     /// ```
     pub unsafe fn from_raw(ptr: *const ()) -> Self {
         Self {
-            unparker: unsafe { Unparker::from_raw(ptr) },
+            unparker: Unparker::from_raw(ptr),
             _marker: PhantomData,
         }
     }
@@ -293,7 +293,7 @@ impl Unparker {
     /// ```
     pub unsafe fn from_raw(ptr: *const ()) -> Self {
         Self {
-            inner: unsafe { Arc::from_raw(ptr.cast::<Inner>()) },
+            inner: Arc::from_raw(ptr.cast::<Inner>()),
         }
     }
 }

--- a/crossbeam-utils/src/thread.rs
+++ b/crossbeam-utils/src/thread.rs
@@ -84,7 +84,7 @@
 //! tricky because argument `s` lives *inside* the invocation of `thread::scope()` and as such
 //! cannot be borrowed by scoped threads:
 //!
-//! ```compile_fail,E0521
+//! ```compile_fail,E0373,E0521
 //! use crossbeam_utils::thread;
 //!
 //! thread::scope(|s| {


### PR DESCRIPTION
Implements https://github.com/crossbeam-rs/crossbeam/pull/1075#issuecomment-2039050221.

This is not a PR intended to be merged as is, and I think it is fine to relax MSRV to 1.56, 1.52, or worse, 1.43, but I'm quite negative with relaxing to 1.42 or lower because it decreases efficiency (see crossbeam-utils/src/sync/once_lock.rs).

cc @mgeier