### PR TITLE
Replace iterative capacity growth with `next_power_of_two`

### DIFF
--- a/crossbeam-deque/src/deque.rs
+++ b/crossbeam-deque/src/deque.rs
@@ -333,7 +333,7 @@ impl<T> Worker<T> {
 
             // Is there enough capacity to push `reserve_cap` tasks?
             if cap - len < reserve_cap {
-                // Keep doubling the capacity as much as is needed.
+                // Ensure capacity for reserve_cap + len, rounded up to the next power of 2
                 let new_cap = (reserve_cap + len).next_power_of_two();
 
                 // Resize the buffer.

--- a/crossbeam-deque/src/deque.rs
+++ b/crossbeam-deque/src/deque.rs
@@ -334,10 +334,7 @@ impl<T> Worker<T> {
             // Is there enough capacity to push `reserve_cap` tasks?
             if cap - len < reserve_cap {
                 // Keep doubling the capacity as much as is needed.
-                let mut new_cap = cap * 2;
-                while new_cap - len < reserve_cap {
-                    new_cap *= 2;
-                }
+                let new_cap = (reserve_cap + len).next_power_of_two();
 
                 // Resize the buffer.
                 unsafe {


### PR DESCRIPTION
Replace the capacity-doubling [loop](https://github.com/crossbeam-rs/crossbeam/blob/master/crossbeam-deque/src/deque.rs#L337-L340) with `(reserve_cap + len).next_power_of_two()`. Given the existing invariant that capacity is a power of two, the result is identical. 