### PR TITLE
Make `never()` a `const` function

### DIFF
--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -272,7 +272,7 @@ pub fn at(when: Instant) -> Receiver<Instant> {
 /// }
 /// # t.join().unwrap(); // join thread to avoid https://github.com/rust-lang/miri/issues/1371
 /// ```
-pub fn never<T>() -> Receiver<T> {
+pub const fn never<T>() -> Receiver<T> {
     Receiver {
         flavor: ReceiverFlavor::Never(flavors::never::Channel::new()),
     }

--- a/crossbeam-channel/src/flavors/never.rs
+++ b/crossbeam-channel/src/flavors/never.rs
@@ -23,7 +23,7 @@ pub(crate) struct Channel<T> {
 impl<T> Channel<T> {
     /// Creates a channel that never delivers messages.
     #[inline]
-    pub(crate) fn new() -> Self {
+    pub(crate) const fn new() -> Self {
         Self {
             _marker: PhantomData,
         }


### PR DESCRIPTION
This is useful to allow the following scenario which is not possible today:
```
static REQUEST_SYSTEM: Mutex<Receiver<Model>> = Mutex::new(crossbeam_channel::never());
```