### PR TITLE
Go test closed chan

### DIFF
--- a/crossbeam-channel/tests/golang.rs
+++ b/crossbeam-channel/tests/golang.rs
@@ -1626,7 +1626,6 @@ mod closedchan {
         }));
         assert!(result.is_err());
     }
-
 }
 
 // https://github.com/golang/go/blob/master/src/runtime/chanbarrier_test.go

--- a/crossbeam-channel/tests/golang.rs
+++ b/crossbeam-channel/tests/golang.rs
@@ -1578,7 +1578,7 @@ mod closedchan {
         for _ in 0..3 {
             // recv a close signal (a zero value)
             let x = c.recv().unwrap_or(0);
-            assert_eq!(x, 0, "test1: recv on closed");
+            assert_eq!(x, 0);
 
             // should work with select: received a value without blocking
             let x = c.try_recv().unwrap_or(0);

--- a/crossbeam-channel/tests/golang.rs
+++ b/crossbeam-channel/tests/golang.rs
@@ -1572,7 +1572,61 @@ mod chan_test {
 
 // https://github.com/golang/go/blob/master/test/closedchan.go
 mod closedchan {
-    // TODO
+    use super::*;
+
+    fn test1(c: Chan<i32>) {
+        for _ in 0..3 {
+            // recv a close signal (a zero value)
+            let x = c.recv().unwrap_or(0);
+            assert_eq!(x, 0, "test1: recv on closed");
+
+            // should work with select: received a value without blocking
+            let x = c.try_recv().unwrap_or(0);
+            assert_eq!(x, 0);
+        }
+    }
+
+    fn test_async1(c: Chan<i32>) {
+        //should be able to get the last value via Recv
+        let x = c.recv().unwrap_or(0);
+        assert_eq!(x, 1);
+        test1(c);
+    }
+
+    fn test_async2(c: Chan<i32>) {
+        //should be able to get the last value via Nbrecv
+        let x = c.try_recv().unwrap_or(0);
+        assert_eq!(x, 1);
+        test1(c);
+    }
+
+    fn closed_sync() -> Chan<i32> {
+        let c = make::<i32>(0);
+        c.close_s();
+        c
+    }
+
+    fn closed_async() -> Chan<i32> {
+        let c = make::<i32>(2);
+        c.send(1);
+        c.close_s();
+        c
+    }
+    #[test]
+    fn main() {
+        test1(closed_sync());
+        test_async1(closed_async());
+        test_async2(closed_async());
+
+        let ch = make::<i32>(0);
+        ch.close_s();
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            ch.close_s();
+        }));
+        assert!(result.is_err());
+    }
+
 }
 
 // https://github.com/golang/go/blob/master/src/runtime/chanbarrier_test.go


### PR DESCRIPTION
Port of the [closedchan.go](https://github.com/golang/go/blob/master/test/closedchan.go) test
Part of [#201](https://github.com/crossbeam-rs/crossbeam/issues/201)

-Omitted the SChan/XChan/SSChan variants, in Go these variants exercise different codepaths in the Go runtime but in crossbeam wrapping channel operations in select!{} as S and SSChan do would be identical to the default Chan<T> under the hood.
-Omitted sends on a closed channel. In Go, sending on a closed channel panics but the channel remains usable after recovery. In the Rust port, Chan<T>'s send panics via .expect() while holding the inner mutex lock, which poisons the mutex and prevents subsequent operations on the channel.  Always willing to adjust the go.langrs Chan impl to avoid lock poisoning but I erred on the side of not touching anything.
