### PR TITLE
Updated recv_deadline documentation

### DIFF
--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -904,7 +904,9 @@ impl<T> Receiver<T> {
     ///
     /// If the channel is empty and not disconnected, this call will block until the receive
     /// operation can proceed or the operation times out. If the channel is empty and becomes
-    /// disconnected, this call will wake up and return an error.
+    /// disconnected, this call will wake up and return an error. If the channel is non-empty
+    /// and the deadline has already been reached, the next message in the channel will be
+    /// returned.
     ///
     /// If called on a zero-capacity channel, this method will wait for a send operation to appear
     /// on the other side of the channel.


### PR DESCRIPTION
I noticed that the behavior of `recv_deadline` is undocumented for the edge case where the channel is non-empty and the deadline has already been reached already. It has a bit of an unexpected behavior in that it ignores the deadline and returns the next message in the channel. I assume this behavior is intentional since you can check the deadline upstream, so I have updated the documentation to reflect the behavior.

This is related to issue #975 

Closes #975 