### PR TITLE
channel,deque,queue: Use Atomic{I,U}64/{i,u}64 in head/tail index if available

### DIFF
--- a/crossbeam-channel/src/flavors/array.rs
+++ b/crossbeam-channel/src/flavors/array.rs
@@ -13,7 +13,7 @@ use core::{
     cell::UnsafeCell,
     mem::MaybeUninit,
     ptr,
-    sync::atomic::{self, AtomicUsize, Ordering},
+    sync::atomic::{self, Ordering},
 };
 use std::time::Instant;
 
@@ -26,10 +26,23 @@ use crate::{
     waker::SyncWaker,
 };
 
+// Ideally, we want to always use AtomicU64, but since it is not available on all platforms,
+// we only use it when it is available for now.
+// TODO: On platforms where AtomicU64 is unavailable, we may want to use AtomicCell instead of
+// AtomicUsize. (https://github.com/crossbeam-rs/crossbeam/issues/433)
+#[cfg(target_has_atomic = "64")]
+type AtomicIndex = core::sync::atomic::AtomicU64;
+#[cfg(target_has_atomic = "64")]
+type Index = u64;
+#[cfg(not(target_has_atomic = "64"))]
+type AtomicIndex = core::sync::atomic::AtomicUsize;
+#[cfg(not(target_has_atomic = "64"))]
+type Index = usize;
+
 /// A slot in a channel.
 struct Slot<T> {
     /// The current stamp.
-    stamp: AtomicUsize,
+    stamp: AtomicIndex,
 
     /// The message in this slot. Either read out in `read` or dropped through
     /// `discard_all_messages`.
@@ -43,7 +56,7 @@ pub(crate) struct ArrayToken {
     slot: *const u8,
 
     /// Stamp to store into the slot after reading or writing.
-    stamp: usize,
+    stamp: Index,
 }
 
 impl Default for ArrayToken {
@@ -61,29 +74,29 @@ pub(crate) struct Channel<T> {
     /// The head of the channel.
     ///
     /// This value is a "stamp" consisting of an index into the buffer, a mark bit, and a lap, but
-    /// packed into a single `usize`. The lower bits represent the index, while the upper bits
+    /// packed into a single `Index`. The lower bits represent the index, while the upper bits
     /// represent the lap. The mark bit in the head is always zero.
     ///
     /// Messages are popped from the head of the channel.
-    head: CachePadded<AtomicUsize>,
+    head: CachePadded<AtomicIndex>,
 
     /// The tail of the channel.
     ///
     /// This value is a "stamp" consisting of an index into the buffer, a mark bit, and a lap, but
-    /// packed into a single `usize`. The lower bits represent the index, while the upper bits
+    /// packed into a single `Index`. The lower bits represent the index, while the upper bits
     /// represent the lap. The mark bit indicates that the channel is disconnected.
     ///
     /// Messages are pushed into the tail of the channel.
-    tail: CachePadded<AtomicUsize>,
+    tail: CachePadded<AtomicIndex>,
 
     /// The buffer holding slots.
     buffer: Box<[Slot<T>]>,
 
     /// A stamp with the value of `{ lap: 1, mark: 0, index: 0 }`.
-    one_lap: usize,
+    one_lap: Index,
 
     /// If this bit is set in the tail, that means the channel is disconnected.
-    mark_bit: usize,
+    mark_bit: Index,
 
     /// Senders waiting while the channel is full.
     senders: SyncWaker,
@@ -98,9 +111,9 @@ impl<T> Channel<T> {
         assert!(cap > 0, "capacity must be positive");
 
         // Use checked arithmetic before computing `mark_bit` and `one_lap`.
-        let mark_bit = cap
+        let mark_bit = (cap as Index)
             .checked_add(1)
-            .and_then(usize::checked_next_power_of_two)
+            .and_then(Index::checked_next_power_of_two)
             .expect("bounded channel capacity is too large");
         let one_lap = mark_bit
             .checked_mul(2)
@@ -117,7 +130,7 @@ impl<T> Channel<T> {
             .map(|i| {
                 // Set the stamp to `{ lap: 0, mark: 0, index: i }`.
                 Slot {
-                    stamp: AtomicUsize::new(i),
+                    stamp: AtomicIndex::new(i as Index),
                     msg: UnsafeCell::new(MaybeUninit::uninit()),
                 }
             })
@@ -127,8 +140,8 @@ impl<T> Channel<T> {
             buffer,
             one_lap,
             mark_bit,
-            head: CachePadded::new(AtomicUsize::new(head)),
-            tail: CachePadded::new(AtomicUsize::new(tail)),
+            head: CachePadded::new(AtomicIndex::new(head)),
+            tail: CachePadded::new(AtomicIndex::new(tail)),
             senders: SyncWaker::new(),
             receivers: SyncWaker::new(),
         }
@@ -158,7 +171,7 @@ impl<T> Channel<T> {
             }
 
             // Deconstruct the tail.
-            let index = tail & (self.mark_bit - 1);
+            let index = (tail & (self.mark_bit - 1)) as usize;
             let lap = tail & !(self.one_lap - 1);
 
             // Inspect the corresponding slot.
@@ -241,7 +254,7 @@ impl<T> Channel<T> {
 
         loop {
             // Deconstruct the head.
-            let index = head & (self.mark_bit - 1);
+            let index = (head & (self.mark_bit - 1)) as usize;
             let lap = head & !(self.one_lap - 1);
 
             // Inspect the corresponding slot.
@@ -459,8 +472,8 @@ impl<T> Channel<T> {
 
             // If the tail didn't change, we've got consistent values to work with.
             if self.tail.load(Ordering::SeqCst) == tail {
-                let hix = head & (self.mark_bit - 1);
-                let tix = tail & (self.mark_bit - 1);
+                let hix = (head & (self.mark_bit - 1)) as usize;
+                let tix = (tail & (self.mark_bit - 1)) as usize;
 
                 return if hix < tix {
                     tix - hix
@@ -533,7 +546,7 @@ impl<T> Channel<T> {
     /// This method must only be called when dropping the last receiver. The
     /// destruction of all other receivers must have been observed with acquire
     /// ordering or stronger.
-    unsafe fn discard_all_messages(&self, tail: usize) {
+    unsafe fn discard_all_messages(&self, tail: Index) {
         debug_assert!(self.is_disconnected());
 
         // Only receivers modify `head`, so since we are the last one,
@@ -545,7 +558,7 @@ impl<T> Channel<T> {
         let backoff = Backoff::new();
         loop {
             // Deconstruct the head.
-            let index = head & (self.mark_bit - 1);
+            let index = (head & (self.mark_bit - 1)) as usize;
             let lap = head & !(self.one_lap - 1);
 
             // Inspect the corresponding slot.

--- a/crossbeam-channel/src/flavors/list.rs
+++ b/crossbeam-channel/src/flavors/list.rs
@@ -21,6 +21,19 @@ use crate::{
     waker::SyncWaker,
 };
 
+// Ideally, we want to always use AtomicU64, but since it is not available on all platforms,
+// we only use it when it is available for now.
+// TODO: On platforms where AtomicU64 is unavailable, we may want to use AtomicCell instead of
+// AtomicUsize. (https://github.com/crossbeam-rs/crossbeam/issues/433)
+#[cfg(target_has_atomic = "64")]
+type AtomicIndex = core::sync::atomic::AtomicU64;
+#[cfg(target_has_atomic = "64")]
+type Index = u64;
+#[cfg(not(target_has_atomic = "64"))]
+type AtomicIndex = core::sync::atomic::AtomicUsize;
+#[cfg(not(target_has_atomic = "64"))]
+type Index = usize;
+
 // TODO(stjepang): Once we bump the minimum required Rust version to 1.28 or newer, re-apply the
 // following changes by @kleimkuhler:
 //
@@ -36,15 +49,15 @@ const READ: usize = 2;
 const DESTROY: usize = 4;
 
 // Each block covers one "lap" of indices.
-const LAP: usize = 32;
+const LAP: Index = 32;
 // The maximum number of messages a block can hold.
-const BLOCK_CAP: usize = LAP - 1;
+const BLOCK_CAP: usize = LAP as usize - 1;
 // How many lower bits are reserved for metadata.
 const SHIFT: usize = 1;
 // Has two different purposes:
 // * If set in head, indicates that the block is not the last one.
 // * If set in tail, indicates that the channel is disconnected.
-const MARK_BIT: usize = 1;
+const MARK_BIT: Index = 1;
 
 /// A slot in a block.
 struct Slot<T> {
@@ -141,7 +154,7 @@ impl<T> Block<T> {
 #[derive(Debug)]
 struct Position<T> {
     /// The index in the channel.
-    index: AtomicUsize,
+    index: AtomicIndex,
 
     /// The block in the linked list.
     block: AtomicPtr<Block<T>>,
@@ -170,7 +183,7 @@ impl Default for ListToken {
 /// Unbounded channel implemented as a linked list.
 ///
 /// Each message sent into the channel is assigned a sequence number, i.e. an index. Indices are
-/// represented as numbers of type `usize` and wrap on overflow.
+/// represented as numbers of type `Index` and wrap on overflow.
 ///
 /// Consecutive messages are grouped into blocks in order to put less pressure on the allocator and
 /// improve cache efficiency.
@@ -194,11 +207,11 @@ impl<T> Channel<T> {
         Self {
             head: CachePadded::new(Position {
                 block: AtomicPtr::new(ptr::null_mut()),
-                index: AtomicUsize::new(0),
+                index: AtomicIndex::new(0),
             }),
             tail: CachePadded::new(Position {
                 block: AtomicPtr::new(ptr::null_mut()),
-                index: AtomicUsize::new(0),
+                index: AtomicIndex::new(0),
             }),
             receivers: SyncWaker::new(),
             _marker: PhantomData,
@@ -230,7 +243,7 @@ impl<T> Channel<T> {
             }
 
             // Calculate the offset of the index into the block.
-            let offset = (tail >> SHIFT) % LAP;
+            let offset = ((tail >> SHIFT) % LAP) as usize;
 
             // If we reached the end of the block, wait until the next one is installed.
             if offset == BLOCK_CAP {
@@ -325,7 +338,7 @@ impl<T> Channel<T> {
 
         loop {
             // Calculate the offset of the index into the block.
-            let offset = (head >> SHIFT) % LAP;
+            let offset = ((head >> SHIFT) % LAP) as usize;
 
             // If we reached the end of the block, wait until the next one is installed.
             if offset == BLOCK_CAP {
@@ -545,7 +558,7 @@ impl<T> Channel<T> {
                 head >>= SHIFT;
 
                 // Return the difference minus the number of blocks between tail and head.
-                return tail - head - tail / LAP;
+                return (tail - head - tail / LAP) as usize;
             }
         }
     }
@@ -592,7 +605,7 @@ impl<T> Channel<T> {
         let backoff = Backoff::new();
         let mut tail = self.tail.index.load(Ordering::Acquire);
         loop {
-            let offset = (tail >> SHIFT) % LAP;
+            let offset = ((tail >> SHIFT) % LAP) as usize;
             if offset != BLOCK_CAP {
                 break;
             }
@@ -625,7 +638,7 @@ impl<T> Channel<T> {
         unsafe {
             // Drop all messages between head and tail and deallocate the heap-allocated blocks.
             while head >> SHIFT != tail >> SHIFT {
-                let offset = (head >> SHIFT) % LAP;
+                let offset = ((head >> SHIFT) % LAP) as usize;
 
                 if offset < BLOCK_CAP {
                     // Drop the message in the slot.
@@ -683,7 +696,7 @@ impl<T> Drop for Channel<T> {
         unsafe {
             // Drop all messages between head and tail and deallocate the heap-allocated blocks.
             while head != tail {
-                let offset = (head >> SHIFT) % LAP;
+                let offset = ((head >> SHIFT) % LAP) as usize;
 
                 if offset < BLOCK_CAP {
                     // Drop the message in the slot.

--- a/crossbeam-deque/src/deque.rs
+++ b/crossbeam-deque/src/deque.rs
@@ -6,13 +6,34 @@ use core::{
     marker::PhantomData,
     mem::{self, MaybeUninit},
     ptr,
-    sync::atomic::{self, AtomicIsize, AtomicPtr, AtomicUsize, Ordering},
+    sync::atomic::{self, AtomicPtr, AtomicUsize, Ordering},
 };
 
 use crossbeam_epoch::{self as epoch, Atomic, Owned};
 use crossbeam_utils::{Backoff, CachePadded};
 
 use crate::alloc_helper::Global;
+
+// Ideally, we want to always use AtomicU64/AtomicI64, but since they are not available on all platforms,
+// we only use them when they are available for now.
+// TODO: On platforms where AtomicU64/AtomicI64 is unavailable, we may want to use AtomicCell instead of
+// AtomicUsize/AtomicIsize. (https://github.com/crossbeam-rs/crossbeam/issues/433)
+#[cfg(target_has_atomic = "64")]
+type AtomicIndex = core::sync::atomic::AtomicU64;
+#[cfg(target_has_atomic = "64")]
+type AtomicWorkerIndex = core::sync::atomic::AtomicI64;
+#[cfg(target_has_atomic = "64")]
+type Index = u64;
+#[cfg(target_has_atomic = "64")]
+type WorkerIndex = i64;
+#[cfg(not(target_has_atomic = "64"))]
+type AtomicIndex = core::sync::atomic::AtomicUsize;
+#[cfg(not(target_has_atomic = "64"))]
+type AtomicWorkerIndex = core::sync::atomic::AtomicIsize;
+#[cfg(not(target_has_atomic = "64"))]
+type Index = usize;
+#[cfg(not(target_has_atomic = "64"))]
+type WorkerIndex = isize;
 
 // Minimum buffer capacity.
 const MIN_CAP: usize = 64;
@@ -62,11 +83,14 @@ impl<T> Buffer<T> {
     }
 
     /// Returns a pointer to the task at the specified `index`.
-    unsafe fn at(&self, index: isize) -> *mut T {
+    unsafe fn at(&self, index: WorkerIndex) -> *mut T {
         // `self.cap` is always a power of two.
         // We do all the loads at `MaybeUninit` because we might realize, after loading, that we
         // don't actually have the right to access this memory.
-        unsafe { self.ptr.offset(index & (self.cap - 1) as isize) }
+        unsafe {
+            self.ptr
+                .offset((index & (self.cap - 1) as WorkerIndex) as isize)
+        }
     }
 
     /// Writes `task` into the specified `index`.
@@ -75,7 +99,7 @@ impl<T> Buffer<T> {
     /// technically speaking a data race and therefore UB. We should use an atomic store here, but
     /// that would be more expensive and difficult to implement generically for all types `T`.
     /// Hence, as a hack, we use a volatile write instead.
-    unsafe fn write(&self, index: isize, task: MaybeUninit<T>) {
+    unsafe fn write(&self, index: WorkerIndex, task: MaybeUninit<T>) {
         unsafe { ptr::write_volatile(self.at(index).cast::<MaybeUninit<T>>(), task) }
     }
 
@@ -85,7 +109,7 @@ impl<T> Buffer<T> {
     /// technically speaking a data race and therefore UB. We should use an atomic load here, but
     /// that would be more expensive and difficult to implement generically for all types `T`.
     /// Hence, as a hack, we use a volatile load instead.
-    unsafe fn read(&self, index: isize) -> MaybeUninit<T> {
+    unsafe fn read(&self, index: WorkerIndex) -> MaybeUninit<T> {
         unsafe { ptr::read_volatile(self.at(index).cast::<MaybeUninit<T>>()) }
     }
 }
@@ -113,10 +137,10 @@ impl<T> Copy for Buffer<T> {}
 /// [checker]: https://dl.acm.org/citation.cfm?id=2509514
 struct Inner<T> {
     /// The front index.
-    front: AtomicIsize,
+    front: AtomicWorkerIndex,
 
     /// The back index.
-    back: AtomicIsize,
+    back: AtomicWorkerIndex,
 
     /// The underlying buffer.
     buffer: CachePadded<Atomic<Buffer<T>>>,
@@ -226,8 +250,8 @@ impl<T> Worker<T> {
         let buffer = Buffer::alloc(MIN_CAP);
 
         let inner = Arc::new(CachePadded::new(Inner {
-            front: AtomicIsize::new(0),
-            back: AtomicIsize::new(0),
+            front: AtomicWorkerIndex::new(0),
+            back: AtomicWorkerIndex::new(0),
             buffer: CachePadded::new(Atomic::new(buffer)),
         }));
 
@@ -254,8 +278,8 @@ impl<T> Worker<T> {
         let buffer = Buffer::alloc(MIN_CAP);
 
         let inner = Arc::new(CachePadded::new(Inner {
-            front: AtomicIsize::new(0),
-            back: AtomicIsize::new(0),
+            front: AtomicWorkerIndex::new(0),
+            back: AtomicWorkerIndex::new(0),
             buffer: CachePadded::new(Atomic::new(buffer)),
         }));
 
@@ -403,7 +427,7 @@ impl<T> Worker<T> {
         let len = b.wrapping_sub(f);
 
         // Is the queue full?
-        if len >= buffer.cap as isize {
+        if len >= buffer.cap as WorkerIndex {
             // Yes. Grow the underlying buffer.
             unsafe {
                 self.resize(2 * buffer.cap);
@@ -475,7 +499,7 @@ impl<T> Worker<T> {
                     let task = buffer.read(f).assume_init();
 
                     // Shrink the buffer if `len - 1` is less than one fourth of the capacity.
-                    if buffer.cap > MIN_CAP && len <= buffer.cap as isize / 4 {
+                    if buffer.cap > MIN_CAP && len <= buffer.cap as WorkerIndex / 4 {
                         self.resize(buffer.cap / 2);
                     }
 
@@ -528,7 +552,7 @@ impl<T> Worker<T> {
                         self.inner.back.store(b.wrapping_add(1), Ordering::Relaxed);
                     } else {
                         // Shrink the buffer if `len` is less than one fourth of the capacity.
-                        if buffer.cap > MIN_CAP && len < buffer.cap as isize / 4 {
+                        if buffer.cap > MIN_CAP && len < buffer.cap as WorkerIndex / 4 {
                             unsafe {
                                 self.resize(buffer.cap / 2);
                             }
@@ -776,7 +800,7 @@ impl<T> Stealer<T> {
         // Reserve capacity for the stolen batch.
         let batch_size = cmp::min((len as usize).div_ceil(2), limit);
         dest.reserve(batch_size);
-        let mut batch_size = batch_size as isize;
+        let mut batch_size = batch_size as WorkerIndex;
 
         // Get the destination buffer and back index.
         let dest_buffer = dest.buffer.get();
@@ -1018,7 +1042,7 @@ impl<T> Stealer<T> {
         // Reserve capacity for the stolen batch.
         let batch_size = cmp::min((len as usize - 1) / 2, limit - 1);
         dest.reserve(batch_size);
-        let mut batch_size = batch_size as isize;
+        let mut batch_size = batch_size as WorkerIndex;
 
         // Get the destination buffer and back index.
         let dest_buffer = dest.buffer.get();
@@ -1199,13 +1223,13 @@ const READ: usize = 2;
 const DESTROY: usize = 4;
 
 // Each block covers one "lap" of indices.
-const LAP: usize = 64;
+const LAP: Index = 64;
 // The maximum number of values a block can hold.
-const BLOCK_CAP: usize = LAP - 1;
+const BLOCK_CAP: usize = LAP as usize - 1;
 // How many lower bits are reserved for metadata.
 const SHIFT: usize = 1;
 // Indicates that the block is not the last one.
-const HAS_NEXT: usize = 1;
+const HAS_NEXT: Index = 1;
 
 /// A slot in a block.
 struct Slot<T> {
@@ -1301,7 +1325,7 @@ impl<T> Block<T> {
 /// A position in a queue.
 struct Position<T> {
     /// The index in the queue.
-    index: AtomicUsize,
+    index: AtomicIndex,
 
     /// The block in the linked list.
     block: AtomicPtr<Block<T>>,
@@ -1346,11 +1370,11 @@ impl<T> Default for Injector<T> {
         Self {
             head: CachePadded::new(Position {
                 block: AtomicPtr::new(block),
-                index: AtomicUsize::new(0),
+                index: AtomicIndex::new(0),
             }),
             tail: CachePadded::new(Position {
                 block: AtomicPtr::new(block),
-                index: AtomicUsize::new(0),
+                index: AtomicIndex::new(0),
             }),
             _marker: PhantomData,
         }
@@ -1390,7 +1414,7 @@ impl<T> Injector<T> {
 
         loop {
             // Calculate the offset of the index into the block.
-            let offset = (tail >> SHIFT) % LAP;
+            let offset = ((tail >> SHIFT) % LAP) as usize;
 
             // If we reached the end of the block, wait until the next one is installed.
             if offset == BLOCK_CAP {
@@ -1469,7 +1493,7 @@ impl<T> Injector<T> {
             block = self.head.block.load(Ordering::Acquire);
 
             // Calculate the offset of the index into the block.
-            offset = (head >> SHIFT) % LAP;
+            offset = ((head >> SHIFT) % LAP) as usize;
 
             // If we reached the end of the block, wait until the next one is installed.
             if offset == BLOCK_CAP {
@@ -1607,7 +1631,7 @@ impl<T> Injector<T> {
             block = self.head.block.load(Ordering::Acquire);
 
             // Calculate the offset of the index into the block.
-            offset = (head >> SHIFT) % LAP;
+            offset = ((head >> SHIFT) % LAP) as usize;
 
             // If we reached the end of the block, wait until the next one is installed.
             if offset == BLOCK_CAP {
@@ -1636,7 +1660,7 @@ impl<T> Injector<T> {
                 // We can steal all tasks till the end of the block.
                 advance = (BLOCK_CAP - offset).min(limit);
             } else {
-                let len = (tail - head) >> SHIFT;
+                let len = ((tail - head) >> SHIFT) as usize;
                 // Steal half of the available tasks.
                 advance = len.div_ceil(2).min(limit);
             }
@@ -1645,7 +1669,7 @@ impl<T> Injector<T> {
             advance = (BLOCK_CAP - offset).min(limit);
         }
 
-        new_head += advance << SHIFT;
+        new_head += (advance as Index) << SHIFT;
         let new_offset = offset + advance;
 
         // Try moving the head index forward.
@@ -1689,7 +1713,7 @@ impl<T> Injector<T> {
                         let task = slot.task.get().read();
 
                         // Write it into the destination queue.
-                        dest_buffer.write(dest_b.wrapping_add(i as isize), task);
+                        dest_buffer.write(dest_b.wrapping_add(i as WorkerIndex), task);
                     }
                 }
 
@@ -1701,7 +1725,10 @@ impl<T> Injector<T> {
                         let task = slot.task.get().read();
 
                         // Write it into the destination queue.
-                        dest_buffer.write(dest_b.wrapping_add((batch_size - 1 - i) as isize), task);
+                        dest_buffer.write(
+                            dest_b.wrapping_add((batch_size - 1 - i) as WorkerIndex),
+                            task,
+                        );
                     }
                 }
             }
@@ -1718,7 +1745,7 @@ impl<T> Injector<T> {
             // Update the back index in the destination queue.
             dest.inner
                 .back
-                .store(dest_b.wrapping_add(batch_size as isize), store_order);
+                .store(dest_b.wrapping_add(batch_size as WorkerIndex), store_order);
 
             // Destroy the block if we've reached the end, or if another thread wanted to destroy
             // but couldn't because we were busy reading from the slot.
@@ -1811,7 +1838,7 @@ impl<T> Injector<T> {
             block = self.head.block.load(Ordering::Acquire);
 
             // Calculate the offset of the index into the block.
-            offset = (head >> SHIFT) % LAP;
+            offset = ((head >> SHIFT) % LAP) as usize;
 
             // If we reached the end of the block, wait until the next one is installed.
             if offset == BLOCK_CAP {
@@ -1839,7 +1866,7 @@ impl<T> Injector<T> {
                 // We can steal all tasks till the end of the block.
                 advance = (BLOCK_CAP - offset).min(limit);
             } else {
-                let len = (tail - head) >> SHIFT;
+                let len = ((tail - head) >> SHIFT) as usize;
                 // Steal half of the available tasks.
                 advance = len.div_ceil(2).min(limit);
             }
@@ -1848,7 +1875,7 @@ impl<T> Injector<T> {
             advance = (BLOCK_CAP - offset).min(limit);
         }
 
-        new_head += advance << SHIFT;
+        new_head += (advance as Index) << SHIFT;
         let new_offset = offset + advance;
 
         // Try moving the head index forward.
@@ -1897,7 +1924,7 @@ impl<T> Injector<T> {
                         let task = slot.task.get().read();
 
                         // Write it into the destination queue.
-                        dest_buffer.write(dest_b.wrapping_add(i as isize), task);
+                        dest_buffer.write(dest_b.wrapping_add(i as WorkerIndex), task);
                     }
                 }
 
@@ -1910,7 +1937,10 @@ impl<T> Injector<T> {
                         let task = slot.task.get().read();
 
                         // Write it into the destination queue.
-                        dest_buffer.write(dest_b.wrapping_add((batch_size - 1 - i) as isize), task);
+                        dest_buffer.write(
+                            dest_b.wrapping_add((batch_size - 1 - i) as WorkerIndex),
+                            task,
+                        );
                     }
                 }
             }
@@ -1927,7 +1957,7 @@ impl<T> Injector<T> {
             // Update the back index in the destination queue.
             dest.inner
                 .back
-                .store(dest_b.wrapping_add(batch_size as isize), store_order);
+                .store(dest_b.wrapping_add(batch_size as WorkerIndex), store_order);
 
             // Destroy the block if we've reached the end, or if another thread wanted to destroy
             // but couldn't because we were busy reading from the slot.
@@ -2012,7 +2042,7 @@ impl<T> Injector<T> {
                 head >>= SHIFT;
 
                 // Return the difference minus the number of blocks between tail and head.
-                return tail - head - tail / LAP;
+                return (tail - head - tail / LAP) as usize;
             }
         }
     }
@@ -2031,7 +2061,7 @@ impl<T> Drop for Injector<T> {
         unsafe {
             // Drop all values between `head` and `tail` and deallocate the heap-allocated blocks.
             while head != tail {
-                let offset = (head >> SHIFT) % LAP;
+                let offset = ((head >> SHIFT) % LAP) as usize;
 
                 if offset < BLOCK_CAP {
                     // Drop the task in the slot.

--- a/crossbeam-epoch/src/epoch.rs
+++ b/crossbeam-epoch/src/epoch.rs
@@ -11,7 +11,8 @@ use crate::primitive::sync::atomic::Ordering;
 
 // Ideally, we want to always use AtomicU64, but since it is not available on all platforms,
 // we only use it when it is available for now.
-// TODO: On platforms where AtomicU64 is unavailable, we may want to use AtomicCell instead of AtomicUsize.
+// TODO: On platforms where AtomicU64 is unavailable, we may want to use AtomicCell instead of
+// AtomicUsize. (https://github.com/crossbeam-rs/crossbeam/issues/433)
 #[cfg(target_has_atomic = "64")]
 type AtomicEpochRepr = crate::primitive::sync::atomic::AtomicU64;
 #[cfg(not(target_has_atomic = "64"))]

--- a/crossbeam-queue/src/array_queue.rs
+++ b/crossbeam-queue/src/array_queue.rs
@@ -9,10 +9,23 @@ use core::{
     fmt,
     mem::{self, MaybeUninit},
     panic::{RefUnwindSafe, UnwindSafe},
-    sync::atomic::{self, AtomicUsize, Ordering},
+    sync::atomic::{self, Ordering},
 };
 
 use crossbeam_utils::{Backoff, CachePadded};
+
+// Ideally, we want to always use AtomicU64, but since it is not available on all platforms,
+// we only use it when it is available for now.
+// TODO: On platforms where AtomicU64 is unavailable, we may want to use AtomicCell instead of
+// AtomicUsize. (https://github.com/crossbeam-rs/crossbeam/issues/433)
+#[cfg(target_has_atomic = "64")]
+type AtomicIndex = core::sync::atomic::AtomicU64;
+#[cfg(target_has_atomic = "64")]
+type Index = u64;
+#[cfg(not(target_has_atomic = "64"))]
+type AtomicIndex = core::sync::atomic::AtomicUsize;
+#[cfg(not(target_has_atomic = "64"))]
+type Index = usize;
 
 /// A slot in a queue.
 struct Slot<T> {
@@ -20,7 +33,7 @@ struct Slot<T> {
     ///
     /// If the stamp equals the tail, this node will be next written to. If it equals head + 1,
     /// this node will be next read from.
-    stamp: AtomicUsize,
+    stamp: AtomicIndex,
 
     /// The value in this slot.
     value: UnsafeCell<MaybeUninit<T>>,
@@ -53,24 +66,24 @@ pub struct ArrayQueue<T> {
     /// The head of the queue.
     ///
     /// This value is a "stamp" consisting of an index into the buffer and a lap, but packed into a
-    /// single `usize`. The lower bits represent the index, while the upper bits represent the lap.
+    /// single `Index`. The lower bits represent the index, while the upper bits represent the lap.
     ///
     /// Elements are popped from the head of the queue.
-    head: CachePadded<AtomicUsize>,
+    head: CachePadded<AtomicIndex>,
 
     /// The tail of the queue.
     ///
     /// This value is a "stamp" consisting of an index into the buffer and a lap, but packed into a
-    /// single `usize`. The lower bits represent the index, while the upper bits represent the lap.
+    /// single `Index`. The lower bits represent the index, while the upper bits represent the lap.
     ///
     /// Elements are pushed into the tail of the queue.
-    tail: CachePadded<AtomicUsize>,
+    tail: CachePadded<AtomicIndex>,
 
     /// The buffer holding slots.
     buffer: Box<[Slot<T>]>,
 
     /// A stamp with the value of `{ lap: 1, index: 0 }`.
-    one_lap: usize,
+    one_lap: Index,
 }
 
 unsafe impl<T: Send> Sync for ArrayQueue<T> {}
@@ -107,36 +120,36 @@ impl<T> ArrayQueue<T> {
             .map(|i| {
                 // Set the stamp to `{ lap: 0, index: i }`.
                 Slot {
-                    stamp: AtomicUsize::new(i),
+                    stamp: AtomicIndex::new(i as Index),
                     value: UnsafeCell::new(MaybeUninit::uninit()),
                 }
             })
             .collect();
 
         // One lap is the smallest power of two greater than `cap`.
-        let one_lap = cap
+        let one_lap = (cap as Index)
             .checked_add(1)
-            .and_then(usize::checked_next_power_of_two)
+            .and_then(Index::checked_next_power_of_two)
             .expect("queue capacity is too large");
 
         Self {
             buffer,
             one_lap,
-            head: CachePadded::new(AtomicUsize::new(head)),
-            tail: CachePadded::new(AtomicUsize::new(tail)),
+            head: CachePadded::new(AtomicIndex::new(head)),
+            tail: CachePadded::new(AtomicIndex::new(tail)),
         }
     }
 
     fn push_or_else<F>(&self, mut value: T, f: F) -> Result<(), T>
     where
-        F: Fn(T, usize, usize, &Slot<T>) -> Result<T, T>,
+        F: Fn(T, Index, Index, &Slot<T>) -> Result<T, T>,
     {
         let backoff = Backoff::new();
         let mut tail = self.tail.load(Ordering::Relaxed);
 
         loop {
             // Deconstruct the tail.
-            let index = tail & (self.one_lap - 1);
+            let index = (tail & (self.one_lap - 1)) as usize;
             let lap = tail & !(self.one_lap - 1);
 
             let new_tail = if index + 1 < self.capacity() {
@@ -239,7 +252,7 @@ impl<T> ArrayQueue<T> {
             return Err(value);
         }
 
-        let index = tail & (self.one_lap - 1);
+        let index = (tail & (self.one_lap - 1)) as usize;
         let lap = tail & !(self.one_lap - 1);
         let new_tail = if index + 1 < self.capacity() {
             tail + 1
@@ -324,7 +337,7 @@ impl<T> ArrayQueue<T> {
 
         loop {
             // Deconstruct the head.
-            let index = head & (self.one_lap - 1);
+            let index = (head & (self.one_lap - 1)) as usize;
             let lap = head & !(self.one_lap - 1);
 
             // Inspect the corresponding slot.
@@ -405,7 +418,7 @@ impl<T> ArrayQueue<T> {
         if tail == head {
             return None;
         }
-        let index = head & (self.one_lap - 1);
+        let index = (head & (self.one_lap - 1)) as usize;
         let lap = head & !(self.one_lap - 1);
 
         // Inspect the corresponding slot.
@@ -518,8 +531,8 @@ impl<T> ArrayQueue<T> {
 
             // If the tail didn't change, we've got consistent values to work with.
             if self.tail.load(Ordering::SeqCst) == tail {
-                let hix = head & (self.one_lap - 1);
-                let tix = tail & (self.one_lap - 1);
+                let hix = (head & (self.one_lap - 1)) as usize;
+                let tix = (tail & (self.one_lap - 1)) as usize;
 
                 return if hix < tix {
                     tix - hix
@@ -542,8 +555,8 @@ impl<T> Drop for ArrayQueue<T> {
             let head = *self.head.get_mut();
             let tail = *self.tail.get_mut();
 
-            let hix = head & (self.one_lap - 1);
-            let tix = tail & (self.one_lap - 1);
+            let hix = (head & (self.one_lap - 1)) as usize;
+            let tix = (tail & (self.one_lap - 1)) as usize;
 
             let len = if hix < tix {
                 tix - hix
@@ -602,7 +615,7 @@ impl<T> Iterator for IntoIter<T> {
         let value = &mut self.value;
         let head = *value.head.get_mut();
         if value.head.get_mut() != value.tail.get_mut() {
-            let index = head & (value.one_lap - 1);
+            let index = (head & (value.one_lap - 1)) as usize;
             let lap = head & !(value.one_lap - 1);
             // SAFETY: We have mutable access to this, so we can read without
             // worrying about concurrency. Furthermore, we know this is

--- a/crossbeam-queue/src/seg_queue.rs
+++ b/crossbeam-queue/src/seg_queue.rs
@@ -14,6 +14,19 @@ use crossbeam_utils::{Backoff, CachePadded};
 
 use crate::alloc_helper::Global;
 
+// Ideally, we want to always use AtomicU64, but since it is not available on all platforms,
+// we only use it when it is available for now.
+// TODO: On platforms where AtomicU64 is unavailable, we may want to use AtomicCell instead of
+// AtomicUsize. (https://github.com/crossbeam-rs/crossbeam/issues/433)
+#[cfg(target_has_atomic = "64")]
+type AtomicIndex = core::sync::atomic::AtomicU64;
+#[cfg(target_has_atomic = "64")]
+type Index = u64;
+#[cfg(not(target_has_atomic = "64"))]
+type AtomicIndex = core::sync::atomic::AtomicUsize;
+#[cfg(not(target_has_atomic = "64"))]
+type Index = usize;
+
 // Bits indicating the state of a slot:
 // * If a value has been written into the slot, `WRITE` is set.
 // * If a value has been read from the slot, `READ` is set.
@@ -23,13 +36,13 @@ const READ: usize = 2;
 const DESTROY: usize = 4;
 
 // Each block covers one "lap" of indices.
-const LAP: usize = 32;
+const LAP: Index = 32;
 // The maximum number of values a block can hold.
-const BLOCK_CAP: usize = LAP - 1;
+const BLOCK_CAP: usize = LAP as usize - 1;
 // How many lower bits are reserved for metadata.
 const SHIFT: usize = 1;
 // Indicates that the block is not the last one.
-const HAS_NEXT: usize = 1;
+const HAS_NEXT: Index = 1;
 
 /// A slot in a block.
 struct Slot<T> {
@@ -129,7 +142,7 @@ impl<T> Block<T> {
 /// A position in a queue.
 struct Position<T> {
     /// The index in the queue.
-    index: AtomicUsize,
+    index: AtomicIndex,
 
     /// The block in the linked list.
     block: AtomicPtr<Block<T>>,
@@ -189,11 +202,11 @@ impl<T> SegQueue<T> {
         Self {
             head: CachePadded::new(Position {
                 block: AtomicPtr::new(ptr::null_mut()),
-                index: AtomicUsize::new(0),
+                index: AtomicIndex::new(0),
             }),
             tail: CachePadded::new(Position {
                 block: AtomicPtr::new(ptr::null_mut()),
-                index: AtomicUsize::new(0),
+                index: AtomicIndex::new(0),
             }),
             _marker: PhantomData,
         }
@@ -219,7 +232,7 @@ impl<T> SegQueue<T> {
 
         loop {
             // Calculate the offset of the index into the block.
-            let offset = (tail >> SHIFT) % LAP;
+            let offset = ((tail >> SHIFT) % LAP) as usize;
 
             // If we reached the end of the block, wait until the next one is installed.
             if offset == BLOCK_CAP {
@@ -311,7 +324,7 @@ impl<T> SegQueue<T> {
         let mut block = *self.tail.block.get_mut();
 
         // Calculate the offset of the index into the block.
-        let offset = (tail >> SHIFT) % LAP;
+        let offset = ((tail >> SHIFT) % LAP) as usize;
 
         // If this is the first push operation, we need to allocate the first block.
         if block.is_null() {
@@ -368,7 +381,7 @@ impl<T> SegQueue<T> {
 
         loop {
             // Calculate the offset of the index into the block.
-            let offset = (head >> SHIFT) % LAP;
+            let offset = ((head >> SHIFT) % LAP) as usize;
 
             // If we reached the end of the block, wait until the next one is installed.
             if offset == BLOCK_CAP {
@@ -473,7 +486,7 @@ impl<T> SegQueue<T> {
         let block = *self.head.block.get_mut();
 
         // Calculate the offset of the index into the block.
-        let offset = (head >> SHIFT) % LAP;
+        let offset = ((head >> SHIFT) % LAP) as usize;
 
         let mut new_head = head + (1 << SHIFT);
 
@@ -590,7 +603,7 @@ impl<T> SegQueue<T> {
                 head >>= SHIFT;
 
                 // Return the difference minus the number of blocks between tail and head.
-                return tail - head - tail / LAP;
+                return (tail - head - tail / LAP) as usize;
             }
         }
     }
@@ -609,7 +622,7 @@ impl<T> Drop for SegQueue<T> {
         unsafe {
             // Drop all values between `head` and `tail` and deallocate the heap-allocated blocks.
             while head != tail {
-                let offset = (head >> SHIFT) % LAP;
+                let offset = ((head >> SHIFT) % LAP) as usize;
 
                 if offset < BLOCK_CAP {
                     // Drop the value in the slot.
@@ -671,7 +684,7 @@ impl<T> Iterator for IntoIter<T> {
             None
         } else {
             let block = *value.head.block.get_mut();
-            let offset = (head >> SHIFT) % LAP;
+            let offset = ((head >> SHIFT) % LAP) as usize;
 
             // SAFETY: We have mutable access to this, so we can read without
             // worrying about concurrency. Furthermore, we know this is


### PR DESCRIPTION
cc #433, https://github.com/crossbeam-rs/crossbeam/pull/777
Similar to https://github.com/crossbeam-rs/crossbeam/pull/1230, but for channel,deque,queue.

 Ideally, we want to always use AtomicU64/AtomicI64, but since it is not available on all platforms, we only use it when it is available for now.

On platforms where AtomicU64/AtomicI64 is unavailable, we may want to use AtomicCell instead of AtomicIsize/AtomicUsize, but in this PR, I will postpone the decision on it.