### PR TITLE
epoch: Fix SB violation when guard used after handle&collector dropped

### DIFF
--- a/crossbeam-epoch/src/collector.rs
+++ b/crossbeam-epoch/src/collector.rs
@@ -101,7 +101,7 @@ impl Drop for LocalHandle {
     #[inline]
     fn drop(&mut self) {
         unsafe {
-            Local::release_handle(&*self.local);
+            Local::release_handle(self.local);
         }
     }
 }
@@ -451,5 +451,18 @@ mod tests {
             collector.global.collect(guard);
         }
         assert_eq!(DROPS.load(Ordering::Relaxed), COUNT * THREADS);
+    }
+
+    #[test]
+    fn use_guard_after_handle_and_collector_dropped() {
+        let collector = Collector::new();
+        let handle = collector.register();
+
+        let guard = handle.pin();
+
+        drop(collector);
+        drop(handle);
+
+        guard.flush();
     }
 }

--- a/crossbeam-epoch/src/guard.rs
+++ b/crossbeam-epoch/src/guard.rs
@@ -384,7 +384,7 @@ impl Guard {
             // We need to acquire a handle here to ensure the Local doesn't
             // disappear from under us.
             local.acquire_handle();
-            local.unpin();
+            unsafe { Local::unpin(self.local) }
         }
 
         let _guard = ScopeGuard(self.local);
@@ -416,8 +416,8 @@ impl Guard {
 impl Drop for Guard {
     #[inline]
     fn drop(&mut self) {
-        if let Some(local) = unsafe { self.local.as_ref() } {
-            local.unpin();
+        if !self.local.is_null() {
+            unsafe { Local::unpin(self.local) }
         }
     }
 }

--- a/crossbeam-epoch/src/internal.rs
+++ b/crossbeam-epoch/src/internal.rs
@@ -463,16 +463,16 @@ impl Local {
 
     /// Unpins the `Local`.
     #[inline]
-    pub(crate) fn unpin(&self) {
-        let guard_count = self.guard_count.get();
-        self.guard_count.set(guard_count - 1);
+    pub(crate) unsafe fn unpin(this: *const Self) {
+        let guard_count = unsafe { (*this).guard_count.get() };
+        unsafe { (*this).guard_count.set(guard_count - 1) }
 
         if guard_count == 1 {
-            self.epoch.store(Epoch::starting(), Ordering::Release);
+            unsafe { (*this).epoch.store(Epoch::starting(), Ordering::Release) }
 
-            if self.handle_count.get() == 0 {
+            if unsafe { (*this).handle_count.get() } == 0 {
                 unsafe {
-                    Self::finalize(self);
+                    Self::finalize(this);
                 }
             }
         }


### PR DESCRIPTION
Found by Claude Opus.

```text
error: Undefined Behavior: not granting access to tag <1190> because that would remove [SharedReadOnly for <2328>] which is strongly protected
    --> /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/boxed.rs:1562:9
     |
1562 |         Box(unsafe { Unique::new_unchecked(raw) }, alloc)
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
     |
     = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
     = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
help: <1190> was created by a SharedReadWrite retag at offsets [0x0..0x180]
    --> crossbeam-epoch/src/atomic.rs:167:9
     |
 167 |         Box::into_raw(Box::new(init)).cast::<()>()
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
help: <2328> is this argument
    --> crossbeam-epoch/src/internal.rs:466:25
     |
 466 |     pub(crate) fn unpin(&self) {
     |                         ^^^^^
     = note: stack backtrace:
             0: std::boxed::Box::<crossbeam_epoch::internal::Local>::from_raw_in
                 at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/boxed.rs:1562:9: 1562:58
             1: std::boxed::Box::<crossbeam_epoch::internal::Local>::from_raw
                 at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/boxed.rs:1325:18: 1325:48
             2: <crossbeam_epoch::internal::Local as crossbeam_epoch::Pointable>::drop
                 at crossbeam-epoch/src/atomic.rs:179:23: 179:53
             3: <crossbeam_epoch::Owned<crossbeam_epoch::internal::Local> as std::ops::Drop>::drop
                 at crossbeam-epoch/src/atomic.rs:1104:13: 1104:25
             4: std::ptr::drop_glue::<crossbeam_epoch::Owned<crossbeam_epoch::internal::Local>> - shim(Some(crossbeam_epoch::Owned<crossbeam_epoch::internal::Local>))
                 at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:823:1: 825:25
             5: std::mem::drop::<crossbeam_epoch::Owned<crossbeam_epoch::internal::Local>>
                 at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/mem/mod.rs:1042:1: 1042:2
             6: crossbeam_epoch::Guard::defer_unchecked::<{closure@crossbeam_epoch::Guard::defer_destroy<crossbeam_epoch::internal::Local>::{closure#0}}, crossbeam_epoch::Owned<crossbeam_epoch::internal::Local>>
                 at crossbeam-epoch/src/guard.rs:197:17: 197:26
             7: crossbeam_epoch::Guard::defer_destroy::<crossbeam_epoch::internal::Local>
                 at crossbeam-epoch/src/guard.rs:272:18: 272:64
             8: <crossbeam_epoch::internal::Local as crossbeam_epoch::sync::list::IsElement<crossbeam_epoch::internal::Local>>::finalize
                 at crossbeam-epoch/src/internal.rs:584:18: 584:76
             9: <crossbeam_epoch::sync::list::List<crossbeam_epoch::internal::Local> as std::ops::Drop>::drop
                 at crossbeam-epoch/src/sync/list.rs:231:17: 231:50
             10: std::ptr::drop_glue::<crossbeam_epoch::sync::list::List<crossbeam_epoch::internal::Local>> - shim(Some(crossbeam_epoch::sync::list::List<crossbeam_epoch::internal::Local>))
                 at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:823:1: 825:25
             11: std::ptr::drop_glue::<crossbeam_epoch::internal::Global> - shim(Some(crossbeam_epoch::internal::Global))
                 at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:823:1: 825:25
             12: std::ptr::drop_in_place::<crossbeam_epoch::internal::Global>
                 at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:818:14: 818:38
             13: std::sync::Arc::<crossbeam_epoch::internal::Global>::drop_slow
                 at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/sync.rs:2143:18: 2143:68
             14: <std::sync::Arc<crossbeam_epoch::internal::Global> as std::ops::Drop>::drop
                 at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/sync.rs:2877:13: 2877:29
             15: std::ptr::drop_glue::<std::sync::Arc<crossbeam_epoch::internal::Global>> - shim(Some(std::sync::Arc<crossbeam_epoch::internal::Global>))
                 at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:823:1: 825:25
             16: std::ptr::drop_glue::<crossbeam_epoch::Collector> - shim(Some(crossbeam_epoch::Collector))
                 at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:823:1: 825:25
             17: std::mem::drop::<crossbeam_epoch::Collector>
                 at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/mem/mod.rs:1042:1: 1042:2
             18: crossbeam_epoch::internal::Local::finalize
                 at crossbeam-epoch/src/internal.rs:567:13: 567:28
             19: crossbeam_epoch::internal::Local::unpin
                 at crossbeam-epoch/src/internal.rs:475:21: 475:41
             20: <crossbeam_epoch::Guard as std::ops::Drop>::drop
                 at crossbeam-epoch/src/guard.rs:420:13: 420:26
             21: std::ptr::drop_glue::<crossbeam_epoch::Guard> - shim(Some(crossbeam_epoch::Guard))
                 at /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:823:1: 825:25
             22: main
                 at crossbeam-epoch/examples/sanitize.rs:88:1: 88:2
```