### PR TITLE
ci: Test armv7hf Linux on ubuntu-24.04-arm runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
             os: ubuntu-latest
             target: i686-unknown-linux-gnu
           - rust: nightly
-            os: ubuntu-latest
+            os: ubuntu-24.04-arm
             target: armv7-unknown-linux-gnueabihf
           # Test 32-bit target that does not have AtomicU64/AtomicI64.
           - rust: nightly


### PR DESCRIPTION
setup-cross-toolchain-action now supports this: https://github.com/taiki-e/setup-cross-toolchain-action/releases/tag/v1.27.0

Related: https://github.com/crossbeam-rs/crossbeam/pull/1169