### PR TITLE
epoch: Fix defer_destroy doc example about not requiring T: Send

### DIFF
--- a/crossbeam-epoch/src/guard.rs
+++ b/crossbeam-epoch/src/guard.rs
@@ -224,16 +224,27 @@ impl Guard {
     /// must be sendable to other threads.
     ///
     /// We intentionally didn't require `T: Send`, because Rust's type systems usually cannot prove
-    /// `T: Send` for typical use cases. For example, consider the following code snippet, which
-    /// exemplifies the typical use case of deferring the deallocation of a shared reference:
+    /// `T: Send` for typical use cases. For example, nodes of concurrent data structures often
+    /// contain raw pointers to other nodes, which makes them not `Send`:
     ///
-    /// ```ignore
-    /// let shared = Owned::new(7i32).into_shared(guard);
-    /// guard.defer_destroy(shared); // `Shared` is not `Send`!
+    /// ```
+    /// use crossbeam_epoch::{self as epoch, Owned};
+    /// use std::ptr;
+    ///
+    /// struct Node {
+    ///     value: i32,
+    ///     next: *mut Node, // raw pointers are not `Send`
+    /// }
+    ///
+    /// let guard = &epoch::pin();
+    /// let node = Owned::new(Node { value: 7, next: ptr::null_mut() }).into_shared(guard);
+    /// unsafe {
+    ///     guard.defer_destroy(node); // `Node` is not `Send`!
+    /// }
     /// ```
     ///
-    /// While `Shared` is not `Send`, it's safe for another thread to call the destructor, because
-    /// it's called only after the grace period and `shared` is no longer shared with other
+    /// While `Node` is not `Send`, it's safe for another thread to call the destructor, because
+    /// it's called only after the grace period and the object is no longer shared with other
     /// threads. But we don't expect type systems to prove this.
     ///
     /// # Examples


### PR DESCRIPTION
## What

Replaces the doc example in `Guard::defer_destroy` that motivates the lack of a `T: Send` bound, and turns it from an `ignore` block into a compiling doctest.

Fixes #1253.

## Why

The old snippet was copied from `defer_unchecked` and doesn't actually demonstrate the point: it defers destruction of an `i32`, which *is* `Send`, so it would compile fine even if `defer_destroy` required `T: Send`. The comment "`Shared` is not `Send`!" is beside the point, since the bound in question is on `T`, not on `Shared<'_, T>`.

The new example shows the actual typical case where the type system can't prove `T: Send`: a concurrent data structure node containing a raw pointer to another node. Raw pointers are not `Send`, so such a `Node` isn't either, yet deferring its destruction is fine because the destructor only runs after the grace period, when the object is no longer shared. The surrounding prose is updated to match.

## Testing

The example is now a real doctest instead of `ignore`, so it's compiled and run by CI.

- `cargo test --doc guard` in `crossbeam-epoch` — 13 passed (including the new `defer_destroy` doctest)
- `cargo fmt --check -p crossbeam-epoch` — clean
