### PR TITLE
utils: Fix ShardedLock::write documentation copied from read

### DIFF
--- a/crossbeam-utils/src/sync/sharded_lock.rs
+++ b/crossbeam-utils/src/sync/sharded_lock.rs
@@ -383,10 +383,9 @@ impl<T: ?Sized> ShardedLock<T> {
 
     /// Locks with exclusive write access, blocking the current thread until it can be acquired.
     ///
-    /// The calling thread will be blocked until there are no more writers which hold the lock.
-    /// There may be other readers currently inside the lock when this method returns. This method
-    /// does not provide any guarantees with respect to the ordering of whether contentious readers
-    /// or writers will acquire the lock first.
+    /// This method will not return while other writers or other readers currently have access to
+    /// the lock. This method does not provide any guarantees with respect to the ordering of
+    /// whether contentious readers or writers will acquire the lock first.
     ///
     /// Returns a guard which will release the exclusive access when dropped.
     ///


### PR DESCRIPTION
## What

Rewords the blocking-behavior paragraph in `ShardedLock::write`'s doc comment, which was copied verbatim from `read` and describes the wrong semantics.

## Why

The current text says `write` blocks "until there are no more writers which hold the lock" and that "there may be other readers currently inside the lock when this method returns". Both statements are true for `read` but wrong for `write`: it acquires every shard exclusively, so it also blocks while readers hold the lock, and no readers can be inside once it returns — the method's own example demonstrates this with `try_read` failing while the write guard is held. The new wording matches `std::sync::RwLock::write`, keeping the existing sentence about no ordering guarantees between contentious readers and writers.

## Testing

Doc-only, no behavior change.

- `cargo test --test sharded_lock` in `crossbeam-utils` — 15 passed
- `cargo test --doc sharded_lock` — 9 passed
- `rustfmt --check` — clean
