### PR TITLE
Update MSRV policy to support 1 year instead of 6 months

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ crossbeam = "0.8"
 
 ## Compatibility
 
-Crossbeam supports stable Rust releases going back at least six months,
+Crossbeam supports stable Rust releases going back at least one year,
 and every time the minimum supported Rust version is increased, a new minor
 version is released. Currently, the minimum supported Rust version is 1.74.
 

--- a/crossbeam-channel/README.md
+++ b/crossbeam-channel/README.md
@@ -46,7 +46,7 @@ crossbeam-channel = "0.5"
 
 ## Compatibility
 
-Crossbeam Channel supports stable Rust releases going back at least six months,
+Crossbeam Channel supports stable Rust releases going back at least one year,
 and every time the minimum supported Rust version is increased, a new minor
 version is released. Currently, the minimum supported Rust version is 1.74.
 

--- a/crossbeam-deque/README.md
+++ b/crossbeam-deque/README.md
@@ -26,7 +26,7 @@ crossbeam-deque = "0.8"
 
 ## Compatibility
 
-Crossbeam Deque supports stable Rust releases going back at least six months,
+Crossbeam Deque supports stable Rust releases going back at least one year,
 and every time the minimum supported Rust version is increased, a new minor
 version is released. Currently, the minimum supported Rust version is 1.74.
 

--- a/crossbeam-epoch/README.md
+++ b/crossbeam-epoch/README.md
@@ -33,7 +33,7 @@ crossbeam-epoch = "0.9"
 
 ## Compatibility
 
-Crossbeam Epoch supports stable Rust releases going back at least six months,
+Crossbeam Epoch supports stable Rust releases going back at least one year,
 and every time the minimum supported Rust version is increased, a new minor
 version is released. Currently, the minimum supported Rust version is 1.74.
 

--- a/crossbeam-queue/README.md
+++ b/crossbeam-queue/README.md
@@ -34,7 +34,7 @@ crossbeam-queue = "0.3"
 
 ## Compatibility
 
-Crossbeam Queue supports stable Rust releases going back at least six months,
+Crossbeam Queue supports stable Rust releases going back at least one year,
 and every time the minimum supported Rust version is increased, a new minor
 version is released. Currently, the minimum supported Rust version is 1.60.
 

--- a/crossbeam-skiplist/README.md
+++ b/crossbeam-skiplist/README.md
@@ -32,7 +32,7 @@ crossbeam-skiplist = "0.1"
 
 ## Compatibility
 
-Crossbeam Skiplist supports stable Rust releases going back at least six months,
+Crossbeam Skiplist supports stable Rust releases going back at least one year,
 and every time the minimum supported Rust version is increased, a new minor
 version is released. Currently, the minimum supported Rust version is 1.74.
 

--- a/crossbeam-utils/README.md
+++ b/crossbeam-utils/README.md
@@ -53,7 +53,7 @@ crossbeam-utils = "0.8"
 
 ## Compatibility
 
-Crossbeam Utils supports stable Rust releases going back at least six months,
+Crossbeam Utils supports stable Rust releases going back at least one year,
 and every time the minimum supported Rust version is increased, a new minor
 version is released. Currently, the minimum supported Rust version is 1.56.
 


### PR DESCRIPTION
This makes MSRV bumps that meet our MSRV policy will now also meet rayon’s MSRV policy. This was originally proposed in my comment about four years ago (https://github.com/crossbeam-rs/crossbeam/pull/877#issuecomment-1192585582).

> Also, aside from this PR, I would like to update our MSRV policy to support 1 year instead of 6 months. Otherwise, it is impossible for rayon to actually maintain their MSRV policy (because our current MSRV policy allows us to increase the MSRV as a minor change).

Refs: rayon's MSRV policy https://github.com/rayon-rs/rfcs/blob/HEAD/accepted/rfc0003-minimum-rustc.md

FYI @cuviper

(Since crossbeam is also used by smol's internalls, I might update our policy to also take [its MSRV policy (Debian stable)](https://github.com/smol-rs/smol#msrv-policy) into account in the future. Our current actual MSRV is significantly lower than both of those policies.)