### PR TITLE
channel: Use non-poison Mutex

### DIFF
--- a/crossbeam-channel/src/flavors/zero.rs
+++ b/crossbeam-channel/src/flavors/zero.rs
@@ -10,7 +10,7 @@ use core::{
     ptr,
     sync::atomic::{AtomicBool, Ordering},
 };
-use std::{sync::Mutex, time::Instant};
+use std::time::Instant;
 
 use crossbeam_utils::Backoff;
 
@@ -18,6 +18,7 @@ use crate::{
     context::Context,
     err::{RecvTimeoutError, SendTimeoutError, TryRecvError, TrySendError},
     select::{Operation, SelectHandle, Selected, Token},
+    utils::Mutex,
     waker::Waker,
 };
 
@@ -131,7 +132,7 @@ impl<T> Channel<T> {
 
     /// Attempts to reserve a slot for sending a message.
     fn start_send(&self, token: &mut Token) -> bool {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock();
 
         // If there's a waiting receiver, pair up with it.
         if let Some(operation) = inner.receivers.try_select() {
@@ -160,7 +161,7 @@ impl<T> Channel<T> {
 
     /// Attempts to pair up with a sender.
     fn start_recv(&self, token: &mut Token) -> bool {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock();
 
         // If there's a waiting sender, pair up with it.
         if let Some(operation) = inner.senders.try_select() {
@@ -203,7 +204,7 @@ impl<T> Channel<T> {
     /// Attempts to send a message into the channel.
     pub(crate) fn try_send(&self, msg: T) -> Result<(), TrySendError<T>> {
         let token = &mut Token::default();
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock();
 
         // If there's a waiting receiver, pair up with it.
         if let Some(operation) = inner.receivers.try_select() {
@@ -227,7 +228,7 @@ impl<T> Channel<T> {
         deadline: Option<Instant>,
     ) -> Result<(), SendTimeoutError<T>> {
         let token = &mut Token::default();
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock();
 
         // If there's a waiting receiver, pair up with it.
         if let Some(operation) = inner.receivers.try_select() {
@@ -259,12 +260,12 @@ impl<T> Channel<T> {
             match sel {
                 Selected::Waiting => unreachable!(),
                 Selected::Aborted => {
-                    self.inner.lock().unwrap().senders.unregister(oper).unwrap();
+                    self.inner.lock().senders.unregister(oper).unwrap();
                     let msg = unsafe { packet.msg.get().replace(None).unwrap() };
                     Err(SendTimeoutError::Timeout(msg))
                 }
                 Selected::Disconnected => {
-                    self.inner.lock().unwrap().senders.unregister(oper).unwrap();
+                    self.inner.lock().senders.unregister(oper).unwrap();
                     let msg = unsafe { packet.msg.get().replace(None).unwrap() };
                     Err(SendTimeoutError::Disconnected(msg))
                 }
@@ -280,7 +281,7 @@ impl<T> Channel<T> {
     /// Attempts to receive a message without blocking.
     pub(crate) fn try_recv(&self) -> Result<T, TryRecvError> {
         let token = &mut Token::default();
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock();
 
         // If there's a waiting sender, pair up with it.
         if let Some(operation) = inner.senders.try_select() {
@@ -297,7 +298,7 @@ impl<T> Channel<T> {
     /// Receives a message from the channel.
     pub(crate) fn recv(&self, deadline: Option<Instant>) -> Result<T, RecvTimeoutError> {
         let token = &mut Token::default();
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock();
 
         // If there's a waiting sender, pair up with it.
         if let Some(operation) = inner.senders.try_select() {
@@ -330,21 +331,11 @@ impl<T> Channel<T> {
             match sel {
                 Selected::Waiting => unreachable!(),
                 Selected::Aborted => {
-                    self.inner
-                        .lock()
-                        .unwrap()
-                        .receivers
-                        .unregister(oper)
-                        .unwrap();
+                    self.inner.lock().receivers.unregister(oper).unwrap();
                     Err(RecvTimeoutError::Timeout)
                 }
                 Selected::Disconnected => {
-                    self.inner
-                        .lock()
-                        .unwrap()
-                        .receivers
-                        .unregister(oper)
-                        .unwrap();
+                    self.inner.lock().receivers.unregister(oper).unwrap();
                     Err(RecvTimeoutError::Disconnected)
                 }
                 Selected::Operation(_) => {
@@ -360,7 +351,7 @@ impl<T> Channel<T> {
     ///
     /// Returns `true` if this call disconnected the channel.
     pub(crate) fn disconnect(&self) -> bool {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock();
 
         if !inner.is_disconnected {
             inner.is_disconnected = true;
@@ -411,7 +402,7 @@ impl<T> SelectHandle for Receiver<'_, T> {
     fn register(&self, oper: Operation, cx: &Context) -> bool {
         let packet = Box::into_raw(Packet::<T>::empty_on_heap());
 
-        let mut inner = self.0.inner.lock().unwrap();
+        let mut inner = self.0.inner.lock();
         inner
             .receivers
             .register_with_packet(oper, packet.cast::<()>(), cx);
@@ -420,7 +411,7 @@ impl<T> SelectHandle for Receiver<'_, T> {
     }
 
     fn unregister(&self, oper: Operation) {
-        if let Some(operation) = self.0.inner.lock().unwrap().receivers.unregister(oper) {
+        if let Some(operation) = self.0.inner.lock().receivers.unregister(oper) {
             unsafe {
                 drop(Box::from_raw(operation.packet.cast::<Packet<T>>()));
             }
@@ -433,18 +424,18 @@ impl<T> SelectHandle for Receiver<'_, T> {
     }
 
     fn is_ready(&self) -> bool {
-        let inner = self.0.inner.lock().unwrap();
+        let inner = self.0.inner.lock();
         inner.senders.can_select() || inner.is_disconnected
     }
 
     fn watch(&self, oper: Operation, cx: &Context) -> bool {
-        let mut inner = self.0.inner.lock().unwrap();
+        let mut inner = self.0.inner.lock();
         inner.receivers.watch(oper, cx);
         inner.senders.can_select() || inner.is_disconnected
     }
 
     fn unwatch(&self, oper: Operation) {
-        let mut inner = self.0.inner.lock().unwrap();
+        let mut inner = self.0.inner.lock();
         inner.receivers.unwatch(oper);
     }
 }
@@ -461,7 +452,7 @@ impl<T> SelectHandle for Sender<'_, T> {
     fn register(&self, oper: Operation, cx: &Context) -> bool {
         let packet = Box::into_raw(Packet::<T>::empty_on_heap());
 
-        let mut inner = self.0.inner.lock().unwrap();
+        let mut inner = self.0.inner.lock();
         inner
             .senders
             .register_with_packet(oper, packet.cast::<()>(), cx);
@@ -470,7 +461,7 @@ impl<T> SelectHandle for Sender<'_, T> {
     }
 
     fn unregister(&self, oper: Operation) {
-        if let Some(operation) = self.0.inner.lock().unwrap().senders.unregister(oper) {
+        if let Some(operation) = self.0.inner.lock().senders.unregister(oper) {
             unsafe {
                 drop(Box::from_raw(operation.packet.cast::<Packet<T>>()));
             }
@@ -483,18 +474,18 @@ impl<T> SelectHandle for Sender<'_, T> {
     }
 
     fn is_ready(&self) -> bool {
-        let inner = self.0.inner.lock().unwrap();
+        let inner = self.0.inner.lock();
         inner.receivers.can_select() || inner.is_disconnected
     }
 
     fn watch(&self, oper: Operation, cx: &Context) -> bool {
-        let mut inner = self.0.inner.lock().unwrap();
+        let mut inner = self.0.inner.lock();
         inner.senders.watch(oper, cx);
         inner.receivers.can_select() || inner.is_disconnected
     }
 
     fn unwatch(&self, oper: Operation) {
-        let mut inner = self.0.inner.lock().unwrap();
+        let mut inner = self.0.inner.lock();
         inner.senders.unwatch(oper);
     }
 }

--- a/crossbeam-channel/src/utils.rs
+++ b/crossbeam-channel/src/utils.rs
@@ -54,3 +54,18 @@ pub(crate) fn sleep_until(deadline: Option<Instant>) {
         }
     }
 }
+
+/// Non-poison mutex.
+pub(crate) struct Mutex<T>(std::sync::Mutex<T>);
+
+impl<T> Mutex<T> {
+    pub(crate) fn new(t: T) -> Self {
+        Self(std::sync::Mutex::new(t))
+    }
+
+    pub(crate) fn lock(&self) -> std::sync::MutexGuard<'_, T> {
+        self.0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}

--- a/crossbeam-channel/src/waker.rs
+++ b/crossbeam-channel/src/waker.rs
@@ -5,14 +5,12 @@ use core::{
     ptr,
     sync::atomic::{AtomicBool, Ordering},
 };
-use std::{
-    sync::Mutex,
-    thread::{self, ThreadId},
-};
+use std::thread::{self, ThreadId};
 
 use crate::{
     context::Context,
     select::{Operation, Selected},
+    utils::Mutex,
 };
 
 /// Represents a thread blocked on a specific channel operation.
@@ -202,7 +200,7 @@ impl SyncWaker {
     /// Registers the current thread with an operation.
     #[inline]
     pub(crate) fn register(&self, oper: Operation, cx: &Context) {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock();
         inner.register(oper, cx);
         self.is_empty.store(
             inner.selectors.is_empty() && inner.observers.is_empty(),
@@ -213,7 +211,7 @@ impl SyncWaker {
     /// Unregisters an operation previously registered by the current thread.
     #[inline]
     pub(crate) fn unregister(&self, oper: Operation) -> Option<Entry> {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock();
         let entry = inner.unregister(oper);
         self.is_empty.store(
             inner.selectors.is_empty() && inner.observers.is_empty(),
@@ -226,7 +224,7 @@ impl SyncWaker {
     #[inline]
     pub(crate) fn notify(&self) {
         if !self.is_empty.load(Ordering::SeqCst) {
-            let mut inner = self.inner.lock().unwrap();
+            let mut inner = self.inner.lock();
             if !self.is_empty.load(Ordering::SeqCst) {
                 inner.try_select();
                 inner.notify();
@@ -241,7 +239,7 @@ impl SyncWaker {
     /// Registers an operation waiting to be ready.
     #[inline]
     pub(crate) fn watch(&self, oper: Operation, cx: &Context) {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock();
         inner.watch(oper, cx);
         self.is_empty.store(
             inner.selectors.is_empty() && inner.observers.is_empty(),
@@ -252,7 +250,7 @@ impl SyncWaker {
     /// Unregisters an operation waiting to be ready.
     #[inline]
     pub(crate) fn unwatch(&self, oper: Operation) {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock();
         inner.unwatch(oper);
         self.is_empty.store(
             inner.selectors.is_empty() && inner.observers.is_empty(),
@@ -263,7 +261,7 @@ impl SyncWaker {
     /// Notifies all threads that the channel is disconnected.
     #[inline]
     pub(crate) fn disconnect(&self) {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock();
         inner.disconnect();
         self.is_empty.store(
             inner.selectors.is_empty() && inner.observers.is_empty(),


### PR DESCRIPTION
Use a wrapper around std::sync::Mutex.

Related: https://github.com/crossbeam-rs/crossbeam/pull/835