### PR TITLE
Add watch channel with latest-value semantics

### DIFF
--- a/crossbeam-channel/src/lib.rs
+++ b/crossbeam-channel/src/lib.rs
@@ -364,6 +364,8 @@ mod select_macro;
 mod utils;
 #[cfg(feature = "std")]
 mod waker;
+#[cfg(feature = "std")]
+mod watch;
 
 /// Crate internals used by the `select!` macro.
 #[doc(hidden)]
@@ -384,4 +386,5 @@ pub use crate::{
         SendTimeoutError, TryReadyError, TryRecvError, TrySelectError, TrySendError,
     },
     select::{Select, SelectedOperation},
+    watch::{watch, WatchReceiver, WatchSender},
 };

--- a/crossbeam-channel/src/lib.rs
+++ b/crossbeam-channel/src/lib.rs
@@ -386,5 +386,5 @@ pub use crate::{
         SendTimeoutError, TryReadyError, TryRecvError, TrySelectError, TrySendError,
     },
     select::{Select, SelectedOperation},
-    watch::{watch, WatchReceiver, WatchSender},
+    watch::{WatchReceiver, WatchSender, watch},
 };

--- a/crossbeam-channel/src/watch.rs
+++ b/crossbeam-channel/src/watch.rs
@@ -1,0 +1,215 @@
+//! A watch channel that only stores the latest value.
+//!
+//! Sending never blocks (it overwrites the latest value), while receiving
+//! blocks until a new value is available.
+
+use alloc::sync::Arc;
+use core::fmt;
+use std::sync::{Condvar, Mutex};
+
+use crate::err::{RecvError, SendError, TryRecvError};
+
+struct Inner<T> {
+    /// The latest value, if any.
+    value: Mutex<State<T>>,
+    /// Condvar to notify receivers when a new value is available.
+    notify: Condvar,
+}
+
+struct State<T> {
+    /// The stored value, if any.
+    value: Option<T>,
+    /// Incremented each time a new value is sent.
+    version: u64,
+    /// Whether all senders have been dropped.
+    disconnected: bool,
+    /// Number of active senders.
+    sender_count: usize,
+    /// Number of active receivers.
+    receiver_count: usize,
+}
+
+/// The sending side of a watch channel.
+///
+/// Senders can be cloned. When all senders are dropped, the channel becomes
+/// disconnected.
+pub struct WatchSender<T> {
+    inner: Arc<Inner<T>>,
+}
+
+/// The receiving side of a watch channel.
+///
+/// Receivers can be cloned. Each receiver independently tracks which version
+/// it has seen, so each receiver will get the next new value sent after its
+/// last receive.
+pub struct WatchReceiver<T> {
+    inner: Arc<Inner<T>>,
+    /// The version this receiver last saw.
+    seen_version: u64,
+}
+
+/// Creates a watch channel.
+///
+/// The channel stores only the latest sent value. Sending never blocks; it
+/// simply overwrites the current value. Receiving blocks until a new value
+/// is available (i.e., one with a version newer than what the receiver last
+/// saw).
+///
+/// Returns a [`WatchSender`] and [`WatchReceiver`] pair.
+///
+/// # Examples
+///
+/// ```
+/// use crossbeam_channel::watch;
+///
+/// let (tx, mut rx) = watch::<i32>();
+///
+/// tx.send(1).unwrap();
+/// tx.send(2).unwrap();
+///
+/// // Only the latest value is available.
+/// assert_eq!(rx.recv(), Ok(2));
+///
+/// drop(tx);
+/// assert_eq!(rx.recv(), Err(crossbeam_channel::RecvError));
+/// ```
+pub fn watch<T>() -> (WatchSender<T>, WatchReceiver<T>) {
+    let inner = Arc::new(Inner {
+        value: Mutex::new(State {
+            value: None,
+            version: 0,
+            disconnected: false,
+            sender_count: 1,
+            receiver_count: 1,
+        }),
+        notify: Condvar::new(),
+    });
+
+    let tx = WatchSender {
+        inner: Arc::clone(&inner),
+    };
+    let rx = WatchReceiver {
+        inner,
+        seen_version: 0,
+    };
+    (tx, rx)
+}
+
+impl<T> WatchSender<T> {
+    /// Sends a value into the channel, overwriting any previously stored value.
+    ///
+    /// This operation never blocks.
+    ///
+    /// Returns an error if all receivers have been dropped.
+    pub fn send(&self, value: T) -> Result<(), SendError<T>> {
+        let mut state = self.inner.value.lock().unwrap();
+        if state.receiver_count == 0 {
+            return Err(SendError(value));
+        }
+        state.value = Some(value);
+        state.version += 1;
+        // Notify all waiting receivers.
+        self.inner.notify.notify_all();
+        Ok(())
+    }
+}
+
+impl<T> Clone for WatchSender<T> {
+    fn clone(&self) -> Self {
+        let mut state = self.inner.value.lock().unwrap();
+        state.sender_count += 1;
+        WatchSender {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+impl<T> Drop for WatchSender<T> {
+    fn drop(&mut self) {
+        let mut state = self.inner.value.lock().unwrap();
+        state.sender_count -= 1;
+        if state.sender_count == 0 {
+            state.disconnected = true;
+            self.inner.notify.notify_all();
+        }
+    }
+}
+
+impl<T> fmt::Debug for WatchSender<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad("WatchSender { .. }")
+    }
+}
+
+impl<T> WatchReceiver<T> {
+    /// Blocks until a new value is available and returns it.
+    ///
+    /// Returns an error if all senders have been dropped and no new value
+    /// is available.
+    pub fn recv(&mut self) -> Result<T, RecvError>
+    where
+        T: Clone,
+    {
+        let mut state = self.inner.value.lock().unwrap();
+        loop {
+            // Check if there's a value with a newer version than what we've seen.
+            if state.version > self.seen_version {
+                if let Some(ref value) = state.value {
+                    self.seen_version = state.version;
+                    return Ok(value.clone());
+                }
+            }
+            if state.disconnected {
+                return Err(RecvError);
+            }
+            state = self.inner.notify.wait(state).unwrap();
+        }
+    }
+
+    /// Attempts to receive the latest value without blocking.
+    ///
+    /// Returns an error if no new value is available or the channel is
+    /// disconnected.
+    pub fn try_recv(&mut self) -> Result<T, TryRecvError>
+    where
+        T: Clone,
+    {
+        let state = self.inner.value.lock().unwrap();
+        if state.version > self.seen_version {
+            if let Some(ref value) = state.value {
+                self.seen_version = state.version;
+                return Ok(value.clone());
+            }
+        }
+        if state.disconnected {
+            Err(TryRecvError::Disconnected)
+        } else {
+            Err(TryRecvError::Empty)
+        }
+    }
+}
+
+impl<T> Clone for WatchReceiver<T> {
+    fn clone(&self) -> Self {
+        let mut state = self.inner.value.lock().unwrap();
+        state.receiver_count += 1;
+        WatchReceiver {
+            inner: Arc::clone(&self.inner),
+            seen_version: self.seen_version,
+        }
+    }
+}
+
+impl<T> Drop for WatchReceiver<T> {
+    fn drop(&mut self) {
+        let mut state = self.inner.value.lock().unwrap();
+        state.receiver_count -= 1;
+        // If no receivers left, notify senders so they get errors.
+    }
+}
+
+impl<T> fmt::Debug for WatchReceiver<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad("WatchReceiver { .. }")
+    }
+}

