### PR TITLE
skiplist: Add approximate_range_count

### DIFF
--- a/crossbeam-skiplist/src/base.rs
+++ b/crossbeam-skiplist/src/base.rs
@@ -704,6 +704,91 @@ where
         }
     }
 
+    /// Returns an estimate of the number of entries in the given range.
+    ///
+    /// Runs in O(log n) by sampling the upper tower levels instead of walking
+    /// every node, using the same approach as RocksDB's
+    /// `InlineSkipList::EstimateCount`. The result may differ from the exact
+    /// count by a constant factor.
+    pub fn approximate_range_count<Q>(
+        &self,
+        start: Bound<&Q>,
+        end: Bound<&Q>,
+        guard: &Guard,
+    ) -> usize
+    where
+        C: Comparator<K, Q>,
+        Q: ?Sized,
+    {
+        self.check_guard(guard);
+
+        const BRANCHING_FACTOR: usize = 2;
+
+        // SAFETY: the epoch guard keeps all nodes alive for this traversal.
+        // Marked (tag=1) successors are logically-deleted nodes; we skip them
+        // without restarting, which is fine for an approximate result.
+        unsafe {
+            let mut level = self.hot_data.max_height.load(Ordering::Relaxed);
+
+            while level >= 1
+                && self
+                    .head
+                    .get_level(level - 1)
+                    .load(Ordering::Relaxed, guard)
+                    .is_null()
+            {
+                level -= 1;
+            }
+
+            let mut lower = self.head.as_tower();
+            let mut count: usize = 0;
+
+            while level >= 1 {
+                level -= 1;
+
+                let sufficient_samples = level * BRANCHING_FACTOR + 10;
+                if count >= sufficient_samples {
+                    count = count.saturating_mul(BRANCHING_FACTOR);
+                    continue;
+                }
+
+                count = 0;
+
+                // Advance lower to the start bound at this level.
+                let mut curr = lower.get_level(level).load_consume(guard);
+                while let Some(c) = NodeRef::from_shared(curr) {
+                    let succ = c.get_level(level).load_consume(guard);
+                    if succ.tag() == 1 {
+                        curr = succ.with_tag(0);
+                        continue;
+                    }
+                    if above_lower_bound(&self.comparator, &start, &c.key) {
+                        break;
+                    }
+                    lower = c.as_tower();
+                    curr = succ;
+                }
+
+                // Count nodes from lower to the end bound at this level.
+                let mut curr = lower.get_level(level).load_consume(guard);
+                while let Some(c) = NodeRef::from_shared(curr) {
+                    let succ = c.get_level(level).load_consume(guard);
+                    if succ.tag() == 1 {
+                        curr = succ.with_tag(0);
+                        continue;
+                    }
+                    if !below_upper_bound(&self.comparator, &end, &c.key) {
+                        break;
+                    }
+                    count += 1;
+                    curr = succ;
+                }
+            }
+
+            count
+        }
+    }
+
     /// Generates a random height and returns it.
     fn random_height(&self) -> usize {
         // Pseudorandom number generation from "Xorshift RNGs" by George Marsaglia.

--- a/crossbeam-skiplist/src/map.rs
+++ b/crossbeam-skiplist/src/map.rs
@@ -344,6 +344,34 @@ where
         try_pin_loop(|| self.inner.upper_bound(bound, guard)).map(Entry::new)
     }
 
+    /// Returns an estimate of the number of entries in the given range.
+    ///
+    /// This is an O(log n) operation that exploits the skip list's multi-level
+    /// structure to avoid walking every node. The result is approximate and may
+    /// differ from the exact count by a constant factor.
+    ///
+    /// # Example
+    /// ```
+    /// use crossbeam_skiplist::SkipMap;
+    ///
+    /// let map = SkipMap::new();
+    /// for i in 0..100 {
+    ///     map.insert(i, i);
+    /// }
+    /// let approx = map.approximate_range_count(20..80);
+    /// assert!(approx > 0);
+    /// ```
+    pub fn approximate_range_count<Q, R>(&self, range: R) -> usize
+    where
+        R: RangeBounds<Q>,
+        C: Comparator<K, Q>,
+        Q: ?Sized,
+    {
+        let guard = &epoch::pin();
+        self.inner
+            .approximate_range_count(range.start_bound(), range.end_bound(), guard)
+    }
+
     /// Returns an iterator over a subset of entries in the map.
     ///
     /// This iterator returns [`Entry`]s which

--- a/crossbeam-skiplist/src/set.rs
+++ b/crossbeam-skiplist/src/set.rs
@@ -272,6 +272,30 @@ where
         }
     }
 
+    /// Returns an estimate of the number of entries in the given range.
+    ///
+    /// This is an O(log n) operation that exploits the skip list's multi-level
+    /// structure to avoid walking every node. The result is approximate and may
+    /// differ from the exact count by a constant factor.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use crossbeam_skiplist::SkipSet;
+    ///
+    /// let set: SkipSet<i32> = (0..100).collect();
+    /// let approx = set.approximate_range_count(20..80);
+    /// assert!(approx > 0);
+    /// ```
+    pub fn approximate_range_count<Q, R>(&self, range: R) -> usize
+    where
+        R: RangeBounds<Q>,
+        C: Comparator<T, Q>,
+        Q: ?Sized,
+    {
+        self.inner.approximate_range_count(range)
+    }
+
     /// Returns an iterator over a subset of entries in the set.
     ///
     /// # Example

