### PR TITLE
CachePadded: Fix doctest failure on m68k

### DIFF
--- a/crossbeam-utils/src/cache_padded.rs
+++ b/crossbeam-utils/src/cache_padded.rs
@@ -47,9 +47,9 @@ use core::{
 /// let addr1 = &*array[0] as *const i8 as usize;
 /// let addr2 = &*array[1] as *const i8 as usize;
 ///
-/// assert!(addr2 - addr1 >= 32);
-/// assert_eq!(addr1 % 32, 0);
-/// assert_eq!(addr2 % 32, 0);
+/// assert!(addr2 - addr1 >= 16);
+/// assert_eq!(addr1 % 16, 0);
+/// assert_eq!(addr2 % 16, 0);
 /// ```
 ///
 /// When building a concurrent queue with a head and a tail index, it is wise to place them in


### PR DESCRIPTION
m68k uses repr(align(16)).