### PR TITLE
channel: Document that recv_timeout returns an available message even if the timeout has elapsed

### DIFF
--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -860,7 +860,8 @@ impl<T> Receiver<T> {
     ///
     /// If the channel is empty and not disconnected, this call will block until the receive
     /// operation can proceed or the operation times out. If the channel is empty and becomes
-    /// disconnected, this call will wake up and return an error.
+    /// disconnected, this call will wake up and return an error. If the channel is non-empty
+    /// and the timeout has already elapsed, the next message in the channel will be returned.
     ///
     /// If called on a zero-capacity channel, this method will wait for a send operation to appear
     /// on the other side of the channel.

--- a/crossbeam-channel/tests/list.rs
+++ b/crossbeam-channel/tests/list.rs
@@ -133,6 +133,15 @@ fn recv_timeout() {
 }
 
 #[test]
+fn recv_timeout_nonempty_expired() {
+    let (s, r) = unbounded::<i32>();
+    s.send(5).unwrap();
+    // A non-empty channel yields an already-available message even with a zero (elapsed) timeout.
+    assert_eq!(r.recv_timeout(ms(0)), Ok(5));
+    assert_eq!(r.recv_timeout(ms(0)), Err(RecvTimeoutError::Timeout));
+}
+
+#[test]
 fn try_send() {
     const COUNT: usize = if cfg!(miri) { 50 } else { 1000 };
 


### PR DESCRIPTION
## What

Adds a sentence to `Receiver::recv_timeout`'s doc comment noting that a non-empty channel returns the next available message even when the timeout has already elapsed, and adds a unit test covering that behavior.

## Why

#1245 added the same clarifying note to the sibling method `recv_deadline` (to which `recv_timeout` delegates) but left `recv_timeout`'s docstring — which was otherwise identical — unchanged. This left the docs inconsistent and silently omitted the same real, non-obvious behavior: because the flavor `recv` implementations attempt message retrieval before checking the deadline/timeout, a non-empty channel yields a message even for a zero/elapsed timeout. This change mirrors the wording from #1245, adapting it to `recv_timeout`'s terminology ("timeout has already elapsed"), so both methods document the behavior identically.

## Testing

Added `recv_timeout_nonempty_expired` to `crossbeam-channel/tests/list.rs`, which sends a value and then asserts `recv_timeout(Duration::from_millis(0))` returns `Ok(5)` (message available despite the zero timeout) followed by `Err(RecvTimeoutError::Timeout)` on the now-empty channel. It is deterministic: the send fully completes before `recv_timeout` runs on the same thread, so `start_recv` succeeds on the first attempt before any timeout check.

- `cargo test -p crossbeam-channel --test list recv_timeout_nonempty_expired` — passes
- `cargo test --doc -p crossbeam-channel` — 73 passed (docstrings still compile)
- `rustfmt --check` and `cargo clippy -p crossbeam-channel --tests --all-features -- -D warnings` — clean
