### PR TITLE
Prepare for the next release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Version 0.9.0
+
+- Bump the minimum supported Rust version to 1.74.
+- Remove no longer used `nightly` feature. (#882)
+- Update `crossbeam-epoch` to 0.10.
+- Update `crossbeam-queue` to 0.4.
+- Update `crossbeam-utils` to 0.9.
+- Update `crossbeam-channel` to 0.5.16.
+- Update `crossbeam-deque` to 0.8.7.
+
 # Version 0.8.4
 
 - Remove dependency on `cfg-if`. (#1072)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Version 0.9.0
+
+- Bump the minimum supported Rust version to 1.74.
+- Remove no longer used `nightly` feature. (#882)
+- Update `crossbeam-epoch` to 0.10.
+- Update `crossbeam-queue` to 0.4.
+- Update `crossbeam-utils` to 0.9.
+
 # Version 0.8.5
 
 - Update MSRV policy to support 1 year instead of 6 months to meet rayon's MSRV policy. (#1284)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam"
 # - Update CHANGELOG.md
 # - Update README.md (when increasing major or minor version)
 # - Run './tools/publish.sh crossbeam <version>'
-version = "0.8.4"
+version = "0.9.0"
 edition = "2021"
 # NB: Sync with msrv badge and "Compatibility" section in README.md
 rust-version = "1.74"
@@ -49,11 +49,11 @@ std = [
 alloc = ["crossbeam-epoch/alloc", "crossbeam-queue/alloc"]
 
 [dependencies]
-crossbeam-channel = { version = "0.5.10", path = "crossbeam-channel", default-features = false, optional = true }
-crossbeam-deque = { version = "0.8.4", path = "crossbeam-deque", default-features = false, optional = true }
-crossbeam-epoch = { version = "0.9.17", path = "crossbeam-epoch", default-features = false, optional = true }
-crossbeam-queue = { version = "0.3.10", path = "crossbeam-queue", default-features = false, optional = true }
-crossbeam-utils = { version = "0.8.18", path = "crossbeam-utils", default-features = false, features = ["atomic"] }
+crossbeam-channel = { version = "0.5.17", path = "crossbeam-channel", default-features = false, optional = true }
+crossbeam-deque = { version = "0.8.8", path = "crossbeam-deque", default-features = false, optional = true }
+crossbeam-epoch = { version = "0.10.0", path = "crossbeam-epoch", default-features = false, optional = true }
+crossbeam-queue = { version = "0.4.0", path = "crossbeam-queue", default-features = false, optional = true }
+crossbeam-utils = { version = "0.9.0", path = "crossbeam-utils", default-features = false, features = ["atomic"] }
 
 [dev-dependencies]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam"
 # - Update CHANGELOG.md
 # - Update README.md (when increasing major or minor version)
 # - Run './tools/publish.sh crossbeam <version>'
-version = "0.8.5"
+version = "0.9.0"
 edition = "2021"
 # NB: Sync with msrv badge and "Compatibility" section in README.md
 rust-version = "1.74"
@@ -49,11 +49,11 @@ std = [
 alloc = ["crossbeam-epoch/alloc", "crossbeam-queue/alloc"]
 
 [dependencies]
-crossbeam-channel = { version = "0.5.10", path = "crossbeam-channel", default-features = false, optional = true }
-crossbeam-deque = { version = "0.8.4", path = "crossbeam-deque", default-features = false, optional = true }
-crossbeam-epoch = { version = "0.9.17", path = "crossbeam-epoch", default-features = false, optional = true }
-crossbeam-queue = { version = "0.3.10", path = "crossbeam-queue", default-features = false, optional = true }
-crossbeam-utils = { version = "0.8.18", path = "crossbeam-utils", default-features = false, features = ["atomic"] }
+crossbeam-channel = { version = "0.5.18", path = "crossbeam-channel", default-features = false, optional = true }
+crossbeam-deque = { version = "0.8.9", path = "crossbeam-deque", default-features = false, optional = true }
+crossbeam-epoch = { version = "0.10.0", path = "crossbeam-epoch", default-features = false, optional = true }
+crossbeam-queue = { version = "0.4.0", path = "crossbeam-queue", default-features = false, optional = true }
+crossbeam-utils = { version = "0.9.0", path = "crossbeam-utils", default-features = false, features = ["atomic"] }
 
 [dev-dependencies]
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-crossbeam = "0.8"
+crossbeam = "0.9"
 ```
 
 ## Compatibility

--- a/crossbeam-channel/CHANGELOG.md
+++ b/crossbeam-channel/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Version 0.5.17
+
+- Bump the minimum supported Rust version to 1.74.
+- Fix panic in `SelectedOperation::{send,recv}` when cloned sender/receiver passed. (#1235)
+- Make some operations in `tick` lock-free on some platforms. (#1222)
+- Update `crossbeam-utils` to 0.9.
+
+TODO:
+- mention https://github.com/crossbeam-rs/crossbeam/pull/1121
+
 # Version 0.5.16
 
 - Improve support for rust-analyzer auto-completion of code inside `select!`/`select_biased!` macro. (#1240)

--- a/crossbeam-channel/CHANGELOG.md
+++ b/crossbeam-channel/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Version 0.5.18
+
+- Bump the minimum supported Rust version to 1.74.
+- Fix panic in `SelectedOperation::{send,recv}` when cloned sender/receiver passed. (#1235)
+- Drop all messages in bounded channel when the last receiver dropped. (#1121)
+- Add `Select::recycle`. (#1279)
+- Make some operations in `tick` lock-free on some platforms. (#1222)
+- Update `crossbeam-utils` to 0.9.
+
 # Version 0.5.17
 
 - Fix UB in bounded channel when `SelectedOperation` is leaked. (#1295)

--- a/crossbeam-channel/Cargo.toml
+++ b/crossbeam-channel/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-channel"
 # - Update CHANGELOG.md
 # - Update README.md (when increasing major or minor version)
 # - Run './tools/publish.sh crossbeam-channel <version>'
-version = "0.5.16"
+version = "0.5.17"
 edition = "2021"
 # NB: Sync with msrv badge and "Compatibility" section in README.md
 rust-version = "1.74"
@@ -33,7 +33,7 @@ default = ["std"]
 std = ["crossbeam-utils/std"]
 
 [dependencies]
-crossbeam-utils = { version = "0.8.18", path = "../crossbeam-utils", default-features = false, features = ["atomic"] }
+crossbeam-utils = { version = "0.9.0", path = "../crossbeam-utils", default-features = false, features = ["atomic"] }
 
 [dev-dependencies]
 fastrand = "2"

--- a/crossbeam-channel/Cargo.toml
+++ b/crossbeam-channel/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-channel"
 # - Update CHANGELOG.md
 # - Update README.md (when increasing major or minor version)
 # - Run './tools/publish.sh crossbeam-channel <version>'
-version = "0.5.17"
+version = "0.5.18"
 edition = "2021"
 # NB: Sync with msrv badge and "Compatibility" section in README.md
 rust-version = "1.74"
@@ -33,7 +33,7 @@ default = ["std"]
 std = ["crossbeam-utils/std"]
 
 [dependencies]
-crossbeam-utils = { version = "0.8.18", path = "../crossbeam-utils", default-features = false, features = ["atomic"] }
+crossbeam-utils = { version = "0.9.0", path = "../crossbeam-utils", default-features = false, features = ["atomic"] }
 
 [dev-dependencies]
 fastrand = "2"

--- a/crossbeam-deque/CHANGELOG.md
+++ b/crossbeam-deque/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Version 0.8.8
+
+- Bump the minimum supported Rust version to 1.74.
+- Update `crossbeam-epoch` to 0.10.
+- Update `crossbeam-utils` to 0.9.
+
+TODO:
+- complete https://github.com/crossbeam-rs/crossbeam/pull/1219
+- decide https://github.com/crossbeam-rs/crossbeam/pull/743
+
 # Version 0.8.7
 
 - Optimize `Worker::push`, `Stealer::steal_batch*`, `Injector::steal_batch*`. (#1233)

--- a/crossbeam-deque/CHANGELOG.md
+++ b/crossbeam-deque/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Version 0.8.9
+
+- Bump the minimum supported Rust version to 1.74.
+- Update `crossbeam-epoch` to 0.10.
+- Update `crossbeam-utils` to 0.9.
+
+TODO:
+- complete https://github.com/crossbeam-rs/crossbeam/pull/1219
+- decide https://github.com/crossbeam-rs/crossbeam/pull/1246
+
 # Version 0.8.8
 
 - Improve compatibility with ThreadSanitizer. (#1308)

--- a/crossbeam-deque/Cargo.toml
+++ b/crossbeam-deque/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-deque"
 # - Update CHANGELOG.md
 # - Update README.md (when increasing major or minor version)
 # - Run './tools/publish.sh crossbeam-deque <version>'
-version = "0.8.7"
+version = "0.8.8"
 edition = "2021"
 # NB: Sync with msrv badge and "Compatibility" section in README.md
 rust-version = "1.74"
@@ -33,8 +33,8 @@ default = ["std"]
 std = ["crossbeam-epoch/std", "crossbeam-utils/std"]
 
 [dependencies]
-crossbeam-epoch = { version = "0.9.17", path = "../crossbeam-epoch", default-features = false }
-crossbeam-utils = { version = "0.8.18", path = "../crossbeam-utils", default-features = false }
+crossbeam-epoch = { version = "0.10.0", path = "../crossbeam-epoch", default-features = false }
+crossbeam-utils = { version = "0.9.0", path = "../crossbeam-utils", default-features = false }
 
 [dev-dependencies]
 fastrand = "2"

--- a/crossbeam-deque/Cargo.toml
+++ b/crossbeam-deque/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-deque"
 # - Update CHANGELOG.md
 # - Update README.md (when increasing major or minor version)
 # - Run './tools/publish.sh crossbeam-deque <version>'
-version = "0.8.8"
+version = "0.8.9"
 edition = "2021"
 # NB: Sync with msrv badge and "Compatibility" section in README.md
 rust-version = "1.74"
@@ -33,8 +33,8 @@ default = ["std"]
 std = ["crossbeam-epoch/std", "crossbeam-utils/std"]
 
 [dependencies]
-crossbeam-epoch = { version = "0.9.17", path = "../crossbeam-epoch", default-features = false }
-crossbeam-utils = { version = "0.8.18", path = "../crossbeam-utils", default-features = false }
+crossbeam-epoch = { version = "0.10.0", path = "../crossbeam-epoch", default-features = false }
+crossbeam-utils = { version = "0.9.0", path = "../crossbeam-utils", default-features = false }
 
 [dev-dependencies]
 fastrand = "2"

--- a/crossbeam-epoch/CHANGELOG.md
+++ b/crossbeam-epoch/CHANGELOG.md
@@ -1,3 +1,16 @@
+# Version 0.10.0
+
+- Bump the minimum supported Rust version to 1.74.
+- Improve compatibility with Miri:
+  - Fix stacked borrows violations. (#871)
+  - Remove ptr-to-int casts for `-Zmiri-strict-provenance` compatibility. (#796)
+- Change `Atomic::{compare_exchange,compare_exchange_weak}` to return both the old and new values. (#1197)
+- Remove deprecated `CompareAndSetError`, `CompareAndSetOrdering`, and `Atomic::{compare_and_set,compare_and_set_weak}`. (#881)
+- Remove no longer used `nightly` feature. (#882)
+- Seal `Pointer` trait. (#884)
+- Make `Shared::null` const (#1227)
+- Update `crossbeam-utils` to 0.9.
+
 # Version 0.9.20
 
 - Fix invalid pointer dereference in `fmt::Pointer` impl for `Atomic`/`Shared` when the underlying pointer is invalid. This fixes unsoundness that was not fully addressed in 0.9.19's fix. (#1276)

--- a/crossbeam-epoch/CHANGELOG.md
+++ b/crossbeam-epoch/CHANGELOG.md
@@ -1,3 +1,15 @@
+# Version 0.10.0
+
+- Bump the minimum supported Rust version to 1.74.
+- Improve compatibility with Miri:
+  - Fix stacked borrows violations. (#871, #1297)
+  - Remove ptr-to-int casts for `-Zmiri-strict-provenance` compatibility. (#796)
+- Change `Atomic::{compare_exchange,compare_exchange_weak}` to return both the old and new values. (#1197)
+- Remove deprecated `CompareAndSetError`, `CompareAndSetOrdering`, and `Atomic::{compare_and_set,compare_and_set_weak}`. (#881)
+- Remove no longer used `nightly` feature. (#882)
+- Seal `Pointer` trait. (#884)
+- Update `crossbeam-utils` to 0.9.
+
 # Version 0.9.21
 
 - Make `Shared::null` const. (#1227)

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-epoch"
 # - Update CHANGELOG.md
 # - Update README.md (when increasing major or minor version)
 # - Run './tools/publish.sh crossbeam-epoch <version>'
-version = "0.9.20"
+version = "0.10.0"
 edition = "2021"
 # NB: Sync with msrv badge and "Compatibility" section in README.md
 rust-version = "1.74"
@@ -43,7 +43,7 @@ alloc = []
 loom = ["loom-crate", "crossbeam-utils/loom"]
 
 [dependencies]
-crossbeam-utils = { version = "0.8.18", path = "../crossbeam-utils", default-features = false, features = ["atomic"] }
+crossbeam-utils = { version = "0.9.0", path = "../crossbeam-utils", default-features = false, features = ["atomic"] }
 
 # Enable the use of loom for concurrency testing.
 #

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-epoch"
 # - Update CHANGELOG.md
 # - Update README.md (when increasing major or minor version)
 # - Run './tools/publish.sh crossbeam-epoch <version>'
-version = "0.9.21"
+version = "0.10.0"
 edition = "2021"
 # NB: Sync with msrv badge and "Compatibility" section in README.md
 rust-version = "1.74"
@@ -43,7 +43,7 @@ alloc = []
 loom = ["loom-crate", "crossbeam-utils/loom"]
 
 [dependencies]
-crossbeam-utils = { version = "0.8.18", path = "../crossbeam-utils", default-features = false, features = ["atomic"] }
+crossbeam-utils = { version = "0.9.0", path = "../crossbeam-utils", default-features = false, features = ["atomic"] }
 
 # Enable the use of loom for concurrency testing.
 #

--- a/crossbeam-epoch/README.md
+++ b/crossbeam-epoch/README.md
@@ -28,7 +28,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-crossbeam-epoch = "0.9"
+crossbeam-epoch = "0.10"
 ```
 
 ## Compatibility

--- a/crossbeam-queue/CHANGELOG.md
+++ b/crossbeam-queue/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 0.4.0
+
+- Remove no longer used `nightly` feature. (#882)
+- Update `crossbeam-utils` to 0.9.
+
 # Version 0.3.13
 
 - Add `push_mut` and `pop_mut` to `ArrayQueue` and `SegQueue`. (#1191)

--- a/crossbeam-queue/CHANGELOG.md
+++ b/crossbeam-queue/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 0.4.0
+
+- Remove no longer used `nightly` feature. (#882)
+- Update `crossbeam-utils` to 0.9.
+
 # Version 0.3.14
 
 - Use 64-bit index on 32-bit platforms if 64-bit atomic is available. (#1321)

--- a/crossbeam-queue/Cargo.toml
+++ b/crossbeam-queue/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-queue"
 # - Update CHANGELOG.md
 # - Update README.md (when increasing major or minor version)
 # - Run './tools/publish.sh crossbeam-queue <version>'
-version = "0.3.13"
+version = "0.4.0"
 edition = "2021"
 # NB: Sync with msrv badge and "Compatibility" section in README.md
 rust-version = "1.60"
@@ -37,7 +37,7 @@ std = ["alloc", "crossbeam-utils/std"]
 alloc = []
 
 [dependencies]
-crossbeam-utils = { version = "0.8.18", path = "../crossbeam-utils", default-features = false }
+crossbeam-utils = { version = "0.9.0", path = "../crossbeam-utils", default-features = false }
 
 [dev-dependencies]
 fastrand = "2"

--- a/crossbeam-queue/Cargo.toml
+++ b/crossbeam-queue/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-queue"
 # - Update CHANGELOG.md
 # - Update README.md (when increasing major or minor version)
 # - Run './tools/publish.sh crossbeam-queue <version>'
-version = "0.3.14"
+version = "0.4.0"
 edition = "2021"
 # NB: Sync with msrv badge and "Compatibility" section in README.md
 rust-version = "1.60"
@@ -37,7 +37,7 @@ std = ["alloc", "crossbeam-utils/std"]
 alloc = []
 
 [dependencies]
-crossbeam-utils = { version = "0.8.18", path = "../crossbeam-utils", default-features = false }
+crossbeam-utils = { version = "0.9.0", path = "../crossbeam-utils", default-features = false }
 
 [dev-dependencies]
 fastrand = "2"

--- a/crossbeam-queue/README.md
+++ b/crossbeam-queue/README.md
@@ -29,7 +29,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-crossbeam-queue = "0.3"
+crossbeam-queue = "0.4"
 ```
 
 ## Compatibility

--- a/crossbeam-skiplist/CHANGELOG.md
+++ b/crossbeam-skiplist/CHANGELOG.md
@@ -1,3 +1,20 @@
+# Version 0.2.0
+
+- Bump the minimum supported Rust version to 1.74.
+- Improve compatibility with Miri:
+  - Fix stacked borrows violations. (#871)
+- Allow lookup to be customized. (#1132)
+- Support custom comparators. (#1182)
+- Fix #1023. (#1101)
+- Fix memory leaks in `{map,set}::Range`/`base::RefRange`. (#1217)
+- Update `crossbeam-epoch` to 0.10.
+- Update `crossbeam-utils` to 0.9.
+
+TODO:
+- entry for #1101 should be more descriptive.
+- mention https://github.com/crossbeam-rs/crossbeam/pull/1143
+- audit Send/Sync impls
+
 # Version 0.1.3
 
 - Remove dependency on `cfg-if`. (#1072)

--- a/crossbeam-skiplist/CHANGELOG.md
+++ b/crossbeam-skiplist/CHANGELOG.md
@@ -1,3 +1,21 @@
+# Version 0.2.0
+
+- Bump the minimum supported Rust version to 1.74.
+- Improve compatibility with Miri:
+  - Fix stacked borrows violations. (#871)
+- Allow lookup to be customized. (#1132)
+- Support custom comparators. (#1182)
+- Fix #1023. (#1101)
+- Fix Send/Sync impl of `RefRange`. (#1287)
+- Fix memory leaks in `{map,set}::Range`/`base::RefRange`. (#1217)
+- Update `crossbeam-epoch` to 0.10.
+- Update `crossbeam-utils` to 0.9.
+- Update MSRV policy to support 1 year instead of 6 months to meet rayon's MSRV policy. (#1284)
+
+TODO:
+- entry for #1101 should be more descriptive.
+- mention https://github.com/crossbeam-rs/crossbeam/pull/1143
+
 # Version 0.1.3
 
 - Remove dependency on `cfg-if`. (#1072)

--- a/crossbeam-skiplist/Cargo.toml
+++ b/crossbeam-skiplist/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-skiplist"
 # - Update CHANGELOG.md
 # - Update README.md (when increasing major or minor version)
 # - Run './tools/publish.sh crossbeam-skiplist <version>'
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 # NB: Sync with msrv badge and "Compatibility" section in README.md
 rust-version = "1.74"
@@ -38,8 +38,8 @@ std = ["alloc", "crossbeam-epoch/std", "crossbeam-utils/std"]
 alloc = ["crossbeam-epoch/alloc"]
 
 [dependencies]
-crossbeam-epoch = { version = "0.9.17", path = "../crossbeam-epoch", default-features = false }
-crossbeam-utils = { version = "0.8.18", path = "../crossbeam-utils", default-features = false }
+crossbeam-epoch = { version = "0.10.0", path = "../crossbeam-epoch", default-features = false }
+crossbeam-utils = { version = "0.9.0", path = "../crossbeam-utils", default-features = false }
 
 [dev-dependencies]
 fastrand = "2"

--- a/crossbeam-skiplist/README.md
+++ b/crossbeam-skiplist/README.md
@@ -27,7 +27,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-crossbeam-skiplist = "0.1"
+crossbeam-skiplist = "0.2"
 ```
 
 ## Compatibility

--- a/crossbeam-utils/CHANGELOG.md
+++ b/crossbeam-utils/CHANGELOG.md
@@ -1,3 +1,20 @@
+# Version 0.9.0
+
+- Relax the minimum supported Rust version with the default feature to 1.56. (#1157)
+- Move `atomic` module behind `atomic` Cargo feature. The minimum supported Rust version of this feature is currently 1.74. (#1155)
+- Return `UnparkReason` from `park_{timeout,deadline}`.
+(#1012)
+- Remove deprecated `AtomicCell::compare_and_swap`. (#881)
+- Remove no longer used `nightly` feature. (#882)
+- Use our own `unix::JoinHandleExt` trait instead of `std::os::unix::thread::JoinHandleExt` which is not intended to be implemented for types other than the standard library. (#999)
+- Fix UB around uninitialized bytes in `AtomicCell`. (#1015)
+- Use `cfg(target_has_atomic)` for `AtomicConsume` impl. (#1281)
+
+TODO:
+- complete https://github.com/crossbeam-rs/crossbeam/pull/1219
+- decide https://github.com/crossbeam-rs/crossbeam/pull/1210
+- unconst AtomicCell::is_lock_free for runtime-detection
+
 # Version 0.8.23
 
 - Fix SB violation when `ShardedLockWriteGuard` is leaked. (#1294)

--- a/crossbeam-utils/CHANGELOG.md
+++ b/crossbeam-utils/CHANGELOG.md
@@ -1,3 +1,20 @@
+# Version 0.9.0
+
+- Relax the minimum supported Rust version with the default feature to 1.56. (#1157)
+- Move `atomic` module behind `atomic` Cargo feature. The minimum supported Rust version of this feature is currently 1.74. (#1155)
+- Return `UnparkReason` from `park_{timeout,deadline}`.
+(#1012)
+- Remove deprecated `AtomicCell::compare_and_swap`. (#881)
+- Remove no longer used `nightly` feature. (#882)
+- Use our own `unix::JoinHandleExt` trait instead of `std::os::unix::thread::JoinHandleExt` which is not intended to be implemented for types other than the standard library. (#999)
+- Fix UB around uninitialized bytes in `AtomicCell`. (#1015)
+
+TODO:
+- mention https://github.com/crossbeam-rs/crossbeam/pull/1281
+- complete https://github.com/crossbeam-rs/crossbeam/pull/1219
+- decide https://github.com/crossbeam-rs/crossbeam/pull/1210
+- unconst AtomicCell::is_lock_free for runtime-detection
+
 # Version 0.8.22
 
 - Make `AtomicCell::{as_ptr,into_inner}` const. (#1237)

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-utils"
 # - Update CHANGELOG.md
 # - Update README.md (when increasing major or minor version)
 # - Run './tools/publish.sh crossbeam-utils <version>'
-version = "0.8.22"
+version = "0.9.0"
 edition = "2021"
 # NB: Sync with msrv badge and "Compatibility" section in README.md
 rust-version = "1.56"

--- a/crossbeam-utils/Cargo.toml
+++ b/crossbeam-utils/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-utils"
 # - Update CHANGELOG.md
 # - Update README.md (when increasing major or minor version)
 # - Run './tools/publish.sh crossbeam-utils <version>'
-version = "0.8.23"
+version = "0.9.0"
 edition = "2021"
 # NB: Sync with msrv badge and "Compatibility" section in README.md
 rust-version = "1.56"

--- a/crossbeam-utils/README.md
+++ b/crossbeam-utils/README.md
@@ -48,7 +48,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-crossbeam-utils = "0.8"
+crossbeam-utils = "0.9"
 ```
 
 ## Compatibility


### PR DESCRIPTION
Changes:

- crossbeam-channel 0.5.17 -> 0.5.18
  - Bump the minimum supported Rust version to 1.74.
  - Fix panic in `SelectedOperation::{send,recv}` when cloned sender/receiver passed. (#1235)
  - Drop all messages in bounded channel when the last receiver dropped. (#1121)
  - Add `Select::recycle`. (#1279)
  - Make some operations in `tick` lock-free on some platforms. (#1222)
  - Update `crossbeam-utils` to 0.9.
- crossbeam-deque 0.8.8 -> 0.8.9
  - Bump the minimum supported Rust version to 1.74.
  - Update `crossbeam-epoch` to 0.10.
  - Update `crossbeam-utils` to 0.9.
- crossbeam-epoch 0.9.21 -> 0.10.0
  - Bump the minimum supported Rust version to 1.74.
  - Improve compatibility with Miri:
    - Fix stacked borrows violations. (#871, #1297)
    - Remove ptr-to-int casts for `-Zmiri-strict-provenance` compatibility. (#796)
  - Change `Atomic::{compare_exchange,compare_exchange_weak}` to return both the old and new values. (#1197)
  - Remove deprecated `CompareAndSetError`, `CompareAndSetOrdering`, and `Atomic::{compare_and_set,compare_and_set_weak}`. (#881)
  - Remove no longer used `nightly` feature. (#882)
  - Seal `Pointer` trait. (#884)
  - Update `crossbeam-utils` to 0.9.
- crossbeam-queue 0.3.14 -> 0.4.0
  - Remove no longer used `nightly` feature. (#882)
  - Update `crossbeam-utils` to 0.9.
- crossbeam-skiplist 0.1.3 -> 0.2.0
  - Bump the minimum supported Rust version to 1.74.
  - Improve compatibility with Miri:
    - Fix stacked borrows violations. (#871)
  - Allow lookup to be customized. (#1132)
  - Support custom comparators. (#1182)
  - Fix #1023. (#1101)
  - Fix Send/Sync impl of `RefRange`. (#1287)
  - Fix memory leaks in `{map,set}::Range`/`base::RefRange`. (#1217)
  - Update `crossbeam-epoch` to 0.10.
  - Update `crossbeam-utils` to 0.9.
  - Update MSRV policy to support 1 year instead of 6 months to meet rayon's MSRV policy. (#1284)
- crossbeam-utils 0.8.23 -> 0.9.0
  - Relax the minimum supported Rust version with the default feature to 1.56. (#1157)
  - Move `atomic` module behind `atomic` Cargo feature. The minimum supported Rust version of this feature is currently 1.74. (#1155)
  - Return `UnparkReason` from `park_{timeout,deadline}`.
(#1012)
  - Remove deprecated `AtomicCell::compare_and_swap`. (#881)
  - Remove no longer used `nightly` feature. (#882)
  - Use our own `unix::JoinHandleExt` trait instead of `std::os::unix::thread::JoinHandleExt` which is not intended to be implemented for types other than the standard library. (#999)
  - Fix UB around uninitialized bytes in `AtomicCell`. (#1015)
  - Use `cfg(target_has_atomic)` for `AtomicConsume` impl. (#1281)
- crossbeam 0.8.5 -> 0.9.0
  - Bump the minimum supported Rust version to 1.74.
  - Remove no longer used `nightly` feature. (#882)
  - Update `crossbeam-epoch` to 0.10.
  - Update `crossbeam-queue` to 0.4.
  - Update `crossbeam-utils` to 0.9.

TODO:
- [ ] resolve TODOs in changelog
- [ ] mention https://github.com/crossbeam-rs/crossbeam/pull/1327


Closes https://github.com/crossbeam-rs/crossbeam/issues/1181