### PR TITLE
ci: Re-enable macos-latest test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,8 @@ jobs:
             os: ubuntu-latest
           - rust: nightly
             os: ubuntu-24.04-arm
-          # - rust: nightly
-          #   os: macos-latest
+          - rust: nightly
+            os: macos-latest
           - rust: nightly
             os: windows-latest
           - rust: nightly

--- a/crossbeam-channel/tests/tick.rs
+++ b/crossbeam-channel/tests/tick.rs
@@ -16,6 +16,7 @@ fn ms(ms: u64) -> Duration {
 }
 
 #[test]
+#[cfg_attr(gha_macos_runner, ignore = "GitHub-hosted macOS runner is slow")]
 fn fire() {
     let start = Instant::now();
     let r = tick(ms(50));


### PR DESCRIPTION
Part of https://github.com/crossbeam-rs/crossbeam/issues/1282