### PR TITLE
docs: add inspect.software health badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ https://crates.io/crates/crossbeam)
 https://docs.rs/crossbeam)
 [![Rust 1.74+](https://img.shields.io/badge/rust-1.74+-lightgray.svg)](
 https://www.rust-lang.org)
+[![inspect.software](https://raw.githubusercontent.com/inspect-software/badges/main/v1/c/crossbeam-rs/crossbeam.svg)](https://inspect.software/software/crossbeam-rs/crossbeam)
 [![chat](https://img.shields.io/discord/569610676205781012.svg?logo=discord)](https://discord.com/invite/JXYwgWZ)
 
 This crate provides a set of tools for concurrent programming:


### PR DESCRIPTION
This PR adds the [inspect.software](https://inspect.software) health badge to the README.

**Why this PR?**
Your project ranks in the upper rating bands of our open-source health index (which measures maintainability, responsiveness, and security). This badge makes that standing objectively visible to your users. Our index is a free public good, and scores cannot be bought.

**Technical details:**
- **No tracking:** Static SVG served via GitHub's CDN. No JavaScript, no third-party tracking.
- **No maintenance:** The badge updates automatically after every inspection.
- **Transparent:** Links directly to [your full report](https://inspect.software/software/crossbeam-rs/crossbeam), based on our open [methodology](https://inspect.software/methodology).

If you prefer to keep your README minimal, feel free to close this PR without replying. Your report will remain publicly available and up-to-date either way.
