### PR TITLE
v0.8: Prepare for the next release

### DIFF
--- a/crossbeam-channel/CHANGELOG.md
+++ b/crossbeam-channel/CHANGELOG.md
@@ -1,4 +1,10 @@
+# Version 0.5.15
+
+- Fix regression introduced in 0.5.12 that can lead to a double free when dropping unbounded channel. (#1187)
+
 # Version 0.5.14
+
+**Note:** This release has been yanked due to bug fixed in 0.5.15.
 
 - Fix stack overflow when sending large value to unbounded channel. (#1146, #1147)
 - Add `Select::new_biased` function. (#1150)
@@ -7,9 +13,13 @@
 
 # Version 0.5.13
 
+**Note:** This release has been yanked due to bug fixed in 0.5.15.
+
 - Add `select_biased!` macro. (#1040)
 
 # Version 0.5.12
+
+**Note:** This release has been yanked due to bug fixed in 0.5.15.
 
 - Fix memory leak in unbounded channel. (#1084)
 

--- a/crossbeam-channel/Cargo.toml
+++ b/crossbeam-channel/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-channel"
 # - Update CHANGELOG.md
 # - Update README.md (when increasing major or minor version)
 # - Run './tools/publish.sh crossbeam-channel <version>'
-version = "0.5.14"
+version = "0.5.15"
 edition = "2021"
 rust-version = "1.60"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-channel/src/flavors/list.rs
+++ b/crossbeam-channel/src/flavors/list.rs
@@ -611,7 +611,7 @@ impl<T> Channel<T> {
             // In that case, just wait until it gets initialized.
             while block.is_null() {
                 backoff.snooze();
-                block = self.head.block.load(Ordering::Acquire);
+                block = self.head.block.swap(ptr::null_mut(), Ordering::AcqRel);
             }
         }
 


### PR DESCRIPTION
Changes:
- crossbeam-channel 0.5.14 -> 0.5.15
  - Fix regression introduced in 0.5.12 that can lead to a double free when dropping unbounded channel. (#1187)

Also yanking crossbeam-channel 0.5.12, 0.5.13, 0.5.14.