### PR TITLE
(deque) Debug impl. typo

### DIFF
--- a/crossbeam-deque/src/deque.rs
+++ b/crossbeam-deque/src/deque.rs
@@ -2058,7 +2058,7 @@ impl<T> Drop for Injector<T> {
 
 impl<T> fmt::Debug for Injector<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.pad("Worker { .. }")
+        f.pad("Injector { .. }")
     }
 }
 


### PR DESCRIPTION
This PR fixes a small copy-paste typo in the debug label for the `Injector` queue.