### PR TITLE
make CachePadded<T> have C repr to allow casting to and from T

### DIFF
--- a/crossbeam-utils/src/cache_padded.rs
+++ b/crossbeam-utils/src/cache_padded.rs
@@ -107,19 +107,19 @@ use core::{
         target_arch = "sparc",
         target_arch = "hexagon",
     ),
-    repr(align(32), C)
+    repr(align(32))
 )]
 // m68k has 16-byte cache line size.
 //
 // Sources:
 // - https://github.com/torvalds/linux/blob/3516bd729358a2a9b090c1905bd2a3fa926e24c6/arch/m68k/include/asm/cache.h#L9
-#[cfg_attr(target_arch = "m68k", repr(align(16), C))]
+#[cfg_attr(target_arch = "m68k", repr(align(16)))]
 // s390x has 256-byte cache line size.
 //
 // Sources:
 // - https://github.com/golang/go/blob/3dd58676054223962cd915bb0934d1f9f489d4d2/src/internal/cpu/cpu_s390x.go#L7
 // - https://github.com/torvalds/linux/blob/3516bd729358a2a9b090c1905bd2a3fa926e24c6/arch/s390/include/asm/cache.h#L13
-#[cfg_attr(target_arch = "s390x", repr(align(256), C))]
+#[cfg_attr(target_arch = "s390x", repr(align(256)))]
 // x86, wasm, riscv, and sparc64 have 64-byte cache line size.
 //
 // Sources:
@@ -145,8 +145,27 @@ use core::{
         target_arch = "m68k",
         target_arch = "s390x",
     )),
-    repr(align(64), C)
+    repr(align(64))
 )]
+// repr(C) ensures that the value is stored at the very start of this struct, which enables
+// pointers to this struct to be freely cast to pointers to T.
+//
+// The Rust language reference says the following in relation to field offsets in a repr(C) struct:
+//
+// "The size and offset of fields is determined by the following algorithm.
+//  Start with a current offset of 0 bytes.
+//  For each field in declaration order in the struct, first determine the size and alignment of the
+//  field. If the current offset is not a multiple of the field’s alignment, then add padding bytes
+//  to the current offset until it is a multiple of the field’s alignment. The offset for the field
+//  is what the current offset is now. Then increase the current offset by the size of the field."
+//
+// Since the value is the first an only item in the struct, it is placed in the 0th byte, since 0 is
+// a multiple of every integer, this its alignment wouldn't need to be padded.
+//
+// Sources:
+// - https://github.com/rust-lang/reference/blob/264aec433acc7503c48a8c4a2c59075c955f3497/src/type-layout.md?plain=1#L207C1-L208C1
+// 
+#[repr(C)]
 pub struct CachePadded<T> {
     value: T,
 }

--- a/crossbeam-utils/src/cache_padded.rs
+++ b/crossbeam-utils/src/cache_padded.rs
@@ -33,7 +33,8 @@ use core::{
 ///
 /// # Layout
 ///
-/// Since crossbeam-utils 0.9.0, this type is `#[repr(C)]` and is guaranteed that the pointer to `CachePadded<T>` has the same address as the pointer to the underlying `T`.
+/// Since crossbeam-utils 0.9.0, this type is `#[repr(C)]` and is guaranteed that the pointer to
+/// `CachePadded<T>` has the same address as the pointer to the underlying `T`.
 ///
 /// # Examples
 ///

--- a/crossbeam-utils/src/cache_padded.rs
+++ b/crossbeam-utils/src/cache_padded.rs
@@ -31,6 +31,10 @@ use core::{
 ///
 /// The alignment of `CachePadded<T>` is the maximum of N bytes and the alignment of `T`.
 ///
+/// # Layout
+///
+/// Since crossbeam-utils 0.9.0, this type is `#[repr(C)]` and is guaranteed that the pointer to `CachePadded<T>` has the same address as the pointer to the underlying `T`.
+///
 /// # Examples
 ///
 /// Alignment and padding:

--- a/crossbeam-utils/src/cache_padded.rs
+++ b/crossbeam-utils/src/cache_padded.rs
@@ -33,7 +33,7 @@ use core::{
 ///
 /// # Layout
 ///
-/// Since crossbeam-utils 0.9.0, this type is `#[repr(C)]` and is guaranteed that the pointer to
+/// Since crossbeam-utils 0.8.22, this type is `#[repr(C)]` and is guaranteed that the pointer to
 /// `CachePadded<T>` has the same address as the pointer to the underlying `T`.
 ///
 /// # Examples
@@ -152,24 +152,6 @@ use core::{
     )),
     repr(align(64))
 )]
