### PR TITLE
channel: Fix misleading comment in Select::remove example

### DIFF
--- a/crossbeam-channel/src/select.rs
+++ b/crossbeam-channel/src/select.rs
@@ -737,7 +737,8 @@ impl<'a> Select<'a> {
     /// let oper1 = sel.recv(&r1);
     /// let oper2 = sel.recv(&r2);
     ///
-    /// // Both operations are initially ready, so a random one will be executed.
+    /// // Only operation 2 is ready: `r2` is disconnected, and a receive operation is ready
+    /// // even when it will simply return an error because the channel is disconnected.
     /// let oper = sel.select();
     /// assert_eq!(oper.index(), oper2);
     /// assert!(oper.recv(&r2).is_err());


### PR DESCRIPTION
## What

Fixes a misleading comment in the `Select::remove` doc example. The example asserts `oper.index() == oper2`, but the comment above the `select()` call claimed "Both operations are initially ready, so a random one will be executed."

## Why

Closes #721.

Only operation 2 is ready: `r2` is disconnected, and a receive operation is considered ready even when it will simply return an error because the channel is disconnected. `r1` is empty (nothing is sent on `s1` until after the select), so receiving from it would block. That's why the assertions on `oper2` always hold — the old comment contradicted them. The new wording matches the phrasing already used in the `select()` docs for the same situation.

## Testing

Comment-only change inside a doc example; the example's assertions already pin the behavior the comment now describes.

- `cargo test --doc remove` in `crossbeam-channel` — passes