--- a/crossbeam-skiplist/tests/map.rs
+++ b/crossbeam-skiplist/tests/map.rs
@@ -1026,3 +1026,83 @@ fn comparator() {
     assert_eq!(s.remove("AbC").unwrap().key(), "ABC");
     assert!(s.is_empty());
 }
+
+#[test]
+fn approximate_range_count_empty() {
+    let m: SkipMap<i32, i32> = SkipMap::new();
+    assert_eq!(m.approximate_range_count(..), 0);
+    assert_eq!(m.approximate_range_count(0..10), 0);
+}
+
+#[test]
+fn approximate_range_count_small() {
+    let m = SkipMap::new();
+    for i in 0..10 {
+        m.insert(i, i);
+    }
+    let count = m.approximate_range_count(..);
+    assert!(
+        count >= 8 && count <= 20,
+        "full range: approx={count}, expected ~10"
+    );
+}
+
+#[test]
+fn approximate_range_count_subrange() {
+    let m = SkipMap::new();
+    for i in 0..20 {
+        m.insert(i, i);
+    }
+    let count = m.approximate_range_count(5..15);
+    assert!(
+        count >= 8 && count <= 20,
+        "subrange: approx={count}, expected ~10"
+    );
+}
+
+#[test]
+fn approximate_range_count_bounds() {
+    let m = SkipMap::new();
+    for i in 0..20 {
+        m.insert(i, i);
+    }
+    let c1 = m.approximate_range_count(5..15);
+    assert!(c1 >= 8 && c1 <= 20, "range: approx={c1}, expected ~10");
+    let c2 = m.approximate_range_count((Bound::Excluded(4), Bound::Excluded(15)));
+    assert!(c2 >= 8 && c2 <= 20, "excluded: approx={c2}, expected ~10");
+    let c3 = m.approximate_range_count((Bound::Included(5), Bound::Included(14)));
+    assert!(c3 >= 8 && c3 <= 20, "included: approx={c3}, expected ~10");
+}
+
+#[test]
+fn approximate_range_count_large() {
+    let m = SkipMap::new();
+    let n = 10_000;
+    for i in 0..n {
+        m.insert(i, i);
+    }
+
+    let approx = m.approximate_range_count(..);
+    // Should be within a factor of 4 of the true count.
+    assert!(
+        approx >= n / 4 && approx <= n * 4,
+        "full range: approx={approx}, expected ~{n}"
+    );
+
+    let half_n = n / 2;
+    let approx_half = m.approximate_range_count(0..half_n);
+    assert!(
+        approx_half >= half_n / 4 && approx_half <= half_n * 4,
+        "half range: approx={approx_half}, expected ~{half_n}"
+    );
+}
+
+#[test]
+fn approximate_range_count_out_of_range() {
+    let m = SkipMap::new();
+    for i in 100..200 {
+        m.insert(i, i);
+    }
+    assert_eq!(m.approximate_range_count(0..50), 0);
+    assert_eq!(m.approximate_range_count(250..300), 0);
+}

--- a/crossbeam-skiplist/tests/set.rs
+++ b/crossbeam-skiplist/tests/set.rs
@@ -815,3 +815,28 @@ fn comparator() {
     s.remove(&encode(&[0f32]));
     assert!(!s.contains(&encode(&[-0f32])));
 }
+
+#[test]
+fn approximate_range_count_empty() {
+    let s: SkipSet<i32> = SkipSet::new();
+    assert_eq!(s.approximate_range_count(..), 0);
+    assert_eq!(s.approximate_range_count(0..10), 0);
+}
+
+#[test]
+fn approximate_range_count_small() {
+    let s: SkipSet<i32> = (0..10).collect();
+    assert_eq!(s.approximate_range_count(..), 10);
+}
+
+#[test]
+fn approximate_range_count_large() {
+    let n: usize = 10_000;
+    let s: SkipSet<i32> = (0..n as i32).collect();
+
+    let approx = s.approximate_range_count(..);
+    assert!(
+        approx >= n / 4 && approx <= n * 4,
+        "full range: approx={approx}, expected ~{n}"
+    );
+}


### PR DESCRIPTION
Closes #1249.

When using a skip list as a memtable (like SlateDB does), it's useful to be able to estimate how many entries fall within a key range without walking every node. Right now the only way to get a count is `range(..).count()`, which is O(n) in the size of the range.

This adds `approximate_range_count`, which uses the skip list's existing tower levels to estimate the count in O(log n). The idea is the same one RocksDB uses in `InlineSkipList::EstimateCount`: at level L a node appears with probability 1/2^L, so counting C nodes at some level gives roughly C * 2^L entries at the bottom. The traversal starts at the top level and only descends once it has gathered enough samples for a reasonable estimate, falling back to an exact count at level 0 for small ranges.

The method is available on `SkipMap` and `SkipSet` (taking a `RangeBounds`) and on the internal `SkipList` (taking explicit bounds and a guard). It's read-only, adds no overhead to existing operations, and requires no changes to the node layout.

I've added tests covering empty maps, exact small-range counts, the various bound types, out-of-range queries, and a large (10k entry) case that checks the estimate stays within a small constant factor of the true count.