### PR TITLE
Relax MSRV of utils to 1.56

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,4 +72,5 @@ unreachable_pub = "warn"
 [workspace.lints.clippy]
 # Suppress buggy or noisy clippy lints
 declare_interior_mutable_const = { level = "allow", priority = 1 } # https://github.com/rust-lang/rust-clippy/issues/7665
+incompatible_msrv = { level = "allow", priority = 1 } # buggy: doesn't consider cfg, https://github.com/rust-lang/rust-clippy/issues/12280, https://github.com/rust-lang/rust-clippy/issues/12257#issuecomment-2093667187
 lint_groups_priority = { level = "allow", priority = 1 } # https://github.com/rust-lang/rust-clippy/issues/12920

--- a/ci/check-features.sh
+++ b/ci/check-features.sh
@@ -7,7 +7,10 @@ cd "$(dirname "$0")"/..
 # * `--no-dev-deps` - build without dev-dependencies to avoid https://github.com/rust-lang/cargo/issues/4866
 # * `--exclude benchmarks` - benchmarks doesn't published.
 if [[ "${RUST_VERSION}" == "msrv" ]]; then
-    cargo hack build --all --feature-powerset --no-dev-deps --exclude benchmarks --rust-version
+    cargo hack build --all --feature-powerset --no-dev-deps --exclude crossbeam-utils --exclude benchmarks --rust-version
+    # atomic feature requires Rust 1.60.
+    cargo hack build -p crossbeam-utils --feature-powerset --no-dev-deps --rust-version --exclude-features atomic
+    cargo +1.60 hack build -p crossbeam-utils --feature-powerset --no-dev-deps
 else
     cargo hack build --all --feature-powerset --no-dev-deps --exclude benchmarks
 fi

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -6,7 +6,7 @@ name = "crossbeam-utils"
 # - Run './tools/publish.sh crossbeam-utils <version>'
 version = "0.8.20"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.56"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crossbeam-rs/crossbeam"
 homepage = "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-utils"
@@ -25,6 +25,7 @@ default = ["std"]
 std = []
 
 # Enable `atomic` module.
+# This requires Rust 1.60.
 atomic = []
 
 [dependencies]

--- a/crossbeam-utils/README.md
+++ b/crossbeam-utils/README.md
@@ -55,7 +55,7 @@ crossbeam-utils = "0.8"
 
 Crossbeam Utils supports stable Rust releases going back at least six months,
 and every time the minimum supported Rust version is increased, a new minor
-version is released. Currently, the minimum supported Rust version is 1.60.
+version is released. Currently, the minimum supported Rust version is 1.56.
 
 ## License
 

--- a/crossbeam-utils/src/sync/once_lock.rs
+++ b/crossbeam-utils/src/sync/once_lock.rs
@@ -82,7 +82,9 @@ impl<T> Drop for OnceLock<T> {
     fn drop(&mut self) {
         if self.once.is_completed() {
             // SAFETY: The inner value has been initialized
-            unsafe { (*self.value.get()).assume_init_drop() };
+            // assume_init_drop requires Rust 1.60
+            // unsafe { (*self.value.get()).assume_init_drop() };
+            unsafe { self.value.get().cast::<T>().drop_in_place() };
         }
     }
 }


### PR DESCRIPTION
Non-controversial part of https://github.com/crossbeam-rs/crossbeam/pull/1156.

(I actually have a [use case that needs this](https://github.com/taiki-e/portable-atomic/blob/29824b938b87585a7fa1ff3a7f14786f07a11ade/Cargo.toml#L88).)