-// repr(C) ensures that the value is stored at the very start of this struct, which enables
-// pointers to this struct to be freely cast to pointers to T.
-//
-// The Rust language reference says the following in relation to field offsets in a repr(C) struct:
-//
-// "The size and offset of fields is determined by the following algorithm.
-//  Start with a current offset of 0 bytes.
-//  For each field in declaration order in the struct, first determine the size and alignment of the
-//  field. If the current offset is not a multiple of the field’s alignment, then add padding bytes
-//  to the current offset until it is a multiple of the field’s alignment. The offset for the field
-//  is what the current offset is now. Then increase the current offset by the size of the field."
-//
-// Since the value is the first an only item in the struct, it is placed in the 0th byte, since 0 is
-// a multiple of every integer, this its alignment wouldn't need to be padded.
-//
-// Sources:
-// - https://github.com/rust-lang/reference/blob/264aec433acc7503c48a8c4a2c59075c955f3497/src/type-layout.md?plain=1#L207C1-L208C1
-// 
 #[repr(C)]
 pub struct CachePadded<T> {
     value: T,

--- a/crossbeam-utils/src/cache_padded.rs
+++ b/crossbeam-utils/src/cache_padded.rs
@@ -107,19 +107,19 @@ use core::{
         target_arch = "sparc",
         target_arch = "hexagon",
     ),
-    repr(align(32))
+    repr(align(32), C)
 )]
 // m68k has 16-byte cache line size.
 //
 // Sources:
 // - https://github.com/torvalds/linux/blob/3516bd729358a2a9b090c1905bd2a3fa926e24c6/arch/m68k/include/asm/cache.h#L9
-#[cfg_attr(target_arch = "m68k", repr(align(16)))]
+#[cfg_attr(target_arch = "m68k", repr(align(16), C))]
 // s390x has 256-byte cache line size.
 //
 // Sources:
 // - https://github.com/golang/go/blob/3dd58676054223962cd915bb0934d1f9f489d4d2/src/internal/cpu/cpu_s390x.go#L7
 // - https://github.com/torvalds/linux/blob/3516bd729358a2a9b090c1905bd2a3fa926e24c6/arch/s390/include/asm/cache.h#L13
-#[cfg_attr(target_arch = "s390x", repr(align(256)))]
+#[cfg_attr(target_arch = "s390x", repr(align(256), C))]
 // x86, wasm, riscv, and sparc64 have 64-byte cache line size.
 //
 // Sources:
@@ -145,7 +145,7 @@ use core::{
         target_arch = "m68k",
         target_arch = "s390x",
     )),
-    repr(align(64))
+    repr(align(64), C)
 )]
 pub struct CachePadded<T> {
     value: T,


### PR DESCRIPTION
While working on a current project which uses CachePadded, I noticed that the struct doesn't have a C repr. My project casts pointers to CachePadded<T> to T pretty frequently and I think many others assume that they can do the same. To make matters worse, this isn't something that Miri catches. While it is unlikely to cause problems, I believe that it can as by default the internal layout of any struct is undefined. This change makes CachePadded have a C repr so that casting pointers to T can work as expected.