### PR TITLE
 channel: Fix UB in bounded channel when SelectedOperation is leaked

### DIFF
--- a/crossbeam-channel/src/flavors/list.rs
+++ b/crossbeam-channel/src/flavors/list.rs
@@ -687,8 +687,10 @@ impl<T> Drop for Channel<T> {
 
                 if offset < BLOCK_CAP {
                     // Drop the message in the slot.
-                    let slot = (*block).slots.get_unchecked(offset);
-                    (*slot.msg.get()).assume_init_drop();
+                    let slot = (*block).slots.get_unchecked_mut(offset);
+                    if *slot.state.get_mut() & WRITE != 0 {
+                        (*slot.msg.get()).assume_init_drop();
+                    }
                 } else {
                     // Deallocate the block and move to the next one.
                     let next = *(*block).next.get_mut();

--- a/crossbeam-channel/tests/select.rs
+++ b/crossbeam-channel/tests/select.rs
@@ -3,6 +3,7 @@
 use std::{
     any::Any,
     cell::Cell,
+    mem,
     sync::{
         Arc, Barrier,
         atomic::{AtomicBool, Ordering},
@@ -1370,52 +1371,67 @@ fn issue_1096() {
 #[test]
 // TODO: should panic instead of hang
 // #[should_panic(expected = "dropped `SelectedOperation` without completing the operation")]
-fn uncompleted_select_bounded() {
-    // https://github.com/rust-lang/miri/issues/1371
-    if option_env!("MIRI_LEAK_CHECK").is_some() {
-        return;
-    }
-    let barrier = Arc::new(Barrier::new(2));
-    let barrier2 = barrier.clone();
-    let ready = Arc::new(AtomicBool::new(false));
-    let ready2 = ready.clone();
-    std::thread::spawn(move || {
-        let (s, _r) = bounded::<Box<u8>>(1);
-        let mut sel = Select::new();
-        sel.send(&s);
-        let op = sel.try_select().unwrap();
-        barrier2.wait();
-        drop(op);
-        ready2.store(true, Ordering::Relaxed);
-    });
-    barrier.wait();
-    std::thread::sleep(Duration::from_secs(5));
-    assert!(!ready.load(Ordering::Relaxed));
-}
-#[test]
-// TODO: should panic instead of hang
-// #[should_panic(expected = "dropped `SelectedOperation` without completing the operation")]
 fn uncompleted_select_unbounded() {
     // https://github.com/rust-lang/miri/issues/1371
     if option_env!("MIRI_LEAK_CHECK").is_some() {
         return;
     }
-    let barrier = Arc::new(Barrier::new(2));
-    let barrier2 = barrier.clone();
-    let ready = Arc::new(AtomicBool::new(false));
-    let ready2 = ready.clone();
-    std::thread::spawn(move || {
-        let (s, _r) = unbounded::<Box<u8>>();
-        let mut sel = Select::new();
-        sel.send(&s);
-        let op = sel.try_select().unwrap();
-        barrier2.wait();
-        drop(op);
-        ready2.store(true, Ordering::Relaxed);
-    });
-    barrier.wait();
-    std::thread::sleep(Duration::from_secs(5));
-    assert!(!ready.load(Ordering::Relaxed));
+    for i in 0..=1 {
+        let barrier = Arc::new(Barrier::new(2));
+        let barrier2 = barrier.clone();
+        let ready = Arc::new(AtomicBool::new(false));
+        let ready2 = ready.clone();
+        thread::spawn(move || {
+            let (s, _r) = unbounded::<Box<u8>>();
+            for i in 0..i {
+                s.send(Box::new(i)).unwrap();
+            }
+            let mut sel = Select::new();
+            sel.send(&s);
+            let op = sel.try_select().unwrap();
+            barrier2.wait();
+            drop(op);
+            ready2.store(true, Ordering::Relaxed);
+        });
+        barrier.wait();
+        thread::sleep(Duration::from_secs(5));
+        assert!(!ready.load(Ordering::Relaxed));
+    }
+}
+#[test]
+// TODO: should panic instead of hang
+// #[should_panic(expected = "dropped `SelectedOperation` without completing the operation")]
+fn uncompleted_select_bounded() {
+    // https://github.com/rust-lang/miri/issues/1371
+    if option_env!("MIRI_LEAK_CHECK").is_some() {
+        return;
+    }
+    for i in 0..=2 {
+        let barrier = Arc::new(Barrier::new(2));
+        let barrier2 = barrier.clone();
+        let ready = Arc::new(AtomicBool::new(false));
+        let ready2 = ready.clone();
+        thread::spawn(move || {
+            let (s, _r) = bounded::<Box<u8>>(2);
+            for i in 0..i {
+                s.send(Box::new(i)).unwrap();
+            }
+            let mut sel = Select::new();
+            if i == 2 {
+                barrier2.wait();
+                sel.send(&s);
+                panic!();
+            }
+            sel.send(&s);
+            let op = sel.try_select().unwrap();
+            barrier2.wait();
+            drop(op);
+            ready2.store(true, Ordering::Relaxed);
+        });
+        barrier.wait();
+        thread::sleep(Duration::from_secs(5));
+        assert!(!ready.load(Ordering::Relaxed));
+    }
 }
 #[test]
 fn uncompleted_select_zero() {
@@ -1428,14 +1444,14 @@ fn uncompleted_select_zero() {
     let ready = Arc::new(AtomicBool::new(false));
     let ready2 = ready.clone();
     let (s, r) = bounded::<Box<u8>>(0);
-    std::thread::spawn(move || {
+    thread::spawn(move || {
         barrier2.wait();
         // TODO: should error instead hang
         r.recv().unwrap();
         ready2.store(true, Ordering::Relaxed);
     });
     barrier.wait();
-    std::thread::sleep(Duration::from_secs(1)); // wait for register of receiver.
+    thread::sleep(Duration::from_secs(1)); // wait for register of receiver.
     let res = std::panic::catch_unwind(move || {
         let mut sel = Select::new();
         sel.send(&s);
@@ -1445,6 +1461,79 @@ fn uncompleted_select_zero() {
         *res.unwrap_err().downcast_ref::<&str>().unwrap(),
         "dropped `SelectedOperation` without completing the operation"
     );
-    std::thread::sleep(Duration::from_secs(5));
+    thread::sleep(Duration::from_secs(5));
     assert!(!ready.load(Ordering::Relaxed));
+}
+
+#[test]
+fn forget_select_unbounded() {
+    for i in 0..=1 {
+        let (s, r) = unbounded::<Box<u8>>();
+        for i in 0..i {
+            s.send(Box::new(i)).unwrap();
+        }
+        let s2 = s.clone();
+        let th = thread::spawn(move || {
+            let mut sel = Select::new();
+            sel.send(&s2);
+            let oper = sel.select();
+            mem::forget(oper);
+        });
+        thread::sleep(Duration::from_millis(50));
+        drop(s);
+        drop(r);
+        th.join().unwrap();
+    }
+}
+#[test]
+fn forget_select_bounded() {
+    for i in 0..=2 {
+        let (s, r) = bounded::<Box<u8>>(2);
+        for i in 0..i {
+            s.send(Box::new(i)).unwrap();
+        }
+        let s2 = s.clone();
+        let th = thread::spawn(move || {
+            let mut sel = Select::new();
+            sel.send(&s2);
+            let oper = sel.select();
+            mem::forget(oper);
+        });
+        if i == 2 {
+            thread::sleep(Duration::from_millis(50));
+            drop(s);
+            drop(r);
+        } else if option_env!("MIRI_LEAK_CHECK").is_some() {
+            // https://github.com/rust-lang/miri/issues/1371
+            continue;
+        } else {
+            let ready = Arc::new(AtomicBool::new(false));
+            let ready2 = ready.clone();
+            thread::spawn(move || {
+                thread::sleep(Duration::from_millis(50));
+                drop(s);
+                drop(r);
+                // TODO: should not hang
+                ready2.store(true, Ordering::Relaxed);
+            });
+            th.join().unwrap();
+            thread::sleep(Duration::from_secs(5));
+            assert!(!ready.load(Ordering::Relaxed));
+        }
+    }
+}
+#[test]
+fn forget_select_zero() {
+    let (s, r) = bounded::<Box<u8>>(0);
+    let s2 = s.clone();
+    let th = thread::spawn(move || {
+        let mut sel = Select::new();
+        sel.send(&s2);
+        let oper = sel.select();
+        mem::forget(oper);
+    });
+    thread::sleep(Duration::from_millis(50));
+    drop(s);
+    drop(r);
+    th.join().unwrap();
 }


### PR DESCRIPTION
Found by Claude Opus.
```
error: Undefined Behavior: constructing invalid value of type std::ptr::NonNull<u8>: at .pointer, encountered 0, but expected something greater or equal to 1
   --> /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:823:1
    |
823 | / pub(crate) const unsafe fn drop_glue<T: PointeeSized>(_: &mut T)
824 | | where
825 | |     T: [const] Destruct,
    | |________________________^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: this is on thread `forget_select_unbounded`
    = note: stack backtrace:
            0: std::ptr::drop_glue::<std::boxed::Box<u8>> - shim(Some(std::boxed::Box<u8>))
                at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:823:1: 825:25
            1: std::ptr::drop_in_place::<std::boxed::Box<u8>>
                at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:818:14: 818:38
            2: std::mem::MaybeUninit::<std::boxed::Box<u8>>::assume_init_drop
                at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/mem/maybe_uninit.rs:833:18: 833:55
            3: <crossbeam_channel::flavors::list::Channel<std::boxed::Box<u8>> as std::ops::Drop>::drop
                at crossbeam-channel/src/flavors/list.rs:691:21: 691:57
            4: std::ptr::drop_glue::<crossbeam_channel::flavors::list::Channel<std::boxed::Box<u8>>> - shim(Some(crossbeam_channel::flavors::list::Channel<std::boxed::Box<u8>>))
                at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:823:1: 825:25
            5: std::ptr::drop_glue::<crossbeam_channel::counter::Counter<crossbeam_channel::flavors::list::Channel<std::boxed::Box<u8>>>> - shim(Some(crossbeam_channel::counter::Counter<crossbeam_channel::flavors::list::Channel<std::boxed::Box<u8>>>))
                at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:823:1: 825:25
            6: std::ptr::drop_glue::<std::boxed::Box<crossbeam_channel::counter::Counter<crossbeam_channel::flavors::list::Channel<std::boxed::Box<u8>>>>> - shim(Some(std::boxed::Box<crossbeam_channel::counter::Counter<crossbeam_channel::flavors::list::Channel<std::boxed::Box<u8>>>>))
                at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:823:1: 825:25
            7: std::mem::drop::<std::boxed::Box<crossbeam_channel::counter::Counter<crossbeam_channel::flavors::list::Channel<std::boxed::Box<u8>>>>>
                at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/mem/mod.rs:1042:1: 1042:2
            8: crossbeam_channel::counter::Receiver::<crossbeam_channel::flavors::list::Channel<std::boxed::Box<u8>>>::release::<{closure@<crossbeam_channel::Receiver<std::boxed::Box<u8>> as std::ops::Drop>::drop::{closure#1}}>
                at crossbeam-channel/src/counter.rs:133:17: 133:70
            9: <crossbeam_channel::Receiver<std::boxed::Box<u8>> as std::ops::Drop>::drop
                at crossbeam-channel/src/channel.rs:1190:47: 1190:89
            10: std::ptr::drop_glue::<crossbeam_channel::Receiver<std::boxed::Box<u8>>> - shim(Some(crossbeam_channel::Receiver<std::boxed::Box<u8>>))
                at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:823:1: 825:25
            11: std::mem::drop::<crossbeam_channel::Receiver<std::boxed::Box<u8>>>
                at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/mem/mod.rs:1042:1: 1042:2
            12: forget_select_unbounded
                at crossbeam-channel/tests/select.rs:1484:9: 1484:16
            13: forget_select_unbounded::{closure#0}
                at crossbeam-channel/tests/select.rs:1469:29: 1469:29
```