### PR TITLE
epoch: Skip try_advance in collect() when the queue is empty

### DIFF
--- a/crossbeam-epoch/src/internal.rs
+++ b/crossbeam-epoch/src/internal.rs
@@ -206,6 +206,15 @@ impl Global {
     /// `collect()` is not called.
     #[cold]
     pub(crate) fn collect(&self, guard: &Guard) {
+        // Advancing the epoch is only useful to make queued bags expirable, so if the queue is
+        // empty there is nothing to collect and the expensive `try_advance` (a `SeqCst` fence plus
+        // a traversal of every registered participant) is pure overhead. Skipping it only delays
+        // epoch advancement, never advances it early, so reclamation stays sound: any thread that
+        // pushed a bag will itself advance the epoch on a later `collect`.
+        if self.queue.is_empty(guard) {
+            return;
+        }
+
         let global_epoch = self.try_advance(guard);
 
         let steps = if cfg!(crossbeam_sanitize) {

--- a/crossbeam-epoch/src/sync/queue.rs
+++ b/crossbeam-epoch/src/sync/queue.rs
@@ -200,6 +200,13 @@ impl<T> Queue<T> {
             }
         }
     }
+
+    /// Returns `true` if the queue is observed to be empty.
+    pub(crate) fn is_empty(&self, guard: &Guard) -> bool {
+        let head = self.head.load(Acquire, guard);
+        let h = unsafe { head.deref() };
+        h.next.load(Acquire, guard).is_null()
+    }
 }
 
 impl<T> Drop for Queue<T> {


### PR DESCRIPTION
Addresses #1001 (and the overhead reported in #852).

## Problem
`Global::collect()` runs on the `pin()` hot path (every `PINNINGS_BETWEEN_COLLECT` pins) and unconditionally calls `try_advance()` first. `try_advance()` is genuinely expensive: a `SeqCst` fence plus a full traversal of the intrusive linked list of *every registered participant* (cache-miss-heavy pointer chasing, as the `TODO` there notes).

Advancing the epoch is only useful to make queued `SealedBag`s expirable. When the global garbage queue is empty there is nothing to expire and nothing for the subsequent `try_pop_if` loop to pop, so the entire `try_advance` cost is wasted. In read-mostly workloads where `defer_destroy` is rare (the scenario in #1001), this is paid on every periodic `collect()` and scales O(participants).

## Change
Short-circuit `collect()` when the queue is observed empty, via a new `Queue::is_empty(guard)` (a single `Acquire` load of `head.next`, mirroring the existing test-only helper) — instead of the `SeqCst` fence + O(participants) traversal.

## Why it's sound
Skipping the advance is monotone-conservative: it can only *delay* epoch advancement, never advance it early, so it can never cause premature reclamation. Liveness is preserved because any thread that pushed a bag is itself on the `collect()` cadence and will observe a non-empty queue and advance. Worst case is a bounded reclamation delay, in the same spirit as the existing `IterError::Stalled` early return that already declines to advance.

## Verification
- `cargo test -p crossbeam-epoch` — lib (44) + doctests (51) green, including `collector::tests::pin_holds_advance`, `incremental`, and `buffering`.
- `ci/crossbeam-epoch-loom.sh` (loom, `LOOM_MAX_PREEMPTIONS=2`) — green.
- clippy (lib) clean; `cargo fmt` applied.

The win is deterministic by construction: in the empty-queue case `collect()` now performs one `Acquire` load instead of a `SeqCst` fence plus a traversal of all participants. Happy to add a benchmark or a counted-metric harness if useful.
