### PR TITLE
skiplist: Document why insert and remove require Send but get_or_insert does not

### DIFF
--- a/crossbeam-skiplist/src/map.rs
+++ b/crossbeam-skiplist/src/map.rs
@@ -148,6 +148,9 @@ where
 
     /// Finds an entry with the specified key, or inserts a new `key`-`value` pair if none exist.
     ///
+    /// Unlike [`insert`](SkipMap::insert), this method does not require `K: Send` and `V: Send`
+    /// because it never removes an existing entry.
+    ///
     /// This function returns an [`Entry`] which
     /// can be used to access the key's associated value.
     ///
@@ -388,6 +391,11 @@ where
     /// If there is an existing entry with this key, it will be removed before inserting the new
     /// one.
     ///
+    /// This method requires `K: Send` and `V: Send` because a removed entry is handed to the
+    /// epoch-based garbage collector, which may drop it on a different thread.
+    /// [`get_or_insert`](SkipMap::get_or_insert) never removes an existing entry and does not
+    /// require these bounds.
+    ///
     /// This function returns an [`Entry`] which
     /// can be used to access the inserted key's associated value.
     ///
@@ -410,6 +418,9 @@ where
     /// If there is an existing entry with this key and compare(entry.value) returns true,
     /// it will be removed before inserting the new one.
     /// The closure will not be called if the key is not present.
+    ///
+    /// This method requires `K: Send` and `V: Send` for the same reason as
+    /// [`insert`](SkipMap::insert).
     ///
     /// This function returns an [`Entry`] which
     /// can be used to access the inserted key's associated value.
@@ -439,6 +450,9 @@ where
     ///
     /// The value will not actually be dropped until all references to it have gone
     /// out of scope.
+    ///
+    /// This method requires `K: Send` and `V: Send` because the removed entry is handed to the
+    /// epoch-based garbage collector, which may drop it on a different thread.
     ///
     /// This function returns an [`Entry`] which
     /// can be used to access the removed key's associated value.

--- a/crossbeam-skiplist/src/set.rs
+++ b/crossbeam-skiplist/src/set.rs
@@ -235,6 +235,9 @@ where
 
     /// Finds an entry with the specified key, or inserts a new `key`-`value` pair if none exist.
     ///
+    /// Unlike [`insert`](SkipSet::insert), this method does not require `T: Send` because it
+    /// never removes an existing entry.
+    ///
     /// # Example
     ///
     /// ```
@@ -311,6 +314,11 @@ where
     /// If there is an existing entry with this key, it will be removed before inserting the new
     /// one.
     ///
+    /// This method requires `T: Send` because a removed entry is handed to the epoch-based
+    /// garbage collector, which may drop it on a different thread.
+    /// [`get_or_insert`](SkipSet::get_or_insert) never removes an existing entry and does not
+    /// require this bound.
+    ///
     /// # Example
     ///
     /// ```
@@ -328,6 +336,9 @@ where
     ///
     /// The value will not actually be dropped until all references to it have gone
     /// out of scope.
+    ///
+    /// This method requires `T: Send` because the removed entry is handed to the epoch-based
+    /// garbage collector, which may drop it on a different thread.
     ///
     /// # Example
     ///


### PR DESCRIPTION
## What

Adds doc notes to `SkipMap::{insert, compare_insert, remove, get_or_insert}` and `SkipSet::{insert, remove, get_or_insert}` explaining why the removing methods require `Send` bounds on the key/value types while `get_or_insert` does not.

Fixes #1130.

## Why

#1130 flags the asymmetry as suspicious: `insert` requires `K: Send` and `V: Send` but `get_or_insert` doesn't. As explained in that issue, the bound is real and comes from the removal path, not the insertion: a replaced or removed entry is handed to the epoch-based garbage collector, which may drop it on a different thread. `get_or_insert` never removes an existing entry, so it doesn't need the bound. None of this was documented, so the signatures just looked inconsistent; the follow-up comment on the issue asked for exactly this documentation.

## Testing

Docs-only change, no behavior affected.

- `cargo test --doc` in `crossbeam-skiplist` — 43 passed (docstrings and intra-doc links still compile)
- `cargo fmt --check -p crossbeam-skiplist` — clean
