### PR TITLE
Handle overflow in bounded channel initialization

### DIFF
--- a/crossbeam-channel/src/channel.rs
+++ b/crossbeam-channel/src/channel.rs
@@ -110,6 +110,9 @@ pub fn unbounded<T>() -> (Sender<T>, Receiver<T>) {
 /// thread::sleep(Duration::from_secs(1));
 /// assert_eq!(r.recv(), Ok(1));
 /// ```
+/// # Panics
+///
+/// Panics if `cap` is too large to initialize the bounded channel.
 pub fn bounded<T>(cap: usize) -> (Sender<T>, Receiver<T>) {
     if cap == 0 {
         let (s, r) = counter::new(flavors::zero::Channel::new());

--- a/crossbeam-channel/src/flavors/array.rs
+++ b/crossbeam-channel/src/flavors/array.rs
@@ -97,9 +97,14 @@ impl<T> Channel<T> {
     pub(crate) fn with_capacity(cap: usize) -> Self {
         assert!(cap > 0, "capacity must be positive");
 
-        // Compute constants `mark_bit` and `one_lap`.
-        let mark_bit = (cap + 1).next_power_of_two();
-        let one_lap = mark_bit * 2;
+        // Use checked arithmetic before computing `mark_bit` and `one_lap`.
+        let mark_bit = cap
+            .checked_add(1)
+            .and_then(usize::checked_next_power_of_two)
+            .expect("bounded channel capacity is too large");
+        let one_lap = mark_bit
+            .checked_mul(2)
+            .expect("bounded channel capacity is too large");
 
         // Head is initialized to `{ lap: 0, mark: 0, index: 0 }`.
         let head = 0;

--- a/crossbeam-queue/src/array_queue.rs
+++ b/crossbeam-queue/src/array_queue.rs
@@ -84,7 +84,7 @@ impl<T> ArrayQueue<T> {
     ///
     /// # Panics
     ///
-    /// Panics if the capacity is zero.
+    /// Panics if the capacity is zero or too large.
     ///
     /// # Examples
     ///
@@ -114,7 +114,10 @@ impl<T> ArrayQueue<T> {
             .collect();
 
         // One lap is the smallest power of two greater than `cap`.
-        let one_lap = (cap + 1).next_power_of_two();
+        let one_lap = cap
+            .checked_add(1)
+            .and_then(usize::checked_next_power_of_two)
+            .expect("queue capacity is too large");
 
         Self {
             buffer,


### PR DESCRIPTION
Fixes #1300.

This changes the bounded array channel initialization to use checked arithmetic when computing `mark_bit` and `one_lap`.

Previously, `bounded::<T>(usize::MAX)` could panic due to an unchecked integer overflow in debug builds:

```rust
let mark_bit = (cap + 1).next_power_of_two();
let one_lap = mark_bit * 2;
```

With this change, oversized capacities fail with a controlled panic message instead of an internal arithmetic overflow panic.

I also documented that `bounded` may panic if the capacity is too large.