### PR TITLE
channel: Fix stress_oneshot test in zero.rs

### DIFF
--- a/crossbeam-channel/tests/zero.rs
+++ b/crossbeam-channel/tests/zero.rs
@@ -307,7 +307,7 @@ fn stress_oneshot() {
     const COUNT: usize = if cfg!(miri) { 50 } else { 10_000 };
 
     for _ in 0..COUNT {
-        let (s, r) = bounded(1);
+        let (s, r) = bounded(0);
 
         scope(|scope| {
             scope.spawn(|_| r.recv().unwrap());


### PR DESCRIPTION
`bounded(1)` creates array flavor.