### PR TITLE
Performance bottleneck due to cache contention

### DIFF
--- a/crossbeam-skiplist/Cargo.toml
+++ b/crossbeam-skiplist/Cargo.toml
@@ -40,6 +40,7 @@ alloc = ["crossbeam-epoch/alloc"]
 [dependencies]
 crossbeam-epoch = { version = "0.9.17", path = "../crossbeam-epoch", default-features = false }
 crossbeam-utils = { version = "0.8.18", path = "../crossbeam-utils", default-features = false }
+rand = "0.10"
 
 [dev-dependencies]
 fastrand = "2"

--- a/crossbeam-skiplist/examples/parallel.rs
+++ b/crossbeam-skiplist/examples/parallel.rs
@@ -1,0 +1,107 @@
+use std::{
+    sync::{
+        Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+use crossbeam_skiplist::SkipSet;
+use rand::RngExt;
+
+fn main() {
+    let results: Vec<_> = std::env::args()
+        .skip(1)
+        .map(|nthreads| {
+            // Run 30 iterations with 1_048_576 keys and 10_000_000 ops per thread
+            let result = run(30, nthreads.parse().unwrap(), 1_048_576, 10_000_000);
+            (nthreads, result)
+        })
+        .collect();
+    println!("threads,throughput");
+    for (nthreads, throughput) in results {
+        println!("{nthreads},{throughput:.0}");
+    }
+}
+
+fn run(iters: usize, nthreads: usize, nkeys: usize, ops_per_thread: usize) -> f32 {
+    let total_runtime = Mutex::new(Duration::ZERO);
+
+    eprintln!(
+        "running {} operations per thread ({} threads, {} total operations)...",
+        ops_per_thread,
+        nthreads,
+        ops_per_thread * nthreads,
+    );
+
+    for i in 0..iters {
+        // Initialize barrier (barrier == 2 * nthreads)
+        let barrier = AtomicUsize::new(2 * nthreads);
+        let set: SkipSet<usize> = SkipSet::new();
+
+        // Fill the set to 50% by inserting all even-numbered keys
+        for x in 0..(nkeys / 2) {
+            set.insert(x * 2);
+        }
+
+        std::thread::scope(|s| {
+            for tid in 0..nthreads {
+                let barrier = &barrier;
+                let set = &set;
+                let total_runtime = &total_runtime;
+                s.spawn(move || {
+                    let mut rng = rand::rng();
+
+                    // Wait for all threads to reach here (barrier == nthreads)
+                    barrier.fetch_sub(1, Ordering::Relaxed);
+                    while barrier.load(Ordering::Relaxed) > nthreads {
+                        std::hint::spin_loop();
+                    }
+                    let start = Instant::now();
+
+                    // BEGIN benchmarked region
+                    for _ in 0..ops_per_thread {
+                        // Pick a random key and random operation with equal likelihood: insert, remove, or contains
+                        let key = rng.random_range(0..nkeys);
+                        let operation = rng.random_range(0..3);
+                        match operation {
+                            0 => {
+                                set.insert(key);
+                            }
+                            1 => {
+                                set.remove(&key);
+                            }
+                            _ => {
+                                set.contains(&key);
+                            }
+                        };
+                    }
+                    // END benchmarked region
+
+                    barrier.fetch_sub(1, Ordering::Relaxed);
+
+                    if tid == 0 {
+                        // Wait for all threads to complete (barrier == 0)
+                        while barrier.load(Ordering::Relaxed) != 0 {
+                            std::hint::spin_loop();
+                        }
+
+                        let elapsed = start.elapsed();
+                        eprintln!(
+                            "iter {:2}: {:.4?}, throughput {:.2} ops/s",
+                            i + 1,
+                            elapsed,
+                            (ops_per_thread * nthreads) as f32 / elapsed.as_secs_f32(),
+                        );
+                        *total_runtime.lock().unwrap() += elapsed;
+                    }
+                });
+            }
+        });
+    }
+
+    let average_time = total_runtime.into_inner().unwrap() / iters as u32;
+    let throughput = (ops_per_thread * nthreads) as f32 / average_time.as_secs_f32();
+    eprintln!("\naverage time: {average_time:?}, throughput {throughput} ops/s");
+    throughput
+}

--- a/crossbeam-skiplist/src/base.rs
+++ b/crossbeam-skiplist/src/base.rs
@@ -441,11 +441,11 @@ struct Position<'a, K, V> {
 
 /// Frequently modified data associated with a skip list.
 struct HotData {
-    /// The seed for random height generation.
-    seed: AtomicUsize,
+    // /// The seed for random height generation.
+    // seed: AtomicUsize,
 
-    /// The number of entries in the skip list.
-    len: AtomicUsize,
+    // /// The number of entries in the skip list.
+    // len: AtomicUsize,
 
     /// Highest tower currently in use. This value is used as a hint for where
     /// to start lookups and never decreases.
@@ -496,8 +496,8 @@ impl<K, V, C> SkipList<K, V, C> {
             head: Head::new(),
             collector,
             hot_data: CachePadded::new(HotData {
-                seed: AtomicUsize::new(1),
-                len: AtomicUsize::new(0),
+                // seed: AtomicUsize::new(1),
+                // len: AtomicUsize::new(0),
                 max_height: AtomicUsize::new(1),
             }),
             comparator,
@@ -514,11 +514,12 @@ impl<K, V, C> SkipList<K, V, C> {
     /// If the skip list is being concurrently modified, consider the returned number just an
     /// approximation without any guarantees.
     pub fn len(&self) -> usize {
-        let len = self.hot_data.len.load(Ordering::Relaxed);
+        // let len = self.hot_data.len.load(Ordering::Relaxed);
 
-        // Due to the relaxed memory ordering, the length counter may sometimes
-        // underflow and produce a very large value. We treat such values as 0.
-        if len > isize::MAX as usize { 0 } else { len }
+        // // Due to the relaxed memory ordering, the length counter may sometimes
+        // // underflow and produce a very large value. We treat such values as 0.
+        // if len > isize::MAX as usize { 0 } else { len }
+        0
     }
 
     /// Ensures that all `Guard`s used with the skip list come from the same
@@ -710,11 +711,12 @@ where
         //
         // This particular set of operations generates 32-bit integers. See:
         // https://en.wikipedia.org/wiki/Xorshift#Example_implementation
-        let mut num = self.hot_data.seed.load(Ordering::Relaxed);
-        num ^= num << 13;
-        num ^= num >> 17;
-        num ^= num << 5;
-        self.hot_data.seed.store(num, Ordering::Relaxed);
+        // let mut num = self.hot_data.seed.load(Ordering::Relaxed);
+        // num ^= num << 13;
+        // num ^= num >> 17;
+        // num ^= num << 5;
+        // self.hot_data.seed.store(num, Ordering::Relaxed);
+        let num = rand::random::<u32>();
 
         let mut height = cmp::min(MAX_HEIGHT, num.trailing_zeros() as usize + 1);
         unsafe {
@@ -1064,8 +1066,8 @@ where
                 )
             };
 
-            // Optimistically increment `len`.
-            self.hot_data.len.fetch_add(1, Ordering::Relaxed);
+            // // Optimistically increment `len`.
+            // self.hot_data.len.fetch_add(1, Ordering::Relaxed);
 
             loop {
                 // Set the lowest successor of `n` to `search.right[0]`.
@@ -1087,7 +1089,7 @@ where
                     // This node has been abandoned
                     if let Some(r) = search.found {
                         if r.mark_tower() {
-                            self.hot_data.len.fetch_sub(1, Ordering::Relaxed);
+                            // self.hot_data.len.fetch_sub(1, Ordering::Relaxed);
                         }
                     }
                     break;
@@ -1115,7 +1117,7 @@ where
                         if let Some(e) = RefEntry::try_acquire(self, r) {
                             // Destroy the new node.
                             Node::finalize(node.as_raw() as *mut Node<K, V>);
-                            self.hot_data.len.fetch_sub(1, Ordering::Relaxed);
+                            // self.hot_data.len.fetch_sub(1, Ordering::Relaxed);
 
                             return e;
                         }
@@ -1296,7 +1298,7 @@ where
                 // Try removing the node by marking its tower.
                 if n.mark_tower() {
                     // Success! Decrement `len`.
-                    self.hot_data.len.fetch_sub(1, Ordering::Relaxed);
+                    // self.hot_data.len.fetch_sub(1, Ordering::Relaxed);
 
                     // Unlink the node at each level of the skip list. We could do this by simply
                     // repeating the search, but it's usually faster to unlink it manually using
@@ -1396,7 +1398,7 @@ where
                     // Try removing the current entry.
                     if e.node.mark_tower() {
                         // Success! Decrement `len`.
-                        self.hot_data.len.fetch_sub(1, Ordering::Relaxed);
+                        // self.hot_data.len.fetch_sub(1, Ordering::Relaxed);
                     }
 
                     entry = next;
@@ -1531,7 +1533,7 @@ where
         // Try marking the tower.
         if self.node.mark_tower() {
             // Success - the entry is removed. Now decrement `len`.
-            self.parent.hot_data.len.fetch_sub(1, Ordering::Relaxed);
+            // self.parent.hot_data.len.fetch_sub(1, Ordering::Relaxed);
 
             // Search for the key to unlink the node from the skip list.
             self.parent
@@ -1697,7 +1699,7 @@ where
         // Try marking the tower.
         if self.node.mark_tower() {
             // Success - the entry is removed. Now decrement `len`.
-            self.parent.hot_data.len.fetch_sub(1, Ordering::Relaxed);
+            // self.parent.hot_data.len.fetch_sub(1, Ordering::Relaxed);
 
             // Search for the key to unlink the node from the skip list.
             self.parent


### PR DESCRIPTION
I have been investigating the performance of concurrent data structures as part of an ongoing research project. A key finding is that under heavy parallel workloads, data structures like `crossbeam-skiplist` often suffer from bottlenecks caused by a small number of frequently-modified shared variables due to cache contention (aka cache thrashing).

With skip lists in general, any two operations on different keys in a large set are highly unlikely to modify any shared cache line. However, with crossbeam-skiplist, `HotData` is modified on every insertion and removal. `hot_data.len` is updated using an atomic fetch-and-add, which is particularly expensive for highly-conteded variables on some architectures. Simply switching to a thread-local random seed and removing the atomic length variable dramatically improves performance under heavy parallel workloads.

This PR demonstrates the performance improvements with a simple benchmark. The benefit scales with thread count; on an x86-64 CPU with 64 virtual cores (32 physical cores, hyperthreading enabled), this optimization increases total throughput by >3.6x at 64 threads (with throughput measured as # of set operations per second).

Implementing this optimization would unfortunately mean sacrificing the accuracy of the `len()` method; while I suspect the performance boost would easily justify the loss for most users, this would be a breaking change and removes potentially important functionality. One option could be adding new, alternative versions of certain methods; e.g. create new `fast_insert()` and `fast_remove()` methods which don't modify the length variable, and leave the existing `insert()`/`remove()` methods intact. I am not sure what the best approach is, but I believe it is ultimately worth implementing, and I am open to suggestions for alternative options.

## Benchmarks

Tested with rustc 1.97.0-nightly (ff9a9ea07 2026-05-13).

Baseline revision: d0cb16a
Less-contended revision: 4fefec9

### Dual-socket Intel Xeon Gold 5218 (x86-64, 64 virtual cores)

<details>
<summary><code>lscpu</code> output</summary>
<pre>Architecture:             x86_64
  CPU op-mode(s):         32-bit, 64-bit
  Address sizes:          46 bits physical, 48 bits virtual
  Byte Order:             Little Endian
CPU(s):                   64
  On-line CPU(s) list:    0-63
Vendor ID:                GenuineIntel
  Model name:             Intel(R) Xeon(R) Gold 5218 CPU @ 2.30GHz
    CPU family:           6
    Model:                85
    Thread(s) per core:   2
    Core(s) per socket:   16
    Socket(s):            2
    Stepping:             7
    CPU max MHz:          3900.0000
    CPU min MHz:          1000.0000
    BogoMIPS:             4600.00
    Flags:                fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp 
                          lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2
                           ssse3 sdbg fma cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch c
                          puid_fault epb cat_l3 cdp_l3 invpcid_single intel_ppin ssbd mba ibrs ibpb stibp ibrs_enhanced tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbas
                          e tsc_adjust bmi1 avx2 smep bmi2 erms invpcid cqm mpx rdt_a avx512f avx512dq rdseed adx smap clflushopt clwb intel_pt avx512cd avx512bw avx512vl x
                          saveopt xsavec xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local dtherm ida arat pln pts pku ospke avx512_vnni md_clear flush_l1d a
                          rch_capabilities
Virtualization features:  
  Virtualization:         VT-x
Caches (sum of all):      
  L1d:                    1 MiB (32 instances)
  L1i:                    1 MiB (32 instances)
  L2:                     32 MiB (32 instances)
  L3:                     44 MiB (2 instances)
NUMA:                     
  NUMA node(s):           2
  NUMA node0 CPU(s):      0-15,32-47
  NUMA node1 CPU(s):      16-31,48-63
Vulnerabilities:          
  Gather data sampling:   Mitigation; Microcode
  Itlb multihit:          KVM: Mitigation: VMX disabled
  L1tf:                   Not affected
  Mds:                    Not affected
  Meltdown:               Not affected
  Mmio stale data:        Mitigation; Clear CPU buffers; SMT vulnerable
  Reg file data sampling: Not affected
  Retbleed:               Mitigation; Enhanced IBRS
  Spec rstack overflow:   Not affected
  Spec store bypass:      Mitigation; Speculative Store Bypass disabled via prctl and seccomp
  Spectre v1:             Mitigation; usercopy/swapgs barriers and __user pointer sanitization
  Spectre v2:             Mitigation; Enhanced / Automatic IBRS; IBPB conditional; RSB filling; PBRSB-eIBRS SW sequence; BHI SW loop, KVM SW loop
  Srbds:                  Not affected
  Tsx async abort:        Mitigation; TSX disabled</pre></details>

`cargo run -p crossbeam-skiplist --example parallel --release -- 1 2 4 8 16 32 48 60 64`

Throughput (operations/second):
| threads |   baseline | less-contended | speedup |
|--------:|-----------:|---------------:|--------:|
|       1 |  `1425299` |      `1407394` | `0.99x` |
|       2 |  `2616482` |      `2677422` | `1.02x` |
|       4 |  `4747247` |      `5121696` | `1.08x` |
|       8 |  `5873693` |      `7671461` | `1.31x` |
|      16 |  `6853475` |     `12705138` | `1.85x` |
|      32 |  `7274837` |     `22727032` | `3.12x` |
|      48 |  `8956789` |     `30210372` | `3.37x` |
|      60 | `10018060` |     `36439080` | `3.64x` |
|      64 | `10527560` |     `38291880` | `3.64x` |

### MacBook Pro (aarch64, M1 Pro, 10 cores)

`cargo run -p crossbeam-skiplist --example parallel --release -- 1 2 4 8 10`

Throughput (operations/second):
| threads |  baseline | less-contended | speedup |
|--------:|----------:|---------------:|--------:|
|       1 | `1851189` |      `1816741` | `0.98x` |
|       2 | `3583047` |      `3729654` | `1.06x` |
|       4 | `6333425` |      `7212682` | `1.28x` |
|       8 | `8624892` |     `13132332` | `1.48x` |
|      10 | `9427303` |     `14239139` | `1.55x` |

<img width="573" height="331" alt="Xeon graph" src="https://github.com/user-attachments/assets/2f493277-137c-490e-b8b6-e0d81feb39bd" />
<img width="514" height="331" alt="MacBook Pro graph" src="https://github.com/user-attachments/assets/03502ad1-b52d-401a-bc15-d360fbe30a7c" />