### PR TITLE
ShardedLock: Fix SB violation when ShardedLockWriteGuard is leaked

### DIFF
--- a/crossbeam-utils/src/sync/sharded_lock.rs
+++ b/crossbeam-utils/src/sync/sharded_lock.rs
@@ -3,7 +3,7 @@ use core::{
     cell::UnsafeCell,
     fmt,
     marker::PhantomData,
-    mem,
+    mem::{self, MaybeUninit},
     ops::{Deref, DerefMut},
     panic::{RefUnwindSafe, UnwindSafe},
 };
@@ -30,7 +30,7 @@ struct Shard {
     ///
     /// Write operations will lock each shard and store the guard here. These guards get dropped at
     /// the same time the big guard is dropped.
-    write_guard: UnsafeCell<Option<RwLockWriteGuard<'static, ()>>>,
+    write_guard: UnsafeCell<MaybeUninit<RwLockWriteGuard<'static, ()>>>,
 }
 
 /// A sharded reader-writer lock.
@@ -109,7 +109,7 @@ impl<T> ShardedLock<T> {
                 .map(|_| {
                     CachePadded::new(Shard {
                         lock: RwLock::new(()),
-                        write_guard: UnsafeCell::new(None),
+                        write_guard: UnsafeCell::new(MaybeUninit::uninit()),
                     })
                 })
                 .collect::<Box<[_]>>(),
@@ -353,18 +353,18 @@ impl<T: ?Sized> ShardedLock<T> {
             unsafe {
                 let guard: RwLockWriteGuard<'static, ()> = mem::transmute(guard);
                 let dest: *mut _ = shard.write_guard.get();
-                *dest = Some(guard);
+                *dest = MaybeUninit::new(guard);
             }
         }
 
         if let Some(i) = blocked {
             // Unlock the shards in reverse order of locking.
             for shard in self.shards[0..i].iter().rev() {
-                unsafe {
-                    let dest: *mut _ = shard.write_guard.get();
-                    let guard = (*dest).take();
-                    drop(guard);
-                }
+                let dest: *mut MaybeUninit<RwLockWriteGuard<'static, ()>> = shard.write_guard.get();
+                // SAFETY: we've acquired lock and filled write_guard of self.shards[0..i].
+                // Note that drop_in_place cannot be used because it releases the lock during the drop.
+                let guard = unsafe { dest.cast::<RwLockWriteGuard<'static, ()>>().read() };
+                drop(guard);
             }
             Err(TryLockError::WouldBlock)
         } else if poisoned {
@@ -429,7 +429,7 @@ impl<T: ?Sized> ShardedLock<T> {
                 let guard: RwLockWriteGuard<'_, ()> = guard;
                 let guard: RwLockWriteGuard<'static, ()> = mem::transmute(guard);
                 let dest: *mut _ = shard.write_guard.get();
-                *dest = Some(guard);
+                *dest = MaybeUninit::new(guard);
             }
         }
 
@@ -530,11 +530,11 @@ impl<T: ?Sized> Drop for ShardedLockWriteGuard<'_, T> {
     fn drop(&mut self) {
         // Unlock the shards in reverse order of locking.
         for shard in self.lock.shards.iter().rev() {
-            unsafe {
-                let dest: *mut _ = shard.write_guard.get();
-                let guard = (*dest).take();
-                drop(guard);
-            }
+            let dest: *mut MaybeUninit<RwLockWriteGuard<'static, ()>> = shard.write_guard.get();
+            // SAFETY: ShardedLockWriteGuard is constructed only when all locks have been acquired.
+            // Note that drop_in_place cannot be used because it releases the lock during the drop.
+            let guard = unsafe { dest.cast::<RwLockWriteGuard<'static, ()>>().read() };
+            drop(guard);
         }
     }
 }

--- a/crossbeam-utils/tests/sharded_lock.rs
+++ b/crossbeam-utils/tests/sharded_lock.rs
@@ -1,4 +1,5 @@
 use std::{
+    mem,
     sync::{
         Arc, TryLockError,
         atomic::{AtomicUsize, Ordering},
@@ -248,5 +249,19 @@ fn test_get_mut_poison() {
     match Arc::try_unwrap(m).unwrap().get_mut() {
         Err(e) => assert_eq!(*e.into_inner(), NonCopy(10)),
         Ok(x) => panic!("get_mut of poisoned ShardedLock is Ok: {:?}", x),
+    }
+}
+
+#[test]
+fn forget_guard() {
+    {
+        let lock = ShardedLock::new(vec![1, 2, 3]);
+        let guard = lock.write().unwrap();
+        mem::forget(guard);
+    }
+    {
+        let lock = ShardedLock::new(vec![1, 2, 3]);
+        let guard = lock.read().unwrap();
+        mem::forget(guard);
     }
 }


### PR DESCRIPTION
```
error: Undefined Behavior: trying to retag from <143433> for SharedReadWrite permission at alloc45457[0x8], but that tag does not exist in the borrow stack for this location
    --> /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/sync/poison/rwlock.rs:1130:9
     |
1130 |         self.lock.poison.done(&self.poison);
     |         ^^^^^^^^^^^^^^^^ this error occurs as part of retag at alloc45457[0x8..0x9]
     |
     = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
     = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
help: <143433> was created by a SharedReadWrite retag at offsets [0x0..0x9]
    --> crossbeam-utils/src/sync/sharded_lock.rs:432:16
help: <143433> was later invalidated at offsets [0x0..0x400] by a Unique function-entry retag inside this call
    --> crossbeam-utils/tests/sharded_lock.rs:261:5
     |
 261 |     }
     |     ^
     = note: this is on thread `forget_guard`
     = note: stack backtrace:
             0: <std::sync::RwLockWriteGuard<'_, ()> as std::ops::Drop>::drop
                 at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/sync/poison/rwlock.rs:1130:9: 1130:25
             1: std::ptr::drop_glue::<std::sync::RwLockWriteGuard<'_, ()>> - shim(Some(std::sync::RwLockWriteGuard<'_, ()>))
                 at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:823:1: 825:25
             2: std::ptr::drop_glue::<std::option::Option<std::sync::RwLockWriteGuard<'_, ()>>> - shim(Some(std::option::Option<std::sync::RwLockWriteGuard<'_, ()>>))
                 at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:823:1: 825:25
             3: std::ptr::drop_glue::<std::cell::UnsafeCell<std::option::Option<std::sync::RwLockWriteGuard<'_, ()>>>> - shim(Some(std::cell::UnsafeCell<std::option::Option<std::sync::RwLockWriteGuard<'_, ()>>>))
                 at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:823:1: 825:25
             4: std::ptr::drop_glue::<crossbeam_utils::sync::sharded_lock::Shard> - shim(Some(crossbeam_utils::sync::sharded_lock::Shard))
                 at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:823:1: 825:25
             5: std::ptr::drop_glue::<crossbeam_utils::CachePadded<crossbeam_utils::sync::sharded_lock::Shard>> - shim(Some(crossbeam_utils::CachePadded<crossbeam_utils::sync::sharded_lock::Shard>))
                 at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:823:1: 825:25
             6: std::ptr::drop_glue::<[crossbeam_utils::CachePadded<crossbeam_utils::sync::sharded_lock::Shard>]> - shim(Some([crossbeam_utils::CachePadded<crossbeam_utils::sync::sharded_lock::Shard>]))
                 at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:823:1: 825:25
             7: std::ptr::drop_glue::<std::boxed::Box<[crossbeam_utils::CachePadded<crossbeam_utils::sync::sharded_lock::Shard>]>> - shim(Some(std::boxed::Box<[crossbeam_utils::CachePadded<crossbeam_utils::sync::sharded_lock::Shard>]>))
                 at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:823:1: 825:25
             8: std::ptr::drop_glue::<crossbeam_utils::sync::ShardedLock<std::vec::Vec<i32>>> - shim(Some(crossbeam_utils::sync::ShardedLock<std::vec::Vec<i32>>))
                 at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:823:1: 825:25
             9: forget_guard
                 at crossbeam-utils/tests/sharded_lock.rs:261:5: 261:6
             10: forget_guard::{closure#0}
                 at crossbeam-utils/tests/sharded_lock.rs:256:18: 256:18
```