### PR TITLE
Make crossbeam::deque::Worker::push return slotted index

### DIFF
--- a/crossbeam-deque/src/deque.rs
+++ b/crossbeam-deque/src/deque.rs
@@ -385,7 +385,7 @@ impl<T> Worker<T> {
         b.wrapping_sub(f).max(0) as usize
     }
 
-    /// Pushes a task into the queue.
+    /// Pushes a task into the queue and returns the relative slot index written to.
     ///
     /// # Examples
     ///
@@ -393,10 +393,10 @@ impl<T> Worker<T> {
     /// use crossbeam_deque::Worker;
     ///
     /// let w = Worker::new_lifo();
-    /// w.push(1);
-    /// w.push(2);
+    /// assert_eq!(w.push(1), 0);
+    /// assert_eq!(w.push(2), 1);
     /// ```
-    pub fn push(&self, task: T) {
+    pub fn push(&self, task: T) -> isize {
         // Load the back index, front index, and buffer.
         let b = self.inner.back.load(Ordering::Relaxed);
         let f = self.inner.front.load(Ordering::Acquire);
@@ -429,7 +429,7 @@ impl<T> Worker<T> {
         };
 
         // Increment the back index.
-        self.inner.back.store(b.wrapping_add(1), store_order);
+        self.inner.back.swap(b.wrapping_add(1), store_order) - f
     }
 
     /// Pops a task from the queue.


### PR DESCRIPTION
See https://github.com/crossbeam-rs/crossbeam/pull/743

It is useful to know when crossbeam::deque::Worker::push adds the first task to an empty deque as this can be used to facilitate simple batching by triggering tokio::task::spawn and work stealing to completion.

Here's an example of the how this change could be used

```rust
pub fn batch_update_cache<K, V>(runtime_handle: &Handle, data: (String, Vec<u8>)) {
  thread_local! {
    static QUEUE: Worker<(String, Vec<u8>)> = Worker::new_fifo();
  }

  QUEUE.with(|queue| {
    if queue.push(data).eq(&0) {
      let stealer = queue.stealer();

      runtime_handle.spawn(async move {
        let mut cache = vec![];

        cache.extend(std::iter::from_fn(|| loop {
          match stealer.steal() {
            Steal::Success(data) => break Some(data),
            Steal::Retry => continue,
            Steal::Empty => break None,
          }
        }));

        /// do something with cache
      });
    }
  });
}
```