### PR TITLE
Implement `Unparker::unpark_with_result()`

### DIFF
--- a/crossbeam-utils/src/sync/mod.rs
+++ b/crossbeam-utils/src/sync/mod.rs
@@ -11,7 +11,7 @@ mod parker;
 mod sharded_lock;
 mod wait_group;
 
-pub use self::parker::{Parker, UnparkReason, Unparker};
+pub use self::parker::{Parker, UnparkReason, UnparkResult, Unparker};
 #[cfg(not(crossbeam_loom))]
 pub use self::sharded_lock::{ShardedLock, ShardedLockReadGuard, ShardedLockWriteGuard};
 pub use self::wait_group::WaitGroup;


### PR DESCRIPTION
Fixes #1209.

`Unparker::unpark_with_result()` is like `Unpark::unpark()`, but also returns the previous state of the token. This change also introduces one new public enum `UnparkResult`.

Some other questions to think about:

- This is deliberately a non-breaking change. If we think that in the long term, it is better to migrate `unpark` to returning a result altogether, then making that breaking change here and now could be *less* painful than adding an alternative method, migrate the main method, and finally deprecate the alternative method, which is *two* breaking changes.
- Naming: `unpark_with_result` sounds a bit awkward. I can think of `unpark_returning` as an alternative, but it sounds as awkward.