### PR TITLE
Do not dereference pointer in fmt::Pointer

### DIFF
--- a/crossbeam-epoch/src/atomic.rs
+++ b/crossbeam-epoch/src/atomic.rs
@@ -840,12 +840,7 @@ impl<T: ?Sized + Pointable> fmt::Pointer for Atomic<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let data = self.data.load(Ordering::SeqCst);
         let (raw, _) = decompose_tag::<T>(data);
-        let ptr = if raw.is_null() {
-            raw
-        } else {
-            unsafe { T::as_ptr(raw).cast::<()>() }
-        };
-        fmt::Pointer::fmt(&ptr, f)
+        fmt::Pointer::fmt(&raw, f)
     }
 }
 
@@ -1577,12 +1572,7 @@ impl<T: ?Sized + Pointable> fmt::Debug for Shared<'_, T> {
 impl<T: ?Sized + Pointable> fmt::Pointer for Shared<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let (raw, _) = decompose_tag::<T>(self.data);
-        let ptr = if raw.is_null() {
-            raw
-        } else {
-            unsafe { T::as_ptr(raw).cast::<()>() }
-        };
-        fmt::Pointer::fmt(&ptr, f)
+        fmt::Pointer::fmt(&raw, f)
     }
 }
 


### PR DESCRIPTION
Follow-up to #1273.

When I wrote that PR, I thought it was sound because unsafe code was required to create a non-null invalid pointer, but in reality, calling `fmt::Display` on a `shared` object loaded in relaxed order is still unsound even if the pointer is valid (in this specific case, due to address dependency, the old data shouldn't be readable on arches other than alpha which is not supported in Rust).

See also the description of https://github.com/rustsec/advisory-db/pull/3042.