### PR TITLE
v0.8: Prepare for the next release

### DIFF
--- a/crossbeam-epoch/CHANGELOG.md
+++ b/crossbeam-epoch/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.9.20
+
+- Fix invalid pointer dereference in `fmt::Pointer` impl for `Atomic`/`Shared` when the underlying pointer is invalid. This fixes unsoundness that was not fully addressed in 0.9.19's fix. (#1276)
+
 # Version 0.9.19
 
 - Fix null pointer dereference in `fmt::Pointer` impl for `Atomic`/`Shared` when it is a null pointer. (#1273)

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-epoch"
 # - Update CHANGELOG.md
 # - Update README.md (when increasing major or minor version)
 # - Run './tools/publish.sh crossbeam-epoch <version>'
-version = "0.9.19"
+version = "0.9.20"
 edition = "2021"
 rust-version = "1.61"
 license = "MIT OR Apache-2.0"

--- a/crossbeam-epoch/src/atomic.rs
+++ b/crossbeam-epoch/src/atomic.rs
@@ -942,12 +942,7 @@ impl<T: ?Sized + Pointable> fmt::Pointer for Atomic<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let data = self.data.load(Ordering::SeqCst);
         let (raw, _) = decompose_tag::<T>(data);
-        let ptr = if raw == 0 {
-            raw as *const ()
-        } else {
-            unsafe { T::deref(raw) as *const T as *const () }
-        };
-        fmt::Pointer::fmt(&ptr, f)
+        fmt::Pointer::fmt(&(raw as *const ()), f)
     }
 }
 
@@ -1667,12 +1662,7 @@ impl<T: ?Sized + Pointable> fmt::Debug for Shared<'_, T> {
 impl<T: ?Sized + Pointable> fmt::Pointer for Shared<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let (raw, _) = decompose_tag::<T>(self.data);
-        let ptr = if raw == 0 {
-            raw as *const ()
-        } else {
-            unsafe { T::deref(raw) as *const T as *const () }
-        };
-        fmt::Pointer::fmt(&ptr, f)
+        fmt::Pointer::fmt(&(raw as *const ()), f)
     }
 }
 


### PR DESCRIPTION
- crossbeam-epoch 0.9.19 -> 0.9.20
  - Fix invalid pointer dereference in `fmt::Pointer` impl for `Atomic`/`Shared` when the underlying pointer is invalid. This fixes unsoundness that was not fully addressed in 0.9.19's fix. (#1276)