### PR TITLE
epoch: Add null ptr check to fmt::Pointer impl for Atomic/Shared

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 
-permissions:
-  contents: read
+permissions: {}
 
 on:
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,8 @@ jobs:
             os: ubuntu-latest
           - rust: nightly
             os: ubuntu-24.04-arm
-          - rust: nightly
-            os: macos-latest
+          # - rust: nightly
+          #   os: macos-latest
           - rust: nightly
             os: windows-latest
           - rust: nightly
@@ -82,11 +82,11 @@ jobs:
           - rust: nightly
             os: ubuntu-latest
             target: s390x-unknown-linux-gnu
-          # Test 32-bit target that does not have AtomicU64/AtomicI64.
-          - rust: nightly
-            os: ubuntu-24.04-arm
-            container: debian:13-slim
-            target: armv5te-unknown-linux-gnueabi
+          # # Test 32-bit target that does not have AtomicU64/AtomicI64.
+          # - rust: nightly
+          #   os: ubuntu-24.04-arm
+          #   container: debian:13-slim
+          #   target: armv5te-unknown-linux-gnueabi
           # Test target without stable inline asm support.
           - rust: stable
             os: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Release
 
-permissions:
-  contents: read
+permissions: {}
 
 on:
   push:

--- a/crossbeam-epoch/src/atomic.rs
+++ b/crossbeam-epoch/src/atomic.rs
@@ -840,7 +840,12 @@ impl<T: ?Sized + Pointable> fmt::Pointer for Atomic<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let data = self.data.load(Ordering::SeqCst);
         let (raw, _) = decompose_tag::<T>(data);
-        fmt::Pointer::fmt(&(unsafe { T::as_ptr(raw) }), f)
+        let ptr = if raw.is_null() {
+            raw
+        } else {
+            unsafe { T::as_ptr(raw).cast::<()>() }
+        };
+        fmt::Pointer::fmt(&ptr, f)
     }
 }
 
@@ -1571,7 +1576,13 @@ impl<T: ?Sized + Pointable> fmt::Debug for Shared<'_, T> {
 
 impl<T: ?Sized + Pointable> fmt::Pointer for Shared<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Pointer::fmt(&(unsafe { self.as_ptr() }), f)
+        let (raw, _) = decompose_tag::<T>(self.data);
+        let ptr = if raw.is_null() {
+            raw
+        } else {
+            unsafe { T::as_ptr(raw).cast::<()>() }
+        };
+        fmt::Pointer::fmt(&ptr, f)
     }
 }
 
@@ -1588,7 +1599,7 @@ impl<T: ?Sized + Pointable> Default for Shared<'_, T> {
     clippy::std_instead_of_core
 )]
 mod tests {
-    use std::{mem::MaybeUninit, sync::atomic::Ordering};
+    use std::{format, mem::MaybeUninit, sync::atomic::Ordering};
 
     use super::{Atomic, Owned, Shared};
     use crate::pin;
@@ -1614,9 +1625,23 @@ mod tests {
 
     #[test]
     fn array_init() {
-        let owned = Owned::<[MaybeUninit<usize>]>::init(10);
-        let arr: &[MaybeUninit<usize>] = &owned;
+        let mut owned = Owned::<[MaybeUninit<usize>]>::init(10);
+        let arr: &mut [MaybeUninit<usize>] = &mut owned;
+        arr[arr.len() - 1].write(20);
         assert_eq!(arr.len(), 10);
+    }
+
+    #[test]
+    fn format_null() {
+        let atomic = Atomic::<usize>::null();
+        assert_eq!(format!("{atomic:p}"), "0x0");
+        let atomic = Atomic::<[MaybeUninit<usize>]>::null();
+        assert_eq!(format!("{atomic:p}"), "0x0");
+
+        let shared = Shared::<usize>::null();
+        assert_eq!(format!("{shared:p}"), "0x0");
+        let shared = Shared::<[MaybeUninit<usize>]>::null();
+        assert_eq!(format!("{shared:p}"), "0x0");
     }
 
     #[test]


### PR DESCRIPTION
These types can be constructed with a null pointer, but `as_ptr`, which is called inside `fmt::Display`, requires a valid pointer. (With sized types, it's just a pointer cast, but with DST, it references a len field.)

Affected crossbeam-epoch >= 0.9.0 (https://github.com/crossbeam-rs/crossbeam/pull/452) <= 0.9.18

Reported by Codex Security.
