### PR TITLE
Added lossy channel variety based on bounded

### DIFF
--- a/crossbeam-channel/benches/crossbeam.rs
+++ b/crossbeam-channel/benches/crossbeam.rs
@@ -4,7 +4,7 @@ extern crate test;
 
 use std::num::NonZeroUsize;
 
-use crossbeam_channel::{bounded, unbounded};
+use crossbeam_channel::{bounded, lossy, unbounded};
 use crossbeam_utils::thread::scope;
 use test::Bencher;
 
@@ -536,6 +536,132 @@ mod bounded_1 {
                     while r1.recv().is_ok() {
                         for i in 0..steps {
                             s.send(i as i32).unwrap();
+                        }
+                        s2.send(()).unwrap();
+                    }
+                });
+            }
+            for _ in 0..threads / 2 {
+                scope.spawn(|_| {
+                    while r1.recv().is_ok() {
+                        for _ in 0..steps {
+                            r.recv().unwrap();
+                        }
+                        s2.send(()).unwrap();
+                    }
+                });
+            }
+
+            b.iter(|| {
+                for _ in 0..threads {
+                    s1.send(()).unwrap();
+                }
+                for _ in 0..threads {
+                    r2.recv().unwrap();
+                }
+            });
+            drop(s1);
+        })
+        .unwrap();
+    }
+}
+
+mod lossy {
+    use super::*;
+
+    #[bench]
+    fn create(b: &mut Bencher) {
+        b.iter(|| lossy::<i32>(1));
+    }
+
+    #[bench]
+    fn inout(b: &mut Bencher) {
+        let (s, r) = lossy::<i32>(1);
+        b.iter(|| {
+            s.lossy_send(0).unwrap();
+            r.recv().unwrap();
+        });
+    }
+
+    #[bench]
+    fn spsc(b: &mut Bencher) {
+        let steps = TOTAL_STEPS;
+        let (s, r) = lossy::<i32>(steps);
+
+        let (s1, r1) = bounded(0);
+        let (s2, r2) = bounded(0);
+        scope(|scope| {
+            scope.spawn(|_| {
+                while r1.recv().is_ok() {
+                    for i in 0..steps {
+                        let _ = s.lossy_send(i as i32);
+                    }
+                    s2.send(()).unwrap();
+                }
+            });
+
+            b.iter(|| {
+                s1.send(()).unwrap();
+                for _ in 0..steps {
+                    r.recv().unwrap();
+                }
+                r2.recv().unwrap();
+            });
+            drop(s1);
+        })
+        .unwrap();
+    }
+
+    #[bench]
+    fn mpsc(b: &mut Bencher) {
+        let threads = num_cpus() - 1;
+        let steps = TOTAL_STEPS / threads;
+        let (s, r) = lossy::<i32>(steps * threads);
+
+        let (s1, r1) = bounded(0);
+        let (s2, r2) = bounded(0);
+        scope(|scope| {
+            for _ in 0..threads {
+                scope.spawn(|_| {
+                    while r1.recv().is_ok() {
+                        for i in 0..steps {
+                            let _ = s.lossy_send(i as i32);
+                        }
+                        s2.send(()).unwrap();
+                    }
+                });
+            }
+
+            b.iter(|| {
+                for _ in 0..threads {
+                    s1.send(()).unwrap();
+                }
+                for _ in 0..steps * threads {
+                    r.recv().unwrap();
+                }
+                for _ in 0..threads {
+                    r2.recv().unwrap();
+                }
+            });
+            drop(s1);
+        })
+        .unwrap();
+    }
+
+    #[bench]
+    fn mpmc(b: &mut Bencher) {
+        let threads = num_cpus();
+        let steps = TOTAL_STEPS / threads;
+        let (s, r) = lossy::<i32>(steps * threads);
+
+        let (s1, r1) = bounded(0);
+        let (s2, r2) = bounded(0);
+        scope(|scope| {
+            for _ in 0..threads / 2 {
+                scope.spawn(|_| {
+                    while r1.recv().is_ok() {
+                        for i in 0..steps {
+                            let _ = s.lossy_send(i as i32);
                         }
                         s2.send(()).unwrap();
                     }

--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -132,6 +132,43 @@ pub fn bounded<T>(cap: usize) -> (Sender<T>, Receiver<T>) {
     }
 }
 
+/// Creates a lossy bounded channel with a capacity of `cap` messages.
+///
+/// A lossy channel behaves like [`bounded`], except that [`Sender::try_send`] on a full channel
+/// evicts the oldest message and returns it inside [`TrySendError::Full`] instead of returning
+/// the incoming message. [`Sender::send`] still blocks when the channel is full.
+///
+/// # Panics
+///
+/// Panics if `cap` is zero.
+///
+/// # Examples
+///
+/// ```
+/// use crossbeam_channel::{lossy, TrySendError};
+///
+/// let (s, r) = lossy(2);
+///
+/// assert!(s.try_send(1).is_ok());
+/// assert!(s.try_send(2).is_ok());
+///
+/// // Channel is full - oldest message (1) is evicted.
+/// assert_eq!(s.try_send(3), Err(TrySendError::Full(1)));
+/// assert_eq!(r.recv(), Ok(2));
+/// assert_eq!(r.recv(), Ok(3));
+/// ```
+pub fn lossy<T>(cap: usize) -> (Sender<T>, Receiver<T>) {
+    assert!(cap > 0, "lossy channel capacity must be positive");
+    let (s, r) = counter::new(flavors::array::Channel::with_capacity_lossy(cap));
+    let s = Sender {
+        flavor: SenderFlavor::Array(s),
+    };
+    let r = Receiver {
+        flavor: ReceiverFlavor::Array(r),
+    };
+    (s, r)
+}
+
 /// Creates a receiver that delivers a message after a certain duration of time.
 ///
 /// The channel is bounded with capacity of 1 and never gets disconnected. Exactly one message will

--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -138,10 +138,6 @@ pub fn bounded<T>(cap: usize) -> (Sender<T>, Receiver<T>) {
 /// evicts the oldest message and returns it inside [`TrySendError::Full`] instead of returning
 /// the incoming message. [`Sender::send`] still blocks when the channel is full.
 ///
-/// # Panics
-///
-/// Panics if `cap` is zero.
-///
 /// # Examples
 ///
 /// ```
@@ -158,7 +154,6 @@ pub fn bounded<T>(cap: usize) -> (Sender<T>, Receiver<T>) {
 /// assert_eq!(r.recv(), Ok(3));
 /// ```
 pub fn lossy<T>(cap: usize) -> (Sender<T>, Receiver<T>) {
-    assert!(cap > 0, "lossy channel capacity must be positive");
     let (s, r) = counter::new(flavors::array::Channel::with_capacity_lossy(cap));
     let s = Sender {
         flavor: SenderFlavor::Array(s),

--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -13,7 +13,10 @@ use std::time::Instant;
 use crate::{
     context::Context,
     counter,
-    err::{RecvError, RecvTimeoutError, SendError, SendTimeoutError, TryRecvError, TrySendError},
+    err::{
+        LossySendError, RecvError, RecvTimeoutError, SendError, SendTimeoutError, TryRecvError,
+        TrySendError,
+    },
     flavors,
     select::{Operation, SelectHandle, Token},
 };
@@ -132,36 +135,35 @@ pub fn bounded<T>(cap: usize) -> (Sender<T>, Receiver<T>) {
     }
 }
 
-/// Creates a lossy bounded channel with a capacity of `cap` messages.
+/// Creates a bounded channel with a capacity of `cap` messages, intended for use with
+/// [`Sender::lossy_send`].
 ///
-/// A lossy channel behaves like [`bounded`], except that [`Sender::try_send`] on a full channel
-/// evicts the oldest message and returns it inside [`TrySendError::Full`] instead of returning
-/// the incoming message. [`Sender::send`] still blocks when the channel is full.
+/// This is equivalent to [`bounded`] with the restriction that `cap` must be positive, since
+/// lossy eviction semantics require a buffer. Use [`Sender::lossy_send`] on the returned
+/// sender to get eviction behavior when the channel is full.
+///
+/// # Panics
+///
+/// Panics if `cap` is zero.
 ///
 /// # Examples
 ///
 /// ```
-/// use crossbeam_channel::{lossy, TrySendError};
+/// use crossbeam_channel::{lossy, LossySendError};
 ///
 /// let (s, r) = lossy(2);
 ///
-/// assert!(s.try_send(1).is_ok());
-/// assert!(s.try_send(2).is_ok());
+/// assert!(s.lossy_send(1).is_ok());
+/// assert!(s.lossy_send(2).is_ok());
 ///
-/// // Channel is full - oldest message (1) is evicted.
-/// assert_eq!(s.try_send(3), Err(TrySendError::Full(1)));
+/// // Channel is full — oldest message (1) is evicted.
+/// assert_eq!(s.lossy_send(3), Err(LossySendError::Evicted(1)));
 /// assert_eq!(r.recv(), Ok(2));
 /// assert_eq!(r.recv(), Ok(3));
 /// ```
 pub fn lossy<T>(cap: usize) -> (Sender<T>, Receiver<T>) {
-    let (s, r) = counter::new(flavors::array::Channel::with_capacity_lossy(cap));
-    let s = Sender {
-        flavor: SenderFlavor::Array(s),
-    };
-    let r = Receiver {
-        flavor: ReceiverFlavor::Array(r),
-    };
-    (s, r)
+    assert!(cap > 0, "capacity must be positive");
+    bounded(cap)
 }
 
 /// Creates a receiver that delivers a message after a certain duration of time.
@@ -444,6 +446,42 @@ impl<T> Sender<T> {
             SenderFlavor::Array(chan) => chan.try_send(msg),
             SenderFlavor::List(chan) => chan.try_send(msg),
             SenderFlavor::Zero(chan) => chan.try_send(msg),
+        }
+    }
+
+    /// Sends a message into the channel without blocking, evicting the oldest message if the
+    /// channel is full.
+    ///
+    /// For bounded channels, the oldest message is evicted and returned as
+    /// `LossySendError::Evicted(old)` if the channel is full. The new message is always sent
+    /// successfully unless the channel is disconnected.
+    ///
+    /// For unbounded channels, this always succeeds if not disconnected, since the channel is
+    /// never full.
+    ///
+    /// For zero-capacity channels, there is no buffer to evict from: returns
+    /// `LossySendError::NotSent(msg)` if no receiver is waiting.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_channel::{bounded, LossySendError};
+    ///
+    /// let (s, r) = bounded(2);
+    ///
+    /// assert!(s.lossy_send(1).is_ok());
+    /// assert!(s.lossy_send(2).is_ok());
+    ///
+    /// // Channel is full — oldest message (1) is evicted.
+    /// assert_eq!(s.lossy_send(3), Err(LossySendError::Evicted(1)));
+    /// assert_eq!(r.recv(), Ok(2));
+    /// assert_eq!(r.recv(), Ok(3));
+    /// ```
+    pub fn lossy_send(&self, msg: T) -> Result<(), LossySendError<T>> {
+        match &self.flavor {
+            SenderFlavor::Array(chan) => chan.lossy_send(msg),
+            SenderFlavor::List(chan) => chan.lossy_send(msg),
+            SenderFlavor::Zero(chan) => chan.lossy_send(msg),
         }
     }
 

--- a/crossbeam-channel/src/err.rs
+++ b/crossbeam-channel/src/err.rs
@@ -265,7 +265,7 @@ impl<T> LossySendError<T> {
     /// # Examples
     ///
     /// ```
-    /// use crossbeam_channel::{bounded, LossySendError};
+    /// use crossbeam_channel::bounded;
     ///
     /// let (s, r) = bounded(1);
     /// s.lossy_send(1).unwrap();

--- a/crossbeam-channel/src/err.rs
+++ b/crossbeam-channel/src/err.rs
@@ -28,6 +28,26 @@ pub enum TrySendError<T> {
     Disconnected(T),
 }
 
+/// An error returned from the [`lossy_send`] method.
+///
+/// The error contains a message so it can be recovered.
+///
+/// [`lossy_send`]: super::Sender::lossy_send
+#[derive(PartialEq, Eq, Clone, Copy)]
+pub enum LossySendError<T> {
+    /// The channel was full. The oldest message was evicted and is returned here.
+    /// The new message was sent successfully.
+    Evicted(T),
+
+    /// The message could not be sent because the channel is a zero-capacity channel
+    /// and there was no receiver available. The original message is returned.
+    NotSent(T),
+
+    /// The message could not be sent because the channel is disconnected.
+    /// The original message is returned.
+    Disconnected(T),
+}
+
 /// An error returned from the [`send_timeout`] method.
 ///
 /// The error contains the message being sent so it can be recovered.
@@ -201,6 +221,75 @@ impl<T> TrySendError<T> {
     /// Returns `true` if the send operation failed because the channel is full.
     pub fn is_full(&self) -> bool {
         matches!(self, Self::Full(_))
+    }
+
+    /// Returns `true` if the send operation failed because the channel is disconnected.
+    pub fn is_disconnected(&self) -> bool {
+        matches!(self, Self::Disconnected(_))
+    }
+}
+
+impl<T> fmt::Debug for LossySendError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Self::Evicted(..) => "Evicted(..)".fmt(f),
+            Self::NotSent(..) => "NotSent(..)".fmt(f),
+            Self::Disconnected(..) => "Disconnected(..)".fmt(f),
+        }
+    }
+}
+
+impl<T> fmt::Display for LossySendError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Self::Evicted(..) => "sending on a full channel evicted the oldest message".fmt(f),
+            Self::NotSent(..) => "sending on a zero-capacity channel with no receiver".fmt(f),
+            Self::Disconnected(..) => "sending on a disconnected channel".fmt(f),
+        }
+    }
+}
+
+impl<T: Send> error::Error for LossySendError<T> {}
+
+impl<T> From<SendError<T>> for LossySendError<T> {
+    fn from(err: SendError<T>) -> Self {
+        match err {
+            SendError(t) => Self::Disconnected(t),
+        }
+    }
+}
+
+impl<T> LossySendError<T> {
+    /// Unwraps the message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_channel::{bounded, LossySendError};
+    ///
+    /// let (s, r) = bounded(1);
+    /// s.lossy_send(1).unwrap();
+    ///
+    /// if let Err(err) = s.lossy_send(2) {
+    ///     assert_eq!(err.into_inner(), 1);
+    /// }
+    /// ```
+    pub fn into_inner(self) -> T {
+        match self {
+            Self::Evicted(v) => v,
+            Self::NotSent(v) => v,
+            Self::Disconnected(v) => v,
+        }
+    }
+
+    /// Returns `true` if the send operation evicted an older message from the channel.
+    pub fn is_evicted(&self) -> bool {
+        matches!(self, Self::Evicted(_))
+    }
+
+    /// Returns `true` if the message could not be sent.
+    pub fn is_not_sent(&self) -> bool {
+        matches!(self, Self::NotSent(_))
     }
 
     /// Returns `true` if the send operation failed because the channel is disconnected.

--- a/crossbeam-channel/src/flavors/array.rs
+++ b/crossbeam-channel/src/flavors/array.rs
@@ -21,7 +21,7 @@ use crossbeam_utils::{Backoff, CachePadded};
 
 use crate::{
     context::Context,
-    err::{RecvTimeoutError, SendTimeoutError, TryRecvError, TrySendError},
+    err::{LossySendError, RecvTimeoutError, SendTimeoutError, TryRecvError, TrySendError},
     select::{Operation, SelectHandle, Selected, Token},
     waker::SyncWaker,
 };
@@ -89,23 +89,11 @@ pub(crate) struct Channel<T> {
 
     /// Receivers waiting while the channel is empty and not disconnected.
     receivers: SyncWaker,
-
-    /// If true, `try_send` on a full channel evicts the oldest message instead of dropping the incoming one.
-    lossy: bool,
 }
 
 impl<T> Channel<T> {
     /// Creates a bounded channel of capacity `cap`.
     pub(crate) fn with_capacity(cap: usize) -> Self {
-        Self::new(cap, false)
-    }
-
-    /// Creates a lossy bounded channel of capacity `cap`.
-    pub(crate) fn with_capacity_lossy(cap: usize) -> Self {
-        Self::new(cap, true)
-    }
-
-    fn new(cap: usize, lossy: bool) -> Self {
         assert!(cap > 0, "capacity must be positive");
 
         // Compute constants `mark_bit` and `one_lap`.
@@ -137,7 +125,6 @@ impl<T> Channel<T> {
             tail: CachePadded::new(AtomicUsize::new(tail)),
             senders: SyncWaker::new(),
             receivers: SyncWaker::new(),
-            lossy,
         }
     }
 
@@ -334,29 +321,22 @@ impl<T> Channel<T> {
 
     /// Attempts to send a message into the channel.
     pub(crate) fn try_send(&self, msg: T) -> Result<(), TrySendError<T>> {
-        if self.lossy {
-            self.force_send(msg)
+        let token = &mut Token::default();
+        if self.start_send(token) {
+            unsafe { self.write(token, msg).map_err(TrySendError::Disconnected) }
         } else {
-            let token = &mut Token::default();
-            if self.start_send(token) {
-                unsafe { self.write(token, msg).map_err(TrySendError::Disconnected) }
-            } else {
-                Err(TrySendError::Full(msg))
-            }
+            Err(TrySendError::Full(msg))
         }
     }
 
     /// Sends a message, evicting the oldest if the channel is full.
-    ///
-    /// Returns `Ok(())` if there was space, `Err(TrySendError::Full(evicted))` if the oldest
-    /// message was displaced, or `Err(TrySendError::Disconnected(msg))` if disconnected.
-    fn force_send(&self, msg: T) -> Result<(), TrySendError<T>> {
+    pub(crate) fn lossy_send(&self, msg: T) -> Result<(), LossySendError<T>> {
         let backoff = Backoff::new();
         let mut tail = self.tail.load(Ordering::Relaxed);
 
         loop {
             if tail & self.mark_bit != 0 {
-                return Err(TrySendError::Disconnected(msg));
+                return Err(LossySendError::Disconnected(msg));
             }
 
             let index = tail & (self.mark_bit - 1);
@@ -410,7 +390,7 @@ impl<T> Channel<T> {
                     slot.stamp.store(tail + 1, Ordering::Release);
 
                     self.receivers.notify();
-                    return Err(TrySendError::Full(old));
+                    return Err(LossySendError::Evicted(old));
                 }
 
                 backoff.spin();

--- a/crossbeam-channel/src/flavors/array.rs
+++ b/crossbeam-channel/src/flavors/array.rs
@@ -405,7 +405,8 @@ impl<T> Channel<T> {
                 {
                     self.tail.store(new_tail, Ordering::SeqCst);
 
-                    let old = unsafe { slot.msg.get().replace(MaybeUninit::new(msg)).assume_init() };
+                    let old =
+                        unsafe { slot.msg.get().replace(MaybeUninit::new(msg)).assume_init() };
                     slot.stamp.store(tail + 1, Ordering::Release);
 
                     self.receivers.notify();

--- a/crossbeam-channel/src/flavors/array.rs
+++ b/crossbeam-channel/src/flavors/array.rs
@@ -89,11 +89,23 @@ pub(crate) struct Channel<T> {
 
     /// Receivers waiting while the channel is empty and not disconnected.
     receivers: SyncWaker,
+
+    /// If true, `try_send` on a full channel evicts the oldest message instead of dropping the incoming one.
+    lossy: bool,
 }
 
 impl<T> Channel<T> {
     /// Creates a bounded channel of capacity `cap`.
     pub(crate) fn with_capacity(cap: usize) -> Self {
+        Self::new(cap, false)
+    }
+
+    /// Creates a lossy bounded channel of capacity `cap`.
+    pub(crate) fn with_capacity_lossy(cap: usize) -> Self {
+        Self::new(cap, true)
+    }
+
+    fn new(cap: usize, lossy: bool) -> Self {
         assert!(cap > 0, "capacity must be positive");
 
         // Compute constants `mark_bit` and `one_lap`.
@@ -125,6 +137,7 @@ impl<T> Channel<T> {
             tail: CachePadded::new(AtomicUsize::new(tail)),
             senders: SyncWaker::new(),
             receivers: SyncWaker::new(),
+            lossy,
         }
     }
 
@@ -321,11 +334,90 @@ impl<T> Channel<T> {
 
     /// Attempts to send a message into the channel.
     pub(crate) fn try_send(&self, msg: T) -> Result<(), TrySendError<T>> {
-        let token = &mut Token::default();
-        if self.start_send(token) {
-            unsafe { self.write(token, msg).map_err(TrySendError::Disconnected) }
+        if self.lossy {
+            self.force_send(msg)
         } else {
-            Err(TrySendError::Full(msg))
+            let token = &mut Token::default();
+            if self.start_send(token) {
+                unsafe { self.write(token, msg).map_err(TrySendError::Disconnected) }
+            } else {
+                Err(TrySendError::Full(msg))
+            }
+        }
+    }
+
+    /// Sends a message, evicting the oldest if the channel is full.
+    ///
+    /// Returns `Ok(())` if there was space, `Err(TrySendError::Full(evicted))` if the oldest
+    /// message was displaced, or `Err(TrySendError::Disconnected(msg))` if disconnected.
+    fn force_send(&self, msg: T) -> Result<(), TrySendError<T>> {
+        let backoff = Backoff::new();
+        let mut tail = self.tail.load(Ordering::Relaxed);
+
+        loop {
+            if tail & self.mark_bit != 0 {
+                return Err(TrySendError::Disconnected(msg));
+            }
+
+            let index = tail & (self.mark_bit - 1);
+            let lap = tail & !(self.one_lap - 1);
+
+            let new_tail = if index + 1 < self.cap() {
+                tail + 1
+            } else {
+                lap.wrapping_add(self.one_lap)
+            };
+
+            debug_assert!(index < self.buffer.len());
+            let slot = unsafe { self.buffer.get_unchecked(index) };
+            let stamp = slot.stamp.load(Ordering::Acquire);
+
+            if tail == stamp {
+                // Slot is empty - try to claim it.
+                match self.tail.compare_exchange_weak(
+                    tail,
+                    new_tail,
+                    Ordering::SeqCst,
+                    Ordering::Relaxed,
+                ) {
+                    Ok(_) => {
+                        unsafe { slot.msg.get().write(MaybeUninit::new(msg)) }
+                        slot.stamp.store(tail + 1, Ordering::Release);
+                        self.receivers.notify();
+                        return Ok(());
+                    }
+                    Err(t) => {
+                        tail = t;
+                        backoff.spin();
+                    }
+                }
+            } else if stamp.wrapping_add(self.one_lap) == tail + 1 {
+                // Slot is full - try to evict the oldest.
+                atomic::fence(Ordering::SeqCst);
+
+                let head = tail.wrapping_sub(self.one_lap);
+                let new_head = new_tail.wrapping_sub(self.one_lap);
+
+                if self
+                    .head
+                    .compare_exchange_weak(head, new_head, Ordering::SeqCst, Ordering::Relaxed)
+                    .is_ok()
+                {
+                    self.tail.store(new_tail, Ordering::SeqCst);
+
+                    let old = unsafe { slot.msg.get().replace(MaybeUninit::new(msg)).assume_init() };
+                    slot.stamp.store(tail + 1, Ordering::Release);
+
+                    self.receivers.notify();
+                    return Err(TrySendError::Full(old));
+                }
+
+                backoff.spin();
+                tail = self.tail.load(Ordering::Relaxed);
+            } else {
+                backoff.snooze();
+                tail = self.tail.load(Ordering::Relaxed);
+            }
         }
     }
 

--- a/crossbeam-channel/src/flavors/list.rs
+++ b/crossbeam-channel/src/flavors/list.rs
@@ -16,7 +16,7 @@ use crossbeam_utils::{Backoff, CachePadded};
 use crate::{
     alloc_helper::Global,
     context::Context,
-    err::{RecvTimeoutError, SendTimeoutError, TryRecvError, TrySendError},
+    err::{LossySendError, RecvTimeoutError, SendTimeoutError, TryRecvError, TrySendError},
     select::{Operation, SelectHandle, Selected, Token},
     waker::SyncWaker,
 };
@@ -434,6 +434,16 @@ impl<T> Channel<T> {
         self.send(msg, None).map_err(|err| match err {
             SendTimeoutError::Disconnected(msg) => TrySendError::Disconnected(msg),
             SendTimeoutError::Timeout(_) => unreachable!(),
+        })
+    }
+
+    /// Sends a message, evicting the oldest if the channel is full.
+    ///
+    /// An unbounded channel is never full, so this always succeeds if not disconnected.
+    pub(crate) fn lossy_send(&self, msg: T) -> Result<(), LossySendError<T>> {
+        self.try_send(msg).map_err(|err| match err {
+            TrySendError::Full(_) => unreachable!(),
+            TrySendError::Disconnected(msg) => LossySendError::Disconnected(msg),
         })
     }
 

--- a/crossbeam-channel/src/flavors/zero.rs
+++ b/crossbeam-channel/src/flavors/zero.rs
@@ -16,7 +16,7 @@ use crossbeam_utils::Backoff;
 
 use crate::{
     context::Context,
-    err::{RecvTimeoutError, SendTimeoutError, TryRecvError, TrySendError},
+    err::{LossySendError, RecvTimeoutError, SendTimeoutError, TryRecvError, TrySendError},
     select::{Operation, SelectHandle, Selected, Token},
     waker::Waker,
 };
@@ -218,6 +218,15 @@ impl<T> Channel<T> {
         } else {
             Err(TrySendError::Full(msg))
         }
+    }
+
+    /// A zero-capacity channel has no buffer to evict from, so a lossy send will either
+    /// succeed or return one of the variants `NotSent` or `Disconnected`.
+    pub(crate) fn lossy_send(&self, msg: T) -> Result<(), LossySendError<T>> {
+        self.try_send(msg).map_err(|err| match err {
+            TrySendError::Full(msg) => LossySendError::NotSent(msg),
+            TrySendError::Disconnected(msg) => LossySendError::Disconnected(msg),
+        })
     }
 
     /// Sends a message into the channel.

--- a/crossbeam-channel/src/lib.rs
+++ b/crossbeam-channel/src/lib.rs
@@ -377,7 +377,8 @@ pub mod internal {
 #[cfg(feature = "std")]
 pub use crate::{
     channel::{
-        IntoIter, Iter, Receiver, Sender, TryIter, after, at, bounded, never, tick, unbounded,
+        IntoIter, Iter, Receiver, Sender, TryIter, after, at, bounded, lossy, never, tick,
+        unbounded,
     },
     err::{
         ReadyTimeoutError, RecvError, RecvTimeoutError, SelectTimeoutError, SendError,

--- a/crossbeam-channel/src/lib.rs
+++ b/crossbeam-channel/src/lib.rs
@@ -381,8 +381,8 @@ pub use crate::{
         unbounded,
     },
     err::{
-        ReadyTimeoutError, RecvError, RecvTimeoutError, SelectTimeoutError, SendError,
-        SendTimeoutError, TryReadyError, TryRecvError, TrySelectError, TrySendError,
+        LossySendError, ReadyTimeoutError, RecvError, RecvTimeoutError, SelectTimeoutError,
+        SendError, SendTimeoutError, TryReadyError, TryRecvError, TrySelectError, TrySendError,
     },
     select::{Select, SelectedOperation},
 };

--- a/crossbeam-channel/tests/lossy.rs
+++ b/crossbeam-channel/tests/lossy.rs
@@ -5,7 +5,9 @@ use std::sync::{
     atomic::{AtomicUsize, Ordering},
 };
 
-use crossbeam_channel::{RecvError, SendError, TryRecvError, TrySendError, lossy};
+use crossbeam_channel::{
+    LossySendError, RecvError, SendError, TryRecvError, bounded, lossy, unbounded,
+};
 use crossbeam_utils::thread::scope;
 
 #[test]
@@ -33,9 +35,9 @@ fn capacity() {
 fn capacity_one() {
     let (s, r) = lossy(1);
 
-    assert!(s.try_send(1).is_ok());
-    assert_eq!(s.try_send(2), Err(TrySendError::Full(1)));
-    assert_eq!(s.try_send(3), Err(TrySendError::Full(2)));
+    assert!(s.lossy_send(1).is_ok());
+    assert_eq!(s.lossy_send(2), Err(LossySendError::Evicted(1)));
+    assert_eq!(s.lossy_send(3), Err(LossySendError::Evicted(2)));
 
     assert_eq!(r.recv(), Ok(3));
     assert_eq!(r.try_recv(), Err(TryRecvError::Empty));
@@ -55,18 +57,18 @@ fn len_empty_full() {
     assert!(s.is_empty());
     assert!(!s.is_full());
 
-    s.try_send(()).unwrap();
+    s.lossy_send(()).unwrap();
     assert_eq!(s.len(), 1);
     assert!(!s.is_empty());
     assert!(!s.is_full());
 
-    s.try_send(()).unwrap();
+    s.lossy_send(()).unwrap();
     assert_eq!(s.len(), 2);
     assert!(!s.is_empty());
     assert!(s.is_full());
 
     // Eviction keeps the channel full.
-    let _ = s.try_send(());
+    let _ = s.lossy_send(());
     assert_eq!(s.len(), 2);
     assert!(s.is_full());
 
@@ -76,16 +78,16 @@ fn len_empty_full() {
 }
 
 #[test]
-fn try_send_evicts_oldest() {
+fn lossy_send_evicts_oldest() {
     let (s, r) = lossy(2);
 
-    assert!(s.try_send(1).is_ok());
-    assert!(s.try_send(2).is_ok());
+    assert!(s.lossy_send(1).is_ok());
+    assert!(s.lossy_send(2).is_ok());
 
     // Full - evicts oldest (1).
-    assert_eq!(s.try_send(3), Err(TrySendError::Full(1)));
+    assert_eq!(s.lossy_send(3), Err(LossySendError::Evicted(1)));
     // Evicts 2.
-    assert_eq!(s.try_send(4), Err(TrySendError::Full(2)));
+    assert_eq!(s.lossy_send(4), Err(LossySendError::Evicted(2)));
 
     assert_eq!(r.recv(), Ok(3));
     assert_eq!(r.recv(), Ok(4));
@@ -93,17 +95,17 @@ fn try_send_evicts_oldest() {
 }
 
 #[test]
-fn try_send_no_eviction_when_space() {
+fn lossy_send_no_eviction_when_space() {
     let (s, r) = lossy(3);
 
-    assert!(s.try_send(1).is_ok());
-    assert!(s.try_send(2).is_ok());
-    assert!(s.try_send(3).is_ok());
+    assert!(s.lossy_send(1).is_ok());
+    assert!(s.lossy_send(2).is_ok());
+    assert!(s.lossy_send(3).is_ok());
 
     assert_eq!(r.recv(), Ok(1));
 
     // Space available now.
-    assert!(s.try_send(4).is_ok());
+    assert!(s.lossy_send(4).is_ok());
 
     assert_eq!(r.recv(), Ok(2));
     assert_eq!(r.recv(), Ok(3));
@@ -135,8 +137,8 @@ fn send_blocks_when_full() {
 #[test]
 fn recv_after_disconnect() {
     let (s, r) = lossy(2);
-    s.try_send(1).unwrap();
-    s.try_send(2).unwrap();
+    s.lossy_send(1).unwrap();
+    s.lossy_send(2).unwrap();
     drop(s);
 
     assert_eq!(r.recv(), Ok(1));
@@ -148,12 +150,12 @@ fn recv_after_disconnect() {
 fn send_after_disconnect() {
     let (s, r) = lossy(100);
 
-    s.try_send(1).unwrap();
-    s.try_send(2).unwrap();
+    s.lossy_send(1).unwrap();
+    s.lossy_send(2).unwrap();
     drop(r);
 
     assert_eq!(s.send(3), Err(SendError(3)));
-    assert_eq!(s.try_send(4), Err(TrySendError::Disconnected(4)));
+    assert_eq!(s.lossy_send(4), Err(LossySendError::Disconnected(4)));
 }
 
 #[test]
@@ -176,11 +178,11 @@ fn disconnect_wakes_sender() {
 }
 
 #[test]
-fn try_send_disconnected() {
+fn lossy_send_disconnected() {
     let (s, r) = lossy(2);
     drop(r);
 
-    assert_eq!(s.try_send(1), Err(TrySendError::Disconnected(1)));
+    assert_eq!(s.lossy_send(1), Err(LossySendError::Disconnected(1)));
 }
 
 #[test]
@@ -198,15 +200,15 @@ fn drops() {
 
     DROPS.store(0, Ordering::SeqCst);
     let (s, r) = lossy(2);
-    s.try_send(DropCounter).unwrap();
-    s.try_send(DropCounter).unwrap();
+    s.lossy_send(DropCounter).unwrap();
+    s.lossy_send(DropCounter).unwrap();
     assert_eq!(DROPS.load(Ordering::SeqCst), 0);
 
     // Evict oldest - should drop it.
-    let _ = s.try_send(DropCounter);
+    let _ = s.lossy_send(DropCounter);
     assert_eq!(DROPS.load(Ordering::SeqCst), 1);
 
-    let _ = s.try_send(DropCounter);
+    let _ = s.lossy_send(DropCounter);
     assert_eq!(DROPS.load(Ordering::SeqCst), 2);
 
     // Remaining items dropped when channel is dropped.
@@ -248,7 +250,7 @@ fn mpmc_lossy() {
             let s = s.clone();
             scope.spawn(move |_| {
                 for i in 0..100 {
-                    let _ = s.try_send(i);
+                    let _ = s.lossy_send(i);
                 }
             });
         }
@@ -269,4 +271,38 @@ fn mpmc_lossy() {
 
     // Some messages may have been evicted, but we should have received some.
     assert!(total.load(Ordering::Relaxed) > 0);
+}
+
+// Tests for lossy_send on non-lossy channels.
+
+#[test]
+fn lossy_send_on_unbounded() {
+    let (s, r) = unbounded();
+
+    assert!(s.lossy_send(1).is_ok());
+    assert!(s.lossy_send(2).is_ok());
+    assert!(s.lossy_send(3).is_ok());
+
+    assert_eq!(r.recv(), Ok(1));
+    assert_eq!(r.recv(), Ok(2));
+    assert_eq!(r.recv(), Ok(3));
+
+    drop(r);
+    assert_eq!(s.lossy_send(4), Err(LossySendError::Disconnected(4)));
+}
+
+#[test]
+fn lossy_send_on_zero_capacity() {
+    let (s, r) = bounded::<i32>(0);
+
+    // No receiver waiting — NotSent.
+    assert_eq!(s.lossy_send(1), Err(LossySendError::NotSent(1)));
+
+    drop(r);
+    assert_eq!(s.lossy_send(2), Err(LossySendError::Disconnected(2)));
+
+    // The success path (receiver already waiting) is not tested here because there is no
+    // simple reliable way to guarantee the receiver is blocked in recv() before lossy_send
+    // fires. That path delegates to zero::try_send internally, which is covered by the
+    // zero-capacity channel tests.
 }

--- a/crossbeam-channel/tests/lossy.rs
+++ b/crossbeam-channel/tests/lossy.rs
@@ -1,9 +1,8 @@
 //! Tests for the lossy bounded channel.
 
-use std::{
-    sync::atomic::{AtomicUsize, Ordering},
-    thread,
-    time::Duration,
+use std::sync::{
+    Barrier,
+    atomic::{AtomicUsize, Ordering},
 };
 
 use crossbeam_channel::{RecvError, SendError, TryRecvError, TrySendError, lossy};
@@ -43,7 +42,7 @@ fn capacity_one() {
 }
 
 #[test]
-#[should_panic(expected = "lossy channel capacity must be positive")]
+#[should_panic(expected = "capacity must be positive")]
 fn zero_capacity_panics() {
     let _ = lossy::<i32>(0);
 }
@@ -116,16 +115,18 @@ fn send_blocks_when_full() {
     let (s, r) = lossy(1);
     s.send(1).unwrap();
 
+    let barrier = Barrier::new(2);
     let received = AtomicUsize::new(0);
     scope(|scope| {
         scope.spawn(|_| {
-            thread::sleep(Duration::from_millis(100));
             assert_eq!(r.recv(), Ok(1));
             received.store(1, Ordering::Release);
+            barrier.wait();
         });
 
         // If send evicted instead of blocking, it would return before the receiver runs.
-        assert!(s.send(2).is_ok());
+        s.send(2).unwrap();
+        barrier.wait();
         assert_eq!(received.load(Ordering::Acquire), 1);
     })
     .unwrap();
@@ -158,14 +159,16 @@ fn send_after_disconnect() {
 #[test]
 fn disconnect_wakes_sender() {
     let (s, r) = lossy(1);
+    let barrier = Barrier::new(2);
 
     scope(|scope| {
-        scope.spawn(move |_| {
+        scope.spawn(|_| {
             assert_eq!(s.send(()), Ok(()));
+            barrier.wait();
             assert_eq!(s.send(()), Err(SendError(())));
         });
-        scope.spawn(move |_| {
-            thread::sleep(Duration::from_millis(100));
+        scope.spawn(|_| {
+            barrier.wait();
             drop(r);
         });
     })

--- a/crossbeam-channel/tests/lossy.rs
+++ b/crossbeam-channel/tests/lossy.rs
@@ -1,0 +1,269 @@
+//! Tests for the lossy bounded channel.
+
+use std::{
+    sync::atomic::{AtomicUsize, Ordering},
+    thread,
+    time::Duration,
+};
+
+use crossbeam_channel::{RecvError, SendError, TryRecvError, TrySendError, lossy};
+use crossbeam_utils::thread::scope;
+
+#[test]
+fn smoke() {
+    let (s, r) = lossy(1);
+    s.send(7).unwrap();
+    assert_eq!(r.try_recv(), Ok(7));
+
+    s.send(8).unwrap();
+    assert_eq!(r.recv(), Ok(8));
+
+    assert_eq!(r.try_recv(), Err(TryRecvError::Empty));
+}
+
+#[test]
+fn capacity() {
+    for i in 1..10 {
+        let (s, r) = lossy::<()>(i);
+        assert_eq!(s.capacity(), Some(i));
+        assert_eq!(r.capacity(), Some(i));
+    }
+}
+
+#[test]
+fn capacity_one() {
+    let (s, r) = lossy(1);
+
+    assert!(s.try_send(1).is_ok());
+    assert_eq!(s.try_send(2), Err(TrySendError::Full(1)));
+    assert_eq!(s.try_send(3), Err(TrySendError::Full(2)));
+
+    assert_eq!(r.recv(), Ok(3));
+    assert_eq!(r.try_recv(), Err(TryRecvError::Empty));
+}
+
+#[test]
+#[should_panic(expected = "lossy channel capacity must be positive")]
+fn zero_capacity_panics() {
+    let _ = lossy::<i32>(0);
+}
+
+#[test]
+fn len_empty_full() {
+    let (s, r) = lossy(2);
+
+    assert_eq!(s.len(), 0);
+    assert!(s.is_empty());
+    assert!(!s.is_full());
+
+    s.try_send(()).unwrap();
+    assert_eq!(s.len(), 1);
+    assert!(!s.is_empty());
+    assert!(!s.is_full());
+
+    s.try_send(()).unwrap();
+    assert_eq!(s.len(), 2);
+    assert!(!s.is_empty());
+    assert!(s.is_full());
+
+    // Eviction keeps the channel full.
+    let _ = s.try_send(());
+    assert_eq!(s.len(), 2);
+    assert!(s.is_full());
+
+    r.recv().unwrap();
+    assert_eq!(r.len(), 1);
+    assert!(!r.is_full());
+}
+
+#[test]
+fn try_send_evicts_oldest() {
+    let (s, r) = lossy(2);
+
+    assert!(s.try_send(1).is_ok());
+    assert!(s.try_send(2).is_ok());
+
+    // Full - evicts oldest (1).
+    assert_eq!(s.try_send(3), Err(TrySendError::Full(1)));
+    // Evicts 2.
+    assert_eq!(s.try_send(4), Err(TrySendError::Full(2)));
+
+    assert_eq!(r.recv(), Ok(3));
+    assert_eq!(r.recv(), Ok(4));
+    assert_eq!(r.try_recv(), Err(TryRecvError::Empty));
+}
+
+#[test]
+fn try_send_no_eviction_when_space() {
+    let (s, r) = lossy(3);
+
+    assert!(s.try_send(1).is_ok());
+    assert!(s.try_send(2).is_ok());
+    assert!(s.try_send(3).is_ok());
+
+    assert_eq!(r.recv(), Ok(1));
+
+    // Space available now.
+    assert!(s.try_send(4).is_ok());
+
+    assert_eq!(r.recv(), Ok(2));
+    assert_eq!(r.recv(), Ok(3));
+    assert_eq!(r.recv(), Ok(4));
+}
+
+#[test]
+fn send_blocks_when_full() {
+    let (s, r) = lossy(1);
+    s.send(1).unwrap();
+
+    let received = AtomicUsize::new(0);
+    scope(|scope| {
+        scope.spawn(|_| {
+            thread::sleep(Duration::from_millis(100));
+            assert_eq!(r.recv(), Ok(1));
+            received.store(1, Ordering::Release);
+        });
+
+        // If send evicted instead of blocking, it would return before the receiver runs.
+        assert!(s.send(2).is_ok());
+        assert_eq!(received.load(Ordering::Acquire), 1);
+    })
+    .unwrap();
+}
+
+#[test]
+fn recv_after_disconnect() {
+    let (s, r) = lossy(2);
+    s.try_send(1).unwrap();
+    s.try_send(2).unwrap();
+    drop(s);
+
+    assert_eq!(r.recv(), Ok(1));
+    assert_eq!(r.recv(), Ok(2));
+    assert_eq!(r.recv(), Err(RecvError));
+}
+
+#[test]
+fn send_after_disconnect() {
+    let (s, r) = lossy(100);
+
+    s.try_send(1).unwrap();
+    s.try_send(2).unwrap();
+    drop(r);
+
+    assert_eq!(s.send(3), Err(SendError(3)));
+    assert_eq!(s.try_send(4), Err(TrySendError::Disconnected(4)));
+}
+
+#[test]
+fn disconnect_wakes_sender() {
+    let (s, r) = lossy(1);
+
+    scope(|scope| {
+        scope.spawn(move |_| {
+            assert_eq!(s.send(()), Ok(()));
+            assert_eq!(s.send(()), Err(SendError(())));
+        });
+        scope.spawn(move |_| {
+            thread::sleep(Duration::from_millis(100));
+            drop(r);
+        });
+    })
+    .unwrap();
+}
+
+#[test]
+fn try_send_disconnected() {
+    let (s, r) = lossy(2);
+    drop(r);
+
+    assert_eq!(s.try_send(1), Err(TrySendError::Disconnected(1)));
+}
+
+#[test]
+fn drops() {
+    static DROPS: AtomicUsize = AtomicUsize::new(0);
+
+    #[derive(Debug, PartialEq)]
+    struct DropCounter;
+
+    impl Drop for DropCounter {
+        fn drop(&mut self) {
+            DROPS.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    DROPS.store(0, Ordering::SeqCst);
+    let (s, r) = lossy(2);
+    s.try_send(DropCounter).unwrap();
+    s.try_send(DropCounter).unwrap();
+    assert_eq!(DROPS.load(Ordering::SeqCst), 0);
+
+    // Evict oldest - should drop it.
+    let _ = s.try_send(DropCounter);
+    assert_eq!(DROPS.load(Ordering::SeqCst), 1);
+
+    let _ = s.try_send(DropCounter);
+    assert_eq!(DROPS.load(Ordering::SeqCst), 2);
+
+    // Remaining items dropped when channel is dropped.
+    drop(s);
+    drop(r);
+    assert_eq!(DROPS.load(Ordering::SeqCst), 4);
+}
+
+#[test]
+fn spsc() {
+    const COUNT: usize = if cfg!(miri) { 100 } else { 100_000 };
+
+    let (s, r) = lossy(3);
+
+    scope(|scope| {
+        scope.spawn(move |_| {
+            for i in 0..COUNT {
+                assert_eq!(r.recv(), Ok(i));
+            }
+            assert_eq!(r.recv(), Err(RecvError));
+        });
+        scope.spawn(move |_| {
+            for i in 0..COUNT {
+                s.send(i).unwrap();
+            }
+        });
+    })
+    .unwrap();
+}
+
+#[test]
+fn mpmc_lossy() {
+    let (s, r) = lossy(4);
+    let total = AtomicUsize::new(0);
+
+    scope(|scope| {
+        // Two producers sending 100 each.
+        for _ in 0..2 {
+            let s = s.clone();
+            scope.spawn(move |_| {
+                for i in 0..100 {
+                    let _ = s.try_send(i);
+                }
+            });
+        }
+        drop(s);
+
+        // Two consumers.
+        let total = &total;
+        for _ in 0..2 {
+            let r = r.clone();
+            scope.spawn(move |_| {
+                while r.recv().is_ok() {
+                    total.fetch_add(1, Ordering::Relaxed);
+                }
+            });
+        }
+    })
+    .unwrap();
+
+    // Some messages may have been evicted, but we should have received some.
+    assert!(total.load(Ordering::Relaxed) > 0);
+}

--- a/crossbeam-skiplist/tests/base.rs
+++ b/crossbeam-skiplist/tests/base.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::redundant_clone)]
 
 use std::{
+    hint,
     ops::Bound,
     sync::atomic::{AtomicUsize, Ordering},
 };
@@ -999,7 +1000,9 @@ fn remove_race() {
                 let mut removed_entries = Vec::with_capacity(KEY_RANGE as usize);
 
                 barrier1.fetch_sub(1, Ordering::Relaxed);
-                while barrier1.load(Ordering::Acquire) != 0 {}
+                while barrier1.load(Ordering::Acquire) != 0 {
+                    hint::spin_loop()
+                }
 
                 for x in 0..KEY_RANGE {
                     if let Some(entry) = s.remove(&x, guard) {
@@ -1008,7 +1011,9 @@ fn remove_race() {
                 }
 
                 barrier2.fetch_sub(1, Ordering::Relaxed);
-                while barrier2.load(Ordering::Acquire) != 0 {}
+                while barrier2.load(Ordering::Acquire) != 0 {
+                    hint::spin_loop()
+                }
 
                 total_removed.fetch_add(removed_entries.len() as u32, Ordering::Relaxed);
 


### PR DESCRIPTION
Full bounded channels drop the newest item instead of the oldest when used in non-blocking mode.

This adds a `lossy_send` method that pushes out the oldest elements. Semantics are defined for all the existing types of queues. I'm not re-using the existing error semantics for `try_send` to avoid breaking existing code or creating a breaking or non-additive change to the API.

A `lossy` convenience constructor is provided to check that capacity is non-zero and immediately delegate to `bounded`.

Unit tests are made to provide similar coverage to the original `bounded` queue as well as verify basic semantics for non-`bounded` queues.

Benchmarks show that the lossy version is much faster than regular `bounded` because it never has to wait:

```
test lossy::create        ... bench:         122.43 ns/iter (+/- 8.14)
test lossy::inout         ... bench:          16.72 ns/iter (+/- 2.48)
test lossy::mpmc          ... bench:   1,076,605.90 ns/iter (+/- 331,346.17)
test lossy::mpsc          ... bench:   6,635,463.50 ns/iter (+/- 2,494,536.68)
test lossy::spsc          ... bench:     600,372.20 ns/iter (+/- 309,960.31)
                                                                                                                        
test bounded_1::create    ... bench:         125.86 ns/iter (+/- 5.14)
test bounded_1::mpmc      ... bench:  17,134,194.30 ns/iter (+/- 5,030,452.40)
test bounded_1::mpsc      ... bench:  86,669,462.20 ns/iter (+/- 11,068,690.83)
test bounded_1::oneshot   ... bench:         147.53 ns/iter (+/- 17.90)
test bounded_1::spmc      ... bench:  87,127,345.00 ns/iter (+/- 14,460,539.76)
test bounded_1::spsc      ... bench:   9,895,681.25 ns/iter (+/- 1,179,280.38)
```

Unbounded is a bit faster for MPMC, much faster for MPSC, but slower for everything else that involves potential buffer resizing but does not involve eviction:

```
test unbounded::create    ... bench:         107.42 ns/iter (+/- 15.82)
test unbounded::inout     ... bench:          31.88 ns/iter (+/- 4.13)
test unbounded::mpmc      ... bench:     870,335.36 ns/iter (+/- 385,854.63)
test unbounded::mpsc      ... bench:   2,846,018.20 ns/iter (+/- 1,642,916.66)
test unbounded::oneshot   ... bench:         172.70 ns/iter (+/- 40.10)
test unbounded::par_inout ... bench:   3,990,006.80 ns/iter (+/- 1,924,910.08)
test unbounded::spmc      ... bench:   4,544,291.70 ns/iter (+/- 13,056,468.18)
test unbounded::spsc      ... bench:   1,533,016.00 ns/iter (+/- 926,932.93)
```

Summary:

```
                  lossy          bounded_1       unbounded
create            122 ns         126 ns          107 ns
inout              17 ns         —                32 ns
spsc              600 µs         9,896 µs        1,533 µs
mpsc            6,635 µs        86,669 µs        2,846 µs
mpmc            1,077 µs        17,134 µs          870 µs
```