### PR TITLE
skiplist: Fix Send/Sync impl of RefRange

### DIFF
--- a/crossbeam-skiplist/src/base.rs
+++ b/crossbeam-skiplist/src/base.rs
@@ -2107,16 +2107,20 @@ where
 
 unsafe impl<Q, R, K, V, C> Send for RefRange<'_, Q, R, K, V, C>
 where
-    C: Comparator<K> + Comparator<K, Q>,
-    R: RangeBounds<Q>,
+    K: Send + Sync,
+    V: Send + Sync,
+    C: Comparator<K> + Comparator<K, Q> + Send + Sync,
+    R: RangeBounds<Q> + Send,
     Q: ?Sized,
 {
 }
 
 unsafe impl<Q, R, K, V, C> Sync for RefRange<'_, Q, R, K, V, C>
 where
-    C: Comparator<K> + Comparator<K, Q>,
-    R: RangeBounds<Q>,
+    K: Send + Sync,
+    V: Send + Sync,
+    C: Comparator<K> + Comparator<K, Q> + Send + Sync,
+    R: RangeBounds<Q> + Sync,
     Q: ?Sized,
 {
 }


### PR DESCRIPTION
Follow-up to https://github.com/crossbeam-rs/crossbeam/pull/1182#pullrequestreview-3837048671

```rs
#[test]
fn repro() {
    use std::cell::Cell;

    use crossbeam_skiplist::SkipMap;

    let map = SkipMap::new();
    map.insert(0, Cell::new(0));
    std::thread::scope(|scope| {
        let range = map.range(..);
        scope.spawn(move || {
            let cell = range.into_iter().next().unwrap();
            loop {
                cell.value().set(1);
            }
        });
        loop {
            map.get(&0).unwrap().value().set(2);
        }
    });
}
```

```
error: Undefined Behavior: Data race detected between (1) non-atomic write on thread `unnamed-2` and (2) retag write of type `i32` on thread `repro` at alloc55423
   --> /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/cell.rs:513:31
    |
513 |         mem::replace(unsafe { &mut *self.value.get() }, val)
    |                               ^^^^^^^^^^^^^^^^^^^^^^ (2) just happened here
    |
help: and (1) occurred earlier here
   --> crossbeam-skiplist/tests/map.rs:24:17
    |
 24 |                 cell.value().set(1);
    |                 ^^^^^^^^^^^^^^^^^^^
    = help: retags occur on all (re)borrows and as well as when references are copied or moved
    = help: retags permit optimizations that insert speculative reads or writes
    = help: therefore from the perspective of data races, a retag has the same implications as a read or write
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: this is on thread `repro`
    = note: stack backtrace:
            0: std::cell::Cell::<i32>::replace
                at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/cell.rs:513:31: 513:53
            1: std::cell::Cell::<i32>::set
                at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/cell.rs:437:9: 437:26
            2: repro::{closure#0}
                at crossbeam-skiplist/tests/map.rs:28:13: 28:48
            3: std::thread::scope::<'_, {closure@crossbeam-skiplist/tests/map.rs:19:24: 19:31}, ()>::{closure#0}
                at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/thread/scoped.rs:158:51: 158:60
            4: <std::panic::AssertUnwindSafe<{closure@std::thread::scope<'_, {closure@crossbeam-skiplist/tests/map.rs:19:24: 19:31}, ()>::{closure#0}}> as std::ops::FnOnce<()>>::call_once
                at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/panic/unwind_safe.rs:275:9: 275:19
            5: std::panicking::catch_unwind::do_call::<std::panic::AssertUnwindSafe<{closure@std::thread::scope<'_, {closure@crossbeam-skiplist/tests/map.rs:19:24: 19:31}, ()>::{closure#0}}>, ()>
                at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/panicking.rs:576:43: 576:46
            6: std::panicking::catch_unwind::<(), std::panic::AssertUnwindSafe<{closure@std::thread::scope<'_, {closure@crossbeam-skiplist/tests/map.rs:19:24: 19:31}, ()>::{closure#0}}>>
                at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/panicking.rs:544:19: 544:77
            7: std::panic::catch_unwind::<std::panic::AssertUnwindSafe<{closure@std::thread::scope<'_, {closure@crossbeam-skiplist/tests/map.rs:19:24: 19:31}, ()>::{closure#0}}>, ()>
                at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/panic.rs:359:14: 359:40
            8: repro
                at crossbeam-skiplist/tests/map.rs:19:5: 30:7
            9: repro::{closure#0}
                at crossbeam-skiplist/tests/map.rs:12:11: 12:11
```