### PR TITLE
Port Golang select3.go Test

### DIFF
--- a/crossbeam-channel/tests/golang.rs
+++ b/crossbeam-channel/tests/golang.rs
@@ -1011,21 +1011,6 @@ mod select3 {
             }
         });
     }
-
-    //#[test]
-    fn main4() {
-        // selects with closed channels behave like ordinary operations
-        let closedch = make::<i32>(1);
-        closedch.close_s();
-        let closedch = Arc::new(closedch);
-        test_panic(ALWAYS, {
-            move || {
-                select! {
-                    send(closedch.tx(), 7) -> _ => {}
-                }
-            }
-        });
-    }
 }
 
 // https://github.com/golang/go/blob/master/test/chan/select4.go


### PR DESCRIPTION
Port of the [select3.go](https://github.com/golang/go/blob/master/test/chan/select3.go) test.

Part of https://github.com/crossbeam-rs/crossbeam/issues/201

Some tests are omitted:
- Empty `select` statements (they cause a compile error)
- Receiving with the `ok` flag
- Panic on select send to a closed channel (it blocks instead)