--- a/crossbeam-channel/tests/watch.rs
+++ b/crossbeam-channel/tests/watch.rs
@@ -1,0 +1,144 @@
+use crossbeam_channel::{watch, RecvError, TryRecvError};
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn watch_send_recv_basic() {
+    let (tx, mut rx) = watch::<i32>();
+    tx.send(42).unwrap();
+    assert_eq!(rx.recv(), Ok(42));
+}
+
+#[test]
+fn watch_overwrites_value() {
+    let (tx, mut rx) = watch::<i32>();
+    tx.send(1).unwrap();
+    tx.send(2).unwrap();
+    tx.send(3).unwrap();
+    // Only the latest value should be received.
+    assert_eq!(rx.recv(), Ok(3));
+}
+
+#[test]
+fn watch_recv_blocks_until_send() {
+    let (tx, mut rx) = watch::<i32>();
+
+    let handle = thread::spawn(move || {
+        thread::sleep(Duration::from_millis(50));
+        tx.send(99).unwrap();
+    });
+
+    assert_eq!(rx.recv(), Ok(99));
+    handle.join().unwrap();
+}
+
+#[test]
+fn watch_recv_error_on_disconnect() {
+    let (tx, mut rx) = watch::<i32>();
+    drop(tx);
+    assert_eq!(rx.recv(), Err(RecvError));
+}
+
+#[test]
+fn watch_try_recv_empty() {
+    let (_tx, mut rx) = watch::<i32>();
+    assert_eq!(rx.try_recv(), Err(TryRecvError::Empty));
+}
+
+#[test]
+fn watch_try_recv_disconnected() {
+    let (tx, mut rx) = watch::<i32>();
+    drop(tx);
+    assert_eq!(rx.try_recv(), Err(TryRecvError::Disconnected));
+}
+
+#[test]
+fn watch_try_recv_value() {
+    let (tx, mut rx) = watch::<i32>();
+    tx.send(10).unwrap();
+    assert_eq!(rx.try_recv(), Ok(10));
+    // Second try_recv should be empty since version hasn't changed.
+    assert_eq!(rx.try_recv(), Err(TryRecvError::Empty));
+}
+
+#[test]
+fn watch_send_error_when_no_receivers() {
+    let (tx, rx) = watch::<i32>();
+    drop(rx);
+    assert!(tx.send(1).is_err());
+}
+
+#[test]
+fn watch_multiple_sends_between_recvs() {
+    let (tx, mut rx) = watch::<i32>();
+    tx.send(1).unwrap();
+    assert_eq!(rx.recv(), Ok(1));
+
+    tx.send(2).unwrap();
+    tx.send(3).unwrap();
+    // Should only get the latest.
+    assert_eq!(rx.recv(), Ok(3));
+}
+
+#[test]
+fn watch_clone_sender() {
+    let (tx1, mut rx) = watch::<i32>();
+    let tx2 = tx1.clone();
+
+    tx1.send(1).unwrap();
+    assert_eq!(rx.recv(), Ok(1));
+
+    tx2.send(2).unwrap();
+    assert_eq!(rx.recv(), Ok(2));
+
+    drop(tx1);
+    // Channel still alive because tx2 exists.
+    tx2.send(3).unwrap();
+    assert_eq!(rx.recv(), Ok(3));
+
+    drop(tx2);
+    assert_eq!(rx.recv(), Err(RecvError));
+}
+
+#[test]
+fn watch_clone_receiver() {
+    let (tx, mut rx1) = watch::<i32>();
+    let mut rx2 = rx1.clone();
+
+    tx.send(1).unwrap();
+    // Both receivers should be able to receive the value independently.
+    assert_eq!(rx1.recv(), Ok(1));
+    assert_eq!(rx2.recv(), Ok(1));
+
+    tx.send(2).unwrap();
+    assert_eq!(rx1.recv(), Ok(2));
+    assert_eq!(rx2.recv(), Ok(2));
+}
+
+#[test]
+fn watch_multithreaded() {
+    let (tx, mut rx) = watch::<i32>();
+
+    let producer = thread::spawn(move || {
+        for i in 0..100 {
+            tx.send(i).unwrap();
+        }
+    });
+
+    // The receiver should eventually see 99 (or possibly skip some values).
+    let mut last_seen = -1;
+    loop {
+        match rx.recv() {
+            Ok(v) => {
+                assert!(v > last_seen || v == 0);
+                last_seen = v;
+                if v == 99 {
+                    break;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+    assert_eq!(last_seen, 99);
+    producer.join().unwrap();
+}

--- a/crossbeam-channel/tests/watch.rs
+++ b/crossbeam-channel/tests/watch.rs
@@ -1,6 +1,6 @@
-use crossbeam_channel::{watch, RecvError, TryRecvError};
-use std::thread;
-use std::time::Duration;
+use std::{thread, time::Duration};
+
+use crossbeam_channel::{RecvError, TryRecvError, watch};
 
 #[test]
 fn watch_send_recv_basic() {
@@ -127,16 +127,11 @@ fn watch_multithreaded() {
 
     // The receiver should eventually see 99 (or possibly skip some values).
     let mut last_seen = -1;
-    loop {
-        match rx.recv() {
-            Ok(v) => {
-                assert!(v > last_seen || v == 0);
-                last_seen = v;
-                if v == 99 {
-                    break;
-                }
-            }
-            Err(_) => break,
+    while let Ok(v) = rx.recv() {
+        assert!(v > last_seen || v == 0);
+        last_seen = v;
+        if v == 99 {
+            break;
         }
     }
     assert_eq!(last_seen, 99);


### PR DESCRIPTION
Adds a `watch` channel type that stores only the latest value. Sending never blocks (overwrites the previous value), and receiving blocks until a new value is available.

This is useful for scenarios like refresh signals where you only care about the most recent value - if multiple sends happen while the receiver is busy, the receiver processes just one iteration instead of N.

The implementation uses `Mutex<Option<T>> + Condvar` as suggested in #942. Key points:

- `WatchSender` and `WatchReceiver` are both `Clone`
- Each receiver independently tracks which version it has seen
- Disconnection is properly detected (recv returns `RecvError` when all senders are dropped, send returns `SendError` when all receivers are dropped)
- `try_recv` is available for non-blocking checks

```rust
let (tx, mut rx) = crossbeam_channel::watch::<i32>();
tx.send(1);
tx.send(2);
assert_eq!(rx.recv(), Ok(2)); // only latest value
```

Closes #942