### PR TITLE
channel: Fix behavior inconsistency on received==true case in at()

### DIFF
--- a/crossbeam-channel/src/flavors/at.rs
+++ b/crossbeam-channel/src/flavors/at.rs
@@ -91,9 +91,9 @@ impl Channel {
             // Success! Return the message, which is the instant at which it was delivered.
             Ok(self.delivery_time)
         } else {
-            // The message was already received. Block forever.
-            utils::sleep_until(None);
-            unreachable!()
+            // The message was already received.
+            utils::sleep_until(deadline);
+            Err(RecvTimeoutError::Timeout)
         }
     }
 


### PR DESCRIPTION
At the start of recv.
https://github.com/crossbeam-rs/crossbeam/blob/ac6f005e439f5ad0d0ddea0b26dddd6790f81287/crossbeam-channel/src/flavors/at.rs#L64-L69
At the end of recv.
https://github.com/crossbeam-rs/crossbeam/blob/ac6f005e439f5ad0d0ddea0b26dddd6790f81287/crossbeam-channel/src/flavors/at.rs#L89-L97
It should have the same behavior.