### PR TITLE
Implement a recycle method for Select

### DIFF
--- a/crossbeam-channel/src/select.rs
+++ b/crossbeam-channel/src/select.rs
@@ -1208,6 +1208,7 @@ impl<'a> Select<'a> {
         // Replace with [`Vec::recycle`] when it's stable.
         let mut handles = mem::ManuallyDrop::new(handles);
         let (ptr, length, capacity) = (handles.as_mut_ptr(), handles.len(), handles.capacity());
+        debug_assert_eq!(length, 0);
         Select {
             // SAFETY: this vec has been cleared beforehand, so the lifetime has ended.
             handles: unsafe { Vec::from_raw_parts(ptr.cast(), length, capacity) },

--- a/crossbeam-channel/src/select.rs
+++ b/crossbeam-channel/src/select.rs
@@ -1170,6 +1170,48 @@ impl<'a> Select<'a> {
             Some(index) => Ok(index),
         }
     }
+
+    /// Recycles this `Select` and its internal allocated buffer, clearing the `Select` and giving it a new lifetime.
+    ///
+    /// This can be used to avoid allocating a new `Select` when it would be preferable to reuse this one.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_channel::{unbounded, Select};
+    ///
+    /// let (s1, r1) = unbounded();
+    /// s1.send(1).unwrap();
+    ///
+    /// let mut sel = Select::new();
+    /// assert_eq!(sel.recv(&r1), 0);
+    ///
+    /// sel = sel.recycle();
+    /// // We are now free to drop these because they're no longer bound by the 'a lifetime
+    /// drop((s1, r1));
+    ///
+    /// let (s2, r2) = unbounded();
+    /// s2.send(2).unwrap();
+    ///
+    /// assert_eq!(sel.recv(&r2), 0);
+    /// assert_eq!(sel.select().recv(&r2), Ok(2));
+    /// ```
+    pub fn recycle<'b>(self) -> Select<'b> {
+        let Select {
+            mut handles,
+            next_index: _,
+            biased,
+        } = self;
+        handles.clear();
+        // FIXME: Unsafe but stable version of [`Vec::recycle`]. Replace with [`Vec::recycle`] when it's stable, if possible.
+        let (ptr, length, capacity) = handles.into_raw_parts();
+        Select {
+            // SAFETY: this vec has been cleared beforehand, so the lifetime has ended.
+            handles: unsafe { Vec::from_raw_parts(ptr.cast(), length, capacity) },
+            next_index: 0,
+            biased,
+        }
+    }
 }
 
 impl Clone for Select<'_> {

--- a/crossbeam-channel/src/select.rs
+++ b/crossbeam-channel/src/select.rs
@@ -1203,9 +1203,9 @@ impl<'a> Select<'a> {
             biased,
         } = self;
         handles.clear();
-        // FIXME: Unsafe but stable version of [`Vec::recycle`].
-        // Replace with [`Vec::into_raw_parts`] when MSRV hits 1.93.
-        // Replace with [`Vec::recycle`] when it's stable.
+        // FIXME: Unsafe but stable version of `Vec::recycle`.
+        // Replace with `Vec::into_raw_parts` when MSRV hits 1.93.
+        // Replace with `Vec::recycle` when it's stable.
         let mut handles = mem::ManuallyDrop::new(handles);
         let (ptr, length, capacity) = (handles.as_mut_ptr(), handles.len(), handles.capacity());
         debug_assert_eq!(length, 0);

--- a/crossbeam-channel/src/select.rs
+++ b/crossbeam-channel/src/select.rs
@@ -1203,8 +1203,11 @@ impl<'a> Select<'a> {
             biased,
         } = self;
         handles.clear();
-        // FIXME: Unsafe but stable version of [`Vec::recycle`]. Replace with [`Vec::recycle`] when it's stable, if possible.
-        let (ptr, length, capacity) = handles.into_raw_parts();
+        // FIXME: Unsafe but stable version of [`Vec::recycle`].
+        // Replace with [`Vec::into_raw_parts`] when MSRV hits 1.93.
+        // Replace with [`Vec::recycle`] when it's stable.
+        let mut handles = mem::ManuallyDrop::new(handles);
+        let (ptr, length, capacity) = (handles.as_mut_ptr(), handles.len(), handles.capacity());
         Select {
             // SAFETY: this vec has been cleared beforehand, so the lifetime has ended.
             handles: unsafe { Vec::from_raw_parts(ptr.cast(), length, capacity) },


### PR DESCRIPTION
Reduce, reuse, recycle!
This PR adds a method to crossbeam-channel's `Select` that recycles the `Select` and its internal buffer (akin to [`Vec::recycle`](https://doc.rust-lang.org/stable/std/vec/struct.Vec.html#method.recycle)) with a new lifetime, and thus allows the referenced senders and receivers to be dropped, for example. (This is something I needed for a personal project)

First time contributing to crossbeam, please be kind, and let me know if there's anything I forgot to do.