### PR TITLE
Prepare for the next release (crossbeam-epoch 0.9.21)

### DIFF
--- a/crossbeam-epoch/CHANGELOG.md
+++ b/crossbeam-epoch/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Version 0.9.21
+
+- Store pointers in `AtomicPtr` and use provenance-preserving address arithmetic
+  (`map_addr` / `wrapping_add`) instead of `AtomicUsize` int↔ptr casts, so Miri
+  (Stacked Borrows and Tree Borrows) can track epoch-protected pointers. This
+  unblocks aliasing-model Miri for dependents (e.g. skiplists). (#1181, #796)
+- Fix Stacked Borrows violation when a `Guard` is used after its
+  `LocalHandle`/`Collector` are dropped. (#1297)
+- Do not dereference the pointer in `fmt::Pointer` for `Atomic`/`Shared`. (#1276 follow-ups)
+
 # Version 0.9.20
 
 - Fix invalid pointer dereference in `fmt::Pointer` impl for `Atomic`/`Shared` when the underlying pointer is invalid. This fixes unsoundness that was not fully addressed in 0.9.19's fix. (#1276)

--- a/crossbeam-epoch/Cargo.toml
+++ b/crossbeam-epoch/Cargo.toml
@@ -4,7 +4,7 @@ name = "crossbeam-epoch"
 # - Update CHANGELOG.md
 # - Update README.md (when increasing major or minor version)
 # - Run './tools/publish.sh crossbeam-epoch <version>'
-version = "0.9.20"
+version = "0.9.21"
 edition = "2021"
 # NB: Sync with msrv badge and "Compatibility" section in README.md
 rust-version = "1.74"


### PR DESCRIPTION
## Summary

Prepare **crossbeam-epoch 0.9.21** for crates.io.

`main` already carries the provenance-preserving `AtomicPtr` + `map_addr` representation (int↔ptr cast removal). The latest crates.io release (**0.9.20**) still stores pointers as `AtomicUsize`, so Miri with Stacked/Tree Borrows cannot track epoch-protected pointers — see #1181.

This PR only bumps the version and CHANGELOG so maintainers can run `./tools/publish.sh crossbeam-epoch 0.9.21`.

### CHANGELOG highlights for 0.9.21

- **Provenance / Miri:** `AtomicPtr` + provenance-preserving address arithmetic instead of `AtomicUsize` int↔ptr casts (#1181, #796)
- Fix Stacked Borrows violation when a `Guard` is used after its `LocalHandle`/`Collector` are dropped (#1297)
- Do not dereference the pointer in `fmt::Pointer` for `Atomic`/`Shared` (follow-ups to #1276)

### Motivation (downstream)

With 0.9.20, TiKV's vendored skiplist cannot be certified under Miri at all — every node pointer loses provenance in epoch. Pinning `main` (or this release) unblocks aliasing-model Miri and surfaces real skiplist issues that are fixed by the upstream `TowerRef`/`NodeRef` pattern.

### Test plan

- [ ] Maintainers: `./tools/publish.sh crossbeam-epoch 0.9.21` when ready
- [ ] CI green on this branch
- [ ] Confirm no other crates need a coordinated release for this bump

Closes #1181 (once published to crates.